### PR TITLE
Submodules for service-specifc types

### DIFF
--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -35,10 +35,7 @@ function readServiceFiles() {
 
 function generateServiceDefinitions() {
   Object.keys(metadata).forEach((serviceName) => {
-    if (!metadata[serviceName].input) {
-      return;
-    }
-  
+    
     console.log(`Generating ${metadata[serviceName].output}`)
   
     var result = new generator.AWSTypeGenerator().generateServiceDefinitions(metadata[serviceName]);
@@ -53,11 +50,21 @@ function copyCommonDefs() {
 }
 
 function generateModuleFile() {
-  var services = Object.keys(metadata)
-    .filter(name => !!metadata[name].input);
+  var services = Object.keys(metadata);
   var result = new generator.AWSTypeGenerator().generateMainModule(services);
   
   fs.writeFileSync('output/aws-sdk.d.ts', result);
+}
+
+function cleanDefinitions() {
+  var unrecognizedServices = Object.keys(metadata)
+    .filter(name => !metadata[name].descriptor);
+  
+  unrecognizedServices.forEach(name => {
+    console.log(`Ommitting service ${name} because the json definitions are missing`);
+    delete metadata[name];
+  });
+  
 }
 
 console.log(JSON.stringify(process.argv))
@@ -66,6 +73,7 @@ sdkDir = (process.argv.length > 2) ? process.argv[-1 + process.argv.length] : ".
 
 metadata = readMetadata();
 readServiceFiles();
+cleanDefinitions();
 copyCommonDefs();
 generateServiceDefinitions();
 generateModuleFile();

--- a/app/src/generator.ts
+++ b/app/src/generator.ts
@@ -12,7 +12,6 @@ export class AWSTypeGenerator {
 
   generateServiceDefinitions(api: meta.ServiceInfo) {
     var moduleTemplate = this.fetchTemplate("module")
-    var structureTemplate = this.fetchTemplate("structure")
     
     this.cleanShapes(api.descriptor);
 

--- a/app/src/generator.ts
+++ b/app/src/generator.ts
@@ -10,66 +10,94 @@ export class AWSTypeGenerator {
     return handlebars.compile(templateSource)
   }
 
-  executeOn(api: meta.ServiceInfo, content:string|Buffer) {
+  generateServiceDefinitions(api: meta.ServiceInfo) {
     var moduleTemplate = this.fetchTemplate("module")
     var structureTemplate = this.fetchTemplate("structure")
+    
+    this.cleanShapes(api.descriptor);
 
     handlebars.registerHelper("camelCase", function(name) {
       return name.charAt(0).toLowerCase() + name.substring(1)
     })
 
-    var m: meta.Descriptor = JSON.parse(content.toString())
-
-    var prefix = "        "
-
-    handlebars.registerHelper("dumpShape", function(context, options) {
-      var result = ""
-      if ("string" === context.type) {
-        result = `${prefix}export type ${options.data.key} = string;`
-
-        if (context.pattern) {
-          result += ` // pattern: "${context.pattern}"`
-        }
-      } else if ("long" === context.type || "integer" === context.type || "timestamp" === context.type || "double" === context.type || "float" === context.type) {
-        result = `${prefix}export type ${options.data.key} = number;`
-      } else if ("boolean" === context.type) {
-        result = `${prefix}export type ${options.data.key} = boolean;`
-      } else if ("map" === context.type || "blob" === context.type) {
-        result = `${prefix}export type ${options.data.key} = any; // not really - it was '${context.type}' instead - must fix this one`
-      } else if ("list" === context.type) {
-        result = `${prefix}export type ${options.data.key} = Array<${context.member.shape}>;`
-
-        if (context.max) {
-          result += ` // max: ${context.max}`
-        }
-      } else if ("structure" === context.type) {
-        Object.keys(context.members).forEach(function(k) {
-          context.members[k].required = "?"
-        })
-
-        if (context.required) {
-          context.required.forEach(function(k) {
-            context.members[k].required = "";
-          })
-        }
-
-        result = structureTemplate({ c: context, name: options.data.key, api: api })
-      } else {
-        throw new Error(`Unknown type: ${context.type}`)
-      }
-      return result;
-    });
-
-    var ctx = {
-      m: m,
-      api: api
-    }
-
-    return moduleTemplate(ctx)
+    return moduleTemplate(api)
   }
   
   generateMainModule(services:string[]) {
     var template = this.fetchTemplate('aws-sdk');
     return template({services:services});
   }
+  
+  private getAlias(shape:meta.Shape): meta.Alias {
+    var alias:meta.Alias = {name: shape.name, type: shape.type};
+    
+    var comments:string[] = [];      
+    if (shape.pattern) {
+      comments.push(`pattern: "${shape.pattern}"`);
+    }
+    if (shape.max) {
+      comments.push(`max: ${shape.max}`);
+    }
+    if (shape.min) {
+      comments.push(`min: ${shape.min}`);
+    }
+    
+    if (shape.type.match(/long|integer|timestamp|double|float/)){
+      alias.type = 'number';
+    } 
+    else if (shape.type == 'map') {
+      if (shape.value) {
+        alias.type = `{[key:string]: ${shape.value.shape}}`
+      } else {
+        shape.type == 'any';
+        comments.push('type: map');
+      }
+    } 
+    else if (shape.type == 'blob') {
+      alias.type = 'any';
+      comments.push('type: ' + 'blob');
+    } 
+    else if (shape.type == 'list') {
+      alias.type = shape.member.shape + '[]';
+    }
+    
+    if (comments.length) {
+      alias.comment = comments.join(', ');
+    }
+    
+    return alias;
+  }
+  
+  private getStructure(shape:meta.Shape):meta.Shape {
+    Object.keys(shape.members).forEach(function(k) {
+      shape.members[k].required = "?";
+    })
+    
+    if (shape.required) {
+      shape.required.forEach(function(k) {
+        shape.members[k].required = "";
+      })
+    }
+    return shape;
+  }
+  
+  private cleanShapes(descriptor:meta.Descriptor) {
+    //set the name
+    Object.keys(descriptor.shapes)
+      .forEach(name => descriptor.shapes[name].name = name);
+    
+    //get aliases
+    descriptor.aliases = Object.keys(descriptor.shapes)
+      .map(name => descriptor.shapes[name])
+      .filter(shape => shape.type != 'structure')
+      .filter(shape => shape.name != 'string' && shape.name != 'boolean' && shape.name != 'number')  //exclude builtins
+      .map(this.getAlias);
+    
+    //Get structures
+    descriptor.structures = Object.keys(descriptor.shapes)
+      .map(name => descriptor.shapes[name])
+      .filter(shape => shape.type == 'structure')
+      .map(this.getStructure);
+  }
+  
 }

--- a/app/src/generator.ts
+++ b/app/src/generator.ts
@@ -20,24 +20,24 @@ export class AWSTypeGenerator {
 
     var m: meta.Descriptor = JSON.parse(content.toString())
 
-    var prefix = "    "
+    var prefix = "        "
 
     handlebars.registerHelper("dumpShape", function(context, options) {
       var result = ""
       if ("string" === context.type) {
-        result = `${prefix}export type ${api.name}${options.data.key} = string;`
+        result = `${prefix}export type ${options.data.key} = string;`
 
         if (context.pattern) {
           result += ` // pattern: "${context.pattern}"`
         }
       } else if ("long" === context.type || "integer" === context.type || "timestamp" === context.type || "double" === context.type || "float" === context.type) {
-        result = `${prefix}export type ${api.name}${options.data.key} = number;`
+        result = `${prefix}export type ${options.data.key} = number;`
       } else if ("boolean" === context.type) {
-        result = `${prefix}export type ${api.name}${options.data.key} = boolean;`
+        result = `${prefix}export type ${options.data.key} = boolean;`
       } else if ("map" === context.type || "blob" === context.type) {
-        result = `${prefix}export type ${api.name}${options.data.key} = any; // not really - it was '${context.type}' instead - must fix this one`
+        result = `${prefix}export type ${options.data.key} = any; // not really - it was '${context.type}' instead - must fix this one`
       } else if ("list" === context.type) {
-        result = `${prefix}export type ${api.name}${options.data.key} = Array<${api.name}${context.member.shape}>;`
+        result = `${prefix}export type ${options.data.key} = Array<${context.member.shape}>;`
 
         if (context.max) {
           result += ` // max: ${context.max}`

--- a/app/src/meta.ts
+++ b/app/src/meta.ts
@@ -4,6 +4,7 @@ export interface ServiceInfo {
   prefix?:string;
   input?:string;
   output?:string;
+  descriptor?:Descriptor;
 }
 
 export interface Descriptor {
@@ -12,6 +13,14 @@ export interface Descriptor {
   documentation: string
   operations: OperationMap
   shapes: ShapeMap
+  aliases: Alias[]
+  structures: Shape[]
+}
+
+export interface Alias {
+  name: string;
+  type: string;
+  comment?: string;
 }
 
 export interface ShapeMap {
@@ -25,10 +34,17 @@ export interface Shape {
   members?: MemberMap
   exception?: boolean
   documentation?: string
+  name?: string
+  min?: number
+  max?: number
+  key?: {shape: string}
+  value?: {shape: string}
+  member?: {shape: string}
 }
 
 export interface Member {
   shape: string
+  required?: string
 }
 
 export interface MemberMap {

--- a/app/src/module.handlebars
+++ b/app/src/module.handlebars
@@ -8,15 +8,19 @@ declare module "aws-sdk" {
       constructor(options?: any);
 {{#each m.operations}}
       {{{camelCase @key}}}(
-        {{~#if this.input.shape}}params: {{../../api.name}}{{this.input.shape}}, {{/if~}}
+        {{~#if this.input.shape}}params: {{../../api.name}}.{{this.input.shape}}, {{/if~}}
         callback?: ( {{~null~}}
-            err: {{#each this.errors~}}{{../../api.name}}{{this.shape}}|{{/each}}any, {{null~}}
-            data: {{#if this.output.shape}}{{../../api.name}}{{this.output.shape}}|{{/if}}any) => void {{~null~}}
+            err: {{#each this.errors~}}{{../../api.name}}.{{this.shape}}|{{/each}}any, {{null~}}
+            data: {{#if this.output.shape}}{{../../api.name}}.{{this.output.shape}}|{{/if}}any) => void {{~null~}}
       ): Request;
 {{/each}}
     }
+    
+    export module {{api.name}} {
 
 {{#each m.shapes}}
 {{{dumpShape this}}}
 {{/each}}
+
+    }
 }

--- a/app/src/module.handlebars
+++ b/app/src/module.handlebars
@@ -4,22 +4,31 @@
 ///<reference path="./aws-sdk-common.d.ts" />
 declare module "aws-sdk" {
 
-    export class {{api.name}} extends Service {
+    export class {{name}} extends Service {
       constructor(options?: any);
-{{#each m.operations}}
+{{#each descriptor.operations}}
       {{{camelCase @key}}}(
-        {{~#if this.input.shape}}params: {{../../api.name}}.{{this.input.shape}}, {{/if~}}
+        {{~#if this.input.shape}}params: {{../../name}}.{{this.input.shape}}, {{/if~}}
         callback?: ( {{~null~}}
-            err: {{#each this.errors~}}{{../../api.name}}.{{this.shape}}|{{/each}}any, {{null~}}
-            data: {{#if this.output.shape}}{{../../api.name}}.{{this.output.shape}}|{{/if}}any) => void {{~null~}}
+            err: {{#each this.errors~}}{{../../name}}.{{this.shape}}|{{/each}}any, {{null~}}
+            data: {{#if this.output.shape}}{{../../name}}.{{this.output.shape}}|{{/if}}any) => void {{~null~}}
       ): Request;
 {{/each}}
     }
     
-    export module {{api.name}} {
+    export module {{name}} {
+{{!-- Alias definitions --}}
+{{#each descriptor.aliases}}
+        export type {{name}} = {{type}};{{#if comment}}    // {{comment}}{{/if}}
+{{/each}}
 
-{{#each m.shapes}}
-{{{dumpShape this}}}
+{{!-- Interface definitions --}}
+{{#each descriptor.structures}}
+        export interface {{name}} {
+{{#each members}}
+            {{@key}}{{this.required}}: {{this.shape}};            
+{{/each}}
+        }
 {{/each}}
 
     }

--- a/app/src/structure.handlebars
+++ b/app/src/structure.handlebars
@@ -1,5 +1,0 @@
-        export interface {{name}} {
-{{#each c.members}}
-            {{@key}}{{this.required}}: {{this.shape}};            
-{{/each}}
-        }

--- a/app/src/structure.handlebars
+++ b/app/src/structure.handlebars
@@ -1,5 +1,5 @@
-    export interface {{api.name}}{{name}} {
+        export interface {{name}} {
 {{#each c.members}}
-        {{@key}}{{this.required}}: {{../api.name}}{{this.shape}};
+            {{@key}}{{this.required}}: {{this.shape}};            
 {{/each}}
-    }
+        }

--- a/output/aws-apigateway.d.ts
+++ b/output/aws-apigateway.d.ts
@@ -6,757 +6,656 @@ declare module "aws-sdk" {
 
     export class APIGateway extends Service {
       constructor(options?: any);
-      createApiKey(params: APIGatewayCreateApiKeyRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|APIGatewayLimitExceededException|APIGatewayBadRequestException|any, data: APIGatewayApiKey|any) => void): Request;
-      createBasePathMapping(params: APIGatewayCreateBasePathMappingRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayConflictException|APIGatewayBadRequestException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayBasePathMapping|any) => void): Request;
-      createDeployment(params: APIGatewayCreateDeploymentRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayBadRequestException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayTooManyRequestsException|APIGatewayServiceUnavailableException|any, data: APIGatewayDeployment|any) => void): Request;
-      createDomainName(params: APIGatewayCreateDomainNameRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayDomainName|any) => void): Request;
-      createModel(params: APIGatewayCreateModelRequest, callback?: (err: APIGatewayBadRequestException|APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayTooManyRequestsException|any, data: APIGatewayModel|any) => void): Request;
-      createResource(params: APIGatewayCreateResourceRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayResource|any) => void): Request;
-      createRestApi(params: APIGatewayCreateRestApiRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayLimitExceededException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayRestApi|any) => void): Request;
-      createStage(params: APIGatewayCreateStageRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayBadRequestException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayTooManyRequestsException|any, data: APIGatewayStage|any) => void): Request;
-      deleteApiKey(params: APIGatewayDeleteApiKeyRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteBasePathMapping(params: APIGatewayDeleteBasePathMappingRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteClientCertificate(params: APIGatewayDeleteClientCertificateRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|APIGatewayBadRequestException|APIGatewayNotFoundException|any, data: any) => void): Request;
-      deleteDeployment(params: APIGatewayDeleteDeploymentRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteDomainName(params: APIGatewayDeleteDomainNameRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteIntegration(params: APIGatewayDeleteIntegrationRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteIntegrationResponse(params: APIGatewayDeleteIntegrationResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteMethod(params: APIGatewayDeleteMethodRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteMethodResponse(params: APIGatewayDeleteMethodResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteModel(params: APIGatewayDeleteModelRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|APIGatewayBadRequestException|APIGatewayConflictException|any, data: any) => void): Request;
-      deleteResource(params: APIGatewayDeleteResourceRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteRestApi(params: APIGatewayDeleteRestApiRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      deleteStage(params: APIGatewayDeleteStageRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      flushStageCache(params: APIGatewayFlushStageCacheRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: any) => void): Request;
-      generateClientCertificate(params: APIGatewayGenerateClientCertificateRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|APIGatewayLimitExceededException|any, data: APIGatewayClientCertificate|any) => void): Request;
-      getAccount(params: APIGatewayGetAccountRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayAccount|any) => void): Request;
-      getApiKey(params: APIGatewayGetApiKeyRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayApiKey|any) => void): Request;
-      getApiKeys(params: APIGatewayGetApiKeysRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|any, data: APIGatewayApiKeys|any) => void): Request;
-      getBasePathMapping(params: APIGatewayGetBasePathMappingRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayBasePathMapping|any) => void): Request;
-      getBasePathMappings(params: APIGatewayGetBasePathMappingsRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayBasePathMappings|any) => void): Request;
-      getClientCertificate(params: APIGatewayGetClientCertificateRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayClientCertificate|any) => void): Request;
-      getClientCertificates(params: APIGatewayGetClientCertificatesRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|any, data: APIGatewayClientCertificates|any) => void): Request;
-      getDeployment(params: APIGatewayGetDeploymentRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|APIGatewayServiceUnavailableException|any, data: APIGatewayDeployment|any) => void): Request;
-      getDeployments(params: APIGatewayGetDeploymentsRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|APIGatewayServiceUnavailableException|any, data: APIGatewayDeployments|any) => void): Request;
-      getDomainName(params: APIGatewayGetDomainNameRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayServiceUnavailableException|APIGatewayTooManyRequestsException|any, data: APIGatewayDomainName|any) => void): Request;
-      getDomainNames(params: APIGatewayGetDomainNamesRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|any, data: APIGatewayDomainNames|any) => void): Request;
-      getIntegration(params: APIGatewayGetIntegrationRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayIntegration|any) => void): Request;
-      getIntegrationResponse(params: APIGatewayGetIntegrationResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayIntegrationResponse|any) => void): Request;
-      getMethod(params: APIGatewayGetMethodRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayMethod|any) => void): Request;
-      getMethodResponse(params: APIGatewayGetMethodResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayMethodResponse|any) => void): Request;
-      getModel(params: APIGatewayGetModelRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayModel|any) => void): Request;
-      getModelTemplate(params: APIGatewayGetModelTemplateRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayTemplate|any) => void): Request;
-      getModels(params: APIGatewayGetModelsRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayModels|any) => void): Request;
-      getResource(params: APIGatewayGetResourceRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayResource|any) => void): Request;
-      getResources(params: APIGatewayGetResourcesRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayResources|any) => void): Request;
-      getRestApi(params: APIGatewayGetRestApiRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayRestApi|any) => void): Request;
-      getRestApis(params: APIGatewayGetRestApisRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|any, data: APIGatewayRestApis|any) => void): Request;
-      getSdk(params: APIGatewayGetSdkRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewaySdkResponse|any) => void): Request;
-      getStage(params: APIGatewayGetStageRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayStage|any) => void): Request;
-      getStages(params: APIGatewayGetStagesRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayStages|any) => void): Request;
-      putIntegration(params: APIGatewayPutIntegrationRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayBadRequestException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayIntegration|any) => void): Request;
-      putIntegrationResponse(params: APIGatewayPutIntegrationResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayLimitExceededException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayIntegrationResponse|any) => void): Request;
-      putMethod(params: APIGatewayPutMethodRequest, callback?: (err: APIGatewayBadRequestException|APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayTooManyRequestsException|any, data: APIGatewayMethod|any) => void): Request;
-      putMethodResponse(params: APIGatewayPutMethodResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayMethodResponse|any) => void): Request;
-      testInvokeMethod(params: APIGatewayTestInvokeMethodRequest, callback?: (err: APIGatewayBadRequestException|APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayTestInvokeMethodResponse|any) => void): Request;
-      updateAccount(params: APIGatewayUpdateAccountRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayBadRequestException|APIGatewayNotFoundException|APIGatewayTooManyRequestsException|any, data: APIGatewayAccount|any) => void): Request;
-      updateApiKey(params: APIGatewayUpdateApiKeyRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayApiKey|any) => void): Request;
-      updateBasePathMapping(params: APIGatewayUpdateBasePathMappingRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayBasePathMapping|any) => void): Request;
-      updateClientCertificate(params: APIGatewayUpdateClientCertificateRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayTooManyRequestsException|APIGatewayBadRequestException|APIGatewayNotFoundException|any, data: APIGatewayClientCertificate|any) => void): Request;
-      updateDeployment(params: APIGatewayUpdateDeploymentRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|APIGatewayServiceUnavailableException|any, data: APIGatewayDeployment|any) => void): Request;
-      updateDomainName(params: APIGatewayUpdateDomainNameRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayDomainName|any) => void): Request;
-      updateIntegration(params: APIGatewayUpdateIntegrationRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayIntegration|any) => void): Request;
-      updateIntegrationResponse(params: APIGatewayUpdateIntegrationResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayIntegrationResponse|any) => void): Request;
-      updateMethod(params: APIGatewayUpdateMethodRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayMethod|any) => void): Request;
-      updateMethodResponse(params: APIGatewayUpdateMethodResponseRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayLimitExceededException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayMethodResponse|any) => void): Request;
-      updateModel(params: APIGatewayUpdateModelRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayModel|any) => void): Request;
-      updateResource(params: APIGatewayUpdateResourceRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayResource|any) => void): Request;
-      updateRestApi(params: APIGatewayUpdateRestApiRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayRestApi|any) => void): Request;
-      updateStage(params: APIGatewayUpdateStageRequest, callback?: (err: APIGatewayUnauthorizedException|APIGatewayNotFoundException|APIGatewayConflictException|APIGatewayBadRequestException|APIGatewayTooManyRequestsException|any, data: APIGatewayStage|any) => void): Request;
-    }
-
-    export interface APIGatewayAccount {
-        cloudwatchRoleArn?: APIGatewayString;
-        throttleSettings?: APIGatewayThrottleSettings;
-    }
-
-    export interface APIGatewayApiKey {
-        id?: APIGatewayString;
-        name?: APIGatewayString;
-        description?: APIGatewayString;
-        enabled?: APIGatewayBoolean;
-        stageKeys?: APIGatewayListOfString;
-        createdDate?: APIGatewayTimestamp;
-        lastUpdatedDate?: APIGatewayTimestamp;
-    }
-
-    export interface APIGatewayApiKeys {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfApiKey;
-    }
-
-    export interface APIGatewayBadRequestException {
-        message?: APIGatewayString;
-    }
-
-    export interface APIGatewayBasePathMapping {
-        basePath?: APIGatewayString;
-        restApiId?: APIGatewayString;
-        stage?: APIGatewayString;
-    }
-
-    export interface APIGatewayBasePathMappings {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfBasePathMapping;
-    }
-
-    export type APIGatewayBlob = any; // not really - it was 'blob' instead - must fix this one
-    export type APIGatewayBoolean = boolean;
-    export type APIGatewayCacheClusterSize = string;
-    export type APIGatewayCacheClusterStatus = string;
-    export interface APIGatewayClientCertificate {
-        clientCertificateId?: APIGatewayString;
-        description?: APIGatewayString;
-        pemEncodedCertificate?: APIGatewayString;
-        createdDate?: APIGatewayTimestamp;
-        expirationDate?: APIGatewayTimestamp;
-    }
-
-    export interface APIGatewayClientCertificates {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfClientCertificate;
-    }
-
-    export interface APIGatewayConflictException {
-        message?: APIGatewayString;
-    }
-
-    export interface APIGatewayCreateApiKeyRequest {
-        name?: APIGatewayString;
-        description?: APIGatewayString;
-        enabled?: APIGatewayBoolean;
-        stageKeys?: APIGatewayListOfStageKeys;
-    }
-
-    export interface APIGatewayCreateBasePathMappingRequest {
-        domainName: APIGatewayString;
-        basePath?: APIGatewayString;
-        restApiId: APIGatewayString;
-        stage?: APIGatewayString;
-    }
-
-    export interface APIGatewayCreateDeploymentRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-        stageDescription?: APIGatewayString;
-        description?: APIGatewayString;
-        cacheClusterEnabled?: APIGatewayNullableBoolean;
-        cacheClusterSize?: APIGatewayCacheClusterSize;
-        variables?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayCreateDomainNameRequest {
-        domainName: APIGatewayString;
-        certificateName: APIGatewayString;
-        certificateBody: APIGatewayString;
-        certificatePrivateKey: APIGatewayString;
-        certificateChain: APIGatewayString;
-    }
-
-    export interface APIGatewayCreateModelRequest {
-        restApiId: APIGatewayString;
-        name: APIGatewayString;
-        description?: APIGatewayString;
-        schema?: APIGatewayString;
-        contentType: APIGatewayString;
-    }
-
-    export interface APIGatewayCreateResourceRequest {
-        restApiId: APIGatewayString;
-        parentId: APIGatewayString;
-        pathPart: APIGatewayString;
-    }
-
-    export interface APIGatewayCreateRestApiRequest {
-        name: APIGatewayString;
-        description?: APIGatewayString;
-        cloneFrom?: APIGatewayString;
-    }
-
-    export interface APIGatewayCreateStageRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-        deploymentId: APIGatewayString;
-        description?: APIGatewayString;
-        cacheClusterEnabled?: APIGatewayBoolean;
-        cacheClusterSize?: APIGatewayCacheClusterSize;
-        variables?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayDeleteApiKeyRequest {
-        apiKey: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteBasePathMappingRequest {
-        domainName: APIGatewayString;
-        basePath: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteClientCertificateRequest {
-        clientCertificateId: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteDeploymentRequest {
-        restApiId: APIGatewayString;
-        deploymentId: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteDomainNameRequest {
-        domainName: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteIntegrationRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteIntegrationResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-    }
-
-    export interface APIGatewayDeleteMethodRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteMethodResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-    }
-
-    export interface APIGatewayDeleteModelRequest {
-        restApiId: APIGatewayString;
-        modelName: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteResourceRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteRestApiRequest {
-        restApiId: APIGatewayString;
-    }
-
-    export interface APIGatewayDeleteStageRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-    }
-
-    export interface APIGatewayDeployment {
-        id?: APIGatewayString;
-        description?: APIGatewayString;
-        createdDate?: APIGatewayTimestamp;
-        apiSummary?: APIGatewayPathToMapOfMethodSnapshot;
-    }
-
-    export interface APIGatewayDeployments {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfDeployment;
-    }
-
-    export interface APIGatewayDomainName {
-        domainName?: APIGatewayString;
-        certificateName?: APIGatewayString;
-        certificateUploadDate?: APIGatewayTimestamp;
-        distributionDomainName?: APIGatewayString;
-    }
-
-    export interface APIGatewayDomainNames {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfDomainName;
-    }
-
-    export type APIGatewayDouble = number;
-    export interface APIGatewayFlushStageCacheRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-    }
-
-    export interface APIGatewayGenerateClientCertificateRequest {
-        description?: APIGatewayString;
-    }
-
-    export interface APIGatewayGetAccountRequest {
-    }
-
-    export interface APIGatewayGetApiKeyRequest {
-        apiKey: APIGatewayString;
-    }
-
-    export interface APIGatewayGetApiKeysRequest {
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetBasePathMappingRequest {
-        domainName: APIGatewayString;
-        basePath: APIGatewayString;
-    }
-
-    export interface APIGatewayGetBasePathMappingsRequest {
-        domainName: APIGatewayString;
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetClientCertificateRequest {
-        clientCertificateId: APIGatewayString;
-    }
-
-    export interface APIGatewayGetClientCertificatesRequest {
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetDeploymentRequest {
-        restApiId: APIGatewayString;
-        deploymentId: APIGatewayString;
-    }
-
-    export interface APIGatewayGetDeploymentsRequest {
-        restApiId: APIGatewayString;
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetDomainNameRequest {
-        domainName: APIGatewayString;
-    }
-
-    export interface APIGatewayGetDomainNamesRequest {
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetIntegrationRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-    }
-
-    export interface APIGatewayGetIntegrationResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-    }
-
-    export interface APIGatewayGetMethodRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-    }
-
-    export interface APIGatewayGetMethodResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-    }
-
-    export interface APIGatewayGetModelRequest {
-        restApiId: APIGatewayString;
-        modelName: APIGatewayString;
-        flatten?: APIGatewayBoolean;
-    }
+      createApiKey(params: APIGateway.CreateApiKeyRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|APIGateway.LimitExceededException|APIGateway.BadRequestException|any, data: APIGateway.ApiKey|any) => void): Request;
+      createBasePathMapping(params: APIGateway.CreateBasePathMappingRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.ConflictException|APIGateway.BadRequestException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.BasePathMapping|any) => void): Request;
+      createDeployment(params: APIGateway.CreateDeploymentRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.BadRequestException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.TooManyRequestsException|APIGateway.ServiceUnavailableException|any, data: APIGateway.Deployment|any) => void): Request;
+      createDomainName(params: APIGateway.CreateDomainNameRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.DomainName|any) => void): Request;
+      createModel(params: APIGateway.CreateModelRequest, callback?: (err: APIGateway.BadRequestException|APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.TooManyRequestsException|any, data: APIGateway.Model|any) => void): Request;
+      createResource(params: APIGateway.CreateResourceRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Resource|any) => void): Request;
+      createRestApi(params: APIGateway.CreateRestApiRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.LimitExceededException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.RestApi|any) => void): Request;
+      createStage(params: APIGateway.CreateStageRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.BadRequestException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.TooManyRequestsException|any, data: APIGateway.Stage|any) => void): Request;
+      deleteApiKey(params: APIGateway.DeleteApiKeyRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteBasePathMapping(params: APIGateway.DeleteBasePathMappingRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteClientCertificate(params: APIGateway.DeleteClientCertificateRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|APIGateway.BadRequestException|APIGateway.NotFoundException|any, data: any) => void): Request;
+      deleteDeployment(params: APIGateway.DeleteDeploymentRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteDomainName(params: APIGateway.DeleteDomainNameRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteIntegration(params: APIGateway.DeleteIntegrationRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteIntegrationResponse(params: APIGateway.DeleteIntegrationResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteMethod(params: APIGateway.DeleteMethodRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteMethodResponse(params: APIGateway.DeleteMethodResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteModel(params: APIGateway.DeleteModelRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|APIGateway.BadRequestException|APIGateway.ConflictException|any, data: any) => void): Request;
+      deleteResource(params: APIGateway.DeleteResourceRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteRestApi(params: APIGateway.DeleteRestApiRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      deleteStage(params: APIGateway.DeleteStageRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      flushStageCache(params: APIGateway.FlushStageCacheRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: any) => void): Request;
+      generateClientCertificate(params: APIGateway.GenerateClientCertificateRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|APIGateway.LimitExceededException|any, data: APIGateway.ClientCertificate|any) => void): Request;
+      getAccount(params: APIGateway.GetAccountRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Account|any) => void): Request;
+      getApiKey(params: APIGateway.GetApiKeyRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.ApiKey|any) => void): Request;
+      getApiKeys(params: APIGateway.GetApiKeysRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|any, data: APIGateway.ApiKeys|any) => void): Request;
+      getBasePathMapping(params: APIGateway.GetBasePathMappingRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.BasePathMapping|any) => void): Request;
+      getBasePathMappings(params: APIGateway.GetBasePathMappingsRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.BasePathMappings|any) => void): Request;
+      getClientCertificate(params: APIGateway.GetClientCertificateRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.ClientCertificate|any) => void): Request;
+      getClientCertificates(params: APIGateway.GetClientCertificatesRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|any, data: APIGateway.ClientCertificates|any) => void): Request;
+      getDeployment(params: APIGateway.GetDeploymentRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|APIGateway.ServiceUnavailableException|any, data: APIGateway.Deployment|any) => void): Request;
+      getDeployments(params: APIGateway.GetDeploymentsRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|APIGateway.ServiceUnavailableException|any, data: APIGateway.Deployments|any) => void): Request;
+      getDomainName(params: APIGateway.GetDomainNameRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ServiceUnavailableException|APIGateway.TooManyRequestsException|any, data: APIGateway.DomainName|any) => void): Request;
+      getDomainNames(params: APIGateway.GetDomainNamesRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|any, data: APIGateway.DomainNames|any) => void): Request;
+      getIntegration(params: APIGateway.GetIntegrationRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Integration|any) => void): Request;
+      getIntegrationResponse(params: APIGateway.GetIntegrationResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.IntegrationResponse|any) => void): Request;
+      getMethod(params: APIGateway.GetMethodRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Method|any) => void): Request;
+      getMethodResponse(params: APIGateway.GetMethodResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.MethodResponse|any) => void): Request;
+      getModel(params: APIGateway.GetModelRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Model|any) => void): Request;
+      getModelTemplate(params: APIGateway.GetModelTemplateRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Template|any) => void): Request;
+      getModels(params: APIGateway.GetModelsRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Models|any) => void): Request;
+      getResource(params: APIGateway.GetResourceRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Resource|any) => void): Request;
+      getResources(params: APIGateway.GetResourcesRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Resources|any) => void): Request;
+      getRestApi(params: APIGateway.GetRestApiRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.RestApi|any) => void): Request;
+      getRestApis(params: APIGateway.GetRestApisRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|any, data: APIGateway.RestApis|any) => void): Request;
+      getSdk(params: APIGateway.GetSdkRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.SdkResponse|any) => void): Request;
+      getStage(params: APIGateway.GetStageRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Stage|any) => void): Request;
+      getStages(params: APIGateway.GetStagesRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Stages|any) => void): Request;
+      putIntegration(params: APIGateway.PutIntegrationRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.BadRequestException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Integration|any) => void): Request;
+      putIntegrationResponse(params: APIGateway.PutIntegrationResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.LimitExceededException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.IntegrationResponse|any) => void): Request;
+      putMethod(params: APIGateway.PutMethodRequest, callback?: (err: APIGateway.BadRequestException|APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.TooManyRequestsException|any, data: APIGateway.Method|any) => void): Request;
+      putMethodResponse(params: APIGateway.PutMethodResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.MethodResponse|any) => void): Request;
+      testInvokeMethod(params: APIGateway.TestInvokeMethodRequest, callback?: (err: APIGateway.BadRequestException|APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.TestInvokeMethodResponse|any) => void): Request;
+      updateAccount(params: APIGateway.UpdateAccountRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.BadRequestException|APIGateway.NotFoundException|APIGateway.TooManyRequestsException|any, data: APIGateway.Account|any) => void): Request;
+      updateApiKey(params: APIGateway.UpdateApiKeyRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.ApiKey|any) => void): Request;
+      updateBasePathMapping(params: APIGateway.UpdateBasePathMappingRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.BasePathMapping|any) => void): Request;
+      updateClientCertificate(params: APIGateway.UpdateClientCertificateRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.TooManyRequestsException|APIGateway.BadRequestException|APIGateway.NotFoundException|any, data: APIGateway.ClientCertificate|any) => void): Request;
+      updateDeployment(params: APIGateway.UpdateDeploymentRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|APIGateway.ServiceUnavailableException|any, data: APIGateway.Deployment|any) => void): Request;
+      updateDomainName(params: APIGateway.UpdateDomainNameRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.DomainName|any) => void): Request;
+      updateIntegration(params: APIGateway.UpdateIntegrationRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Integration|any) => void): Request;
+      updateIntegrationResponse(params: APIGateway.UpdateIntegrationResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.IntegrationResponse|any) => void): Request;
+      updateMethod(params: APIGateway.UpdateMethodRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Method|any) => void): Request;
+      updateMethodResponse(params: APIGateway.UpdateMethodResponseRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.LimitExceededException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.MethodResponse|any) => void): Request;
+      updateModel(params: APIGateway.UpdateModelRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Model|any) => void): Request;
+      updateResource(params: APIGateway.UpdateResourceRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Resource|any) => void): Request;
+      updateRestApi(params: APIGateway.UpdateRestApiRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.RestApi|any) => void): Request;
+      updateStage(params: APIGateway.UpdateStageRequest, callback?: (err: APIGateway.UnauthorizedException|APIGateway.NotFoundException|APIGateway.ConflictException|APIGateway.BadRequestException|APIGateway.TooManyRequestsException|any, data: APIGateway.Stage|any) => void): Request;
+    }
+    
+    export module APIGateway {
+        export type Blob = any;    // type: blob
+        export type Boolean = boolean;
+        export type CacheClusterSize = string;
+        export type CacheClusterStatus = string;
+        export type Double = number;
+        export type Integer = number;
+        export type IntegrationType = string;
+        export type ListOfApiKey = ApiKey[];
+        export type ListOfBasePathMapping = BasePathMapping[];
+        export type ListOfClientCertificate = ClientCertificate[];
+        export type ListOfDeployment = Deployment[];
+        export type ListOfDomainName = DomainName[];
+        export type ListOfModel = Model[];
+        export type ListOfPatchOperation = PatchOperation[];
+        export type ListOfResource = Resource[];
+        export type ListOfRestApi = RestApi[];
+        export type ListOfStage = Stage[];
+        export type ListOfStageKeys = StageKey[];
+        export type ListOfString = String[];
+        export type Long = number;
+        export type MapOfHeaderValues = {[key:string]: String};
+        export type MapOfIntegrationResponse = {[key:string]: IntegrationResponse};
+        export type MapOfMethod = {[key:string]: Method};
+        export type MapOfMethodResponse = {[key:string]: MethodResponse};
+        export type MapOfMethodSettings = {[key:string]: MethodSetting};
+        export type MapOfMethodSnapshot = {[key:string]: MethodSnapshot};
+        export type MapOfStringToBoolean = {[key:string]: NullableBoolean};
+        export type MapOfStringToString = {[key:string]: String};
+        export type NullableBoolean = boolean;
+        export type NullableInteger = number;
+        export type PathToMapOfMethodSnapshot = {[key:string]: MapOfMethodSnapshot};
+        export type StatusCode = string;    // pattern: &quot;[1-5]\d\d&quot;
+        export type String = string;
+        export type Timestamp = number;
+        export type op = string;
+
+        export interface Account {
+            cloudwatchRoleArn?: String;            
+            throttleSettings?: ThrottleSettings;            
+        }
+        export interface ApiKey {
+            id?: String;            
+            name?: String;            
+            description?: String;            
+            enabled?: Boolean;            
+            stageKeys?: ListOfString;            
+            createdDate?: Timestamp;            
+            lastUpdatedDate?: Timestamp;            
+        }
+        export interface ApiKeys {
+            position?: String;            
+            items?: ListOfApiKey;            
+        }
+        export interface BadRequestException {
+            message?: String;            
+        }
+        export interface BasePathMapping {
+            basePath?: String;            
+            restApiId?: String;            
+            stage?: String;            
+        }
+        export interface BasePathMappings {
+            position?: String;            
+            items?: ListOfBasePathMapping;            
+        }
+        export interface ClientCertificate {
+            clientCertificateId?: String;            
+            description?: String;            
+            pemEncodedCertificate?: String;            
+            createdDate?: Timestamp;            
+            expirationDate?: Timestamp;            
+        }
+        export interface ClientCertificates {
+            position?: String;            
+            items?: ListOfClientCertificate;            
+        }
+        export interface ConflictException {
+            message?: String;            
+        }
+        export interface CreateApiKeyRequest {
+            name?: String;            
+            description?: String;            
+            enabled?: Boolean;            
+            stageKeys?: ListOfStageKeys;            
+        }
+        export interface CreateBasePathMappingRequest {
+            domainName: String;            
+            basePath?: String;            
+            restApiId: String;            
+            stage?: String;            
+        }
+        export interface CreateDeploymentRequest {
+            restApiId: String;            
+            stageName: String;            
+            stageDescription?: String;            
+            description?: String;            
+            cacheClusterEnabled?: NullableBoolean;            
+            cacheClusterSize?: CacheClusterSize;            
+            variables?: MapOfStringToString;            
+        }
+        export interface CreateDomainNameRequest {
+            domainName: String;            
+            certificateName: String;            
+            certificateBody: String;            
+            certificatePrivateKey: String;            
+            certificateChain: String;            
+        }
+        export interface CreateModelRequest {
+            restApiId: String;            
+            name: String;            
+            description?: String;            
+            schema?: String;            
+            contentType: String;            
+        }
+        export interface CreateResourceRequest {
+            restApiId: String;            
+            parentId: String;            
+            pathPart: String;            
+        }
+        export interface CreateRestApiRequest {
+            name: String;            
+            description?: String;            
+            cloneFrom?: String;            
+        }
+        export interface CreateStageRequest {
+            restApiId: String;            
+            stageName: String;            
+            deploymentId: String;            
+            description?: String;            
+            cacheClusterEnabled?: Boolean;            
+            cacheClusterSize?: CacheClusterSize;            
+            variables?: MapOfStringToString;            
+        }
+        export interface DeleteApiKeyRequest {
+            apiKey: String;            
+        }
+        export interface DeleteBasePathMappingRequest {
+            domainName: String;            
+            basePath: String;            
+        }
+        export interface DeleteClientCertificateRequest {
+            clientCertificateId: String;            
+        }
+        export interface DeleteDeploymentRequest {
+            restApiId: String;            
+            deploymentId: String;            
+        }
+        export interface DeleteDomainNameRequest {
+            domainName: String;            
+        }
+        export interface DeleteIntegrationRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+        }
+        export interface DeleteIntegrationResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+        }
+        export interface DeleteMethodRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+        }
+        export interface DeleteMethodResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+        }
+        export interface DeleteModelRequest {
+            restApiId: String;            
+            modelName: String;            
+        }
+        export interface DeleteResourceRequest {
+            restApiId: String;            
+            resourceId: String;            
+        }
+        export interface DeleteRestApiRequest {
+            restApiId: String;            
+        }
+        export interface DeleteStageRequest {
+            restApiId: String;            
+            stageName: String;            
+        }
+        export interface Deployment {
+            id?: String;            
+            description?: String;            
+            createdDate?: Timestamp;            
+            apiSummary?: PathToMapOfMethodSnapshot;            
+        }
+        export interface Deployments {
+            position?: String;            
+            items?: ListOfDeployment;            
+        }
+        export interface DomainName {
+            domainName?: String;            
+            certificateName?: String;            
+            certificateUploadDate?: Timestamp;            
+            distributionDomainName?: String;            
+        }
+        export interface DomainNames {
+            position?: String;            
+            items?: ListOfDomainName;            
+        }
+        export interface FlushStageCacheRequest {
+            restApiId: String;            
+            stageName: String;            
+        }
+        export interface GenerateClientCertificateRequest {
+            description?: String;            
+        }
+        export interface GetAccountRequest {
+        }
+        export interface GetApiKeyRequest {
+            apiKey: String;            
+        }
+        export interface GetApiKeysRequest {
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetBasePathMappingRequest {
+            domainName: String;            
+            basePath: String;            
+        }
+        export interface GetBasePathMappingsRequest {
+            domainName: String;            
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetClientCertificateRequest {
+            clientCertificateId: String;            
+        }
+        export interface GetClientCertificatesRequest {
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetDeploymentRequest {
+            restApiId: String;            
+            deploymentId: String;            
+        }
+        export interface GetDeploymentsRequest {
+            restApiId: String;            
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetDomainNameRequest {
+            domainName: String;            
+        }
+        export interface GetDomainNamesRequest {
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetIntegrationRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+        }
+        export interface GetIntegrationResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+        }
+        export interface GetMethodRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+        }
+        export interface GetMethodResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+        }
+        export interface GetModelRequest {
+            restApiId: String;            
+            modelName: String;            
+            flatten?: Boolean;            
+        }
+        export interface GetModelTemplateRequest {
+            restApiId: String;            
+            modelName: String;            
+        }
+        export interface GetModelsRequest {
+            restApiId: String;            
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetResourceRequest {
+            restApiId: String;            
+            resourceId: String;            
+        }
+        export interface GetResourcesRequest {
+            restApiId: String;            
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetRestApiRequest {
+            restApiId: String;            
+        }
+        export interface GetRestApisRequest {
+            position?: String;            
+            limit?: NullableInteger;            
+        }
+        export interface GetSdkRequest {
+            restApiId: String;            
+            stageName: String;            
+            sdkType: String;            
+            parameters?: MapOfStringToString;            
+        }
+        export interface GetStageRequest {
+            restApiId: String;            
+            stageName: String;            
+        }
+        export interface GetStagesRequest {
+            restApiId: String;            
+            deploymentId?: String;            
+        }
+        export interface Integration {
+            type?: IntegrationType;            
+            httpMethod?: String;            
+            uri?: String;            
+            credentials?: String;            
+            requestParameters?: MapOfStringToString;            
+            requestTemplates?: MapOfStringToString;            
+            cacheNamespace?: String;            
+            cacheKeyParameters?: ListOfString;            
+            integrationResponses?: MapOfIntegrationResponse;            
+        }
+        export interface IntegrationResponse {
+            statusCode?: StatusCode;            
+            selectionPattern?: String;            
+            responseParameters?: MapOfStringToString;            
+            responseTemplates?: MapOfStringToString;            
+        }
+        export interface LimitExceededException {
+            retryAfterSeconds?: String;            
+            message?: String;            
+        }
+        export interface Method {
+            httpMethod?: String;            
+            authorizationType?: String;            
+            apiKeyRequired?: NullableBoolean;            
+            requestParameters?: MapOfStringToBoolean;            
+            requestModels?: MapOfStringToString;            
+            methodResponses?: MapOfMethodResponse;            
+            methodIntegration?: Integration;            
+        }
+        export interface MethodResponse {
+            statusCode?: StatusCode;            
+            responseParameters?: MapOfStringToBoolean;            
+            responseModels?: MapOfStringToString;            
+        }
+        export interface MethodSetting {
+            metricsEnabled?: Boolean;            
+            loggingLevel?: String;            
+            dataTraceEnabled?: Boolean;            
+            throttlingBurstLimit?: Integer;            
+            throttlingRateLimit?: Double;            
+            cachingEnabled?: Boolean;            
+            cacheTtlInSeconds?: Integer;            
+            cacheDataEncrypted?: Boolean;            
+        }
+        export interface MethodSnapshot {
+            authorizationType?: String;            
+            apiKeyRequired?: Boolean;            
+        }
+        export interface Model {
+            id?: String;            
+            name?: String;            
+            description?: String;            
+            schema?: String;            
+            contentType?: String;            
+        }
+        export interface Models {
+            position?: String;            
+            items?: ListOfModel;            
+        }
+        export interface NotFoundException {
+            message?: String;            
+        }
+        export interface PatchOperation {
+            op?: op;            
+            path?: String;            
+            value?: String;            
+            from?: String;            
+        }
+        export interface PutIntegrationRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            type: IntegrationType;            
+            integrationHttpMethod?: String;            
+            uri?: String;            
+            credentials?: String;            
+            requestParameters?: MapOfStringToString;            
+            requestTemplates?: MapOfStringToString;            
+            cacheNamespace?: String;            
+            cacheKeyParameters?: ListOfString;            
+        }
+        export interface PutIntegrationResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+            selectionPattern?: String;            
+            responseParameters?: MapOfStringToString;            
+            responseTemplates?: MapOfStringToString;            
+        }
+        export interface PutMethodRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            authorizationType: String;            
+            apiKeyRequired?: Boolean;            
+            requestParameters?: MapOfStringToBoolean;            
+            requestModels?: MapOfStringToString;            
+        }
+        export interface PutMethodResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+            responseParameters?: MapOfStringToBoolean;            
+            responseModels?: MapOfStringToString;            
+        }
+        export interface Resource {
+            id?: String;            
+            parentId?: String;            
+            pathPart?: String;            
+            path?: String;            
+            resourceMethods?: MapOfMethod;            
+        }
+        export interface Resources {
+            position?: String;            
+            items?: ListOfResource;            
+        }
+        export interface RestApi {
+            id?: String;            
+            name?: String;            
+            description?: String;            
+            createdDate?: Timestamp;            
+        }
+        export interface RestApis {
+            position?: String;            
+            items?: ListOfRestApi;            
+        }
+        export interface SdkResponse {
+            contentType?: String;            
+            contentDisposition?: String;            
+            body?: Blob;            
+        }
+        export interface ServiceUnavailableException {
+            retryAfterSeconds?: String;            
+            message?: String;            
+        }
+        export interface Stage {
+            deploymentId?: String;            
+            clientCertificateId?: String;            
+            stageName?: String;            
+            description?: String;            
+            cacheClusterEnabled?: Boolean;            
+            cacheClusterSize?: CacheClusterSize;            
+            cacheClusterStatus?: CacheClusterStatus;            
+            methodSettings?: MapOfMethodSettings;            
+            variables?: MapOfStringToString;            
+            createdDate?: Timestamp;            
+            lastUpdatedDate?: Timestamp;            
+        }
+        export interface StageKey {
+            restApiId?: String;            
+            stageName?: String;            
+        }
+        export interface Stages {
+            item?: ListOfStage;            
+        }
+        export interface Template {
+            value?: String;            
+        }
+        export interface TestInvokeMethodRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            pathWithQueryString?: String;            
+            body?: String;            
+            headers?: MapOfHeaderValues;            
+            clientCertificateId?: String;            
+            stageVariables?: MapOfStringToString;            
+        }
+        export interface TestInvokeMethodResponse {
+            status?: Integer;            
+            body?: String;            
+            headers?: MapOfHeaderValues;            
+            log?: String;            
+            latency?: Long;            
+        }
+        export interface ThrottleSettings {
+            burstLimit?: Integer;            
+            rateLimit?: Double;            
+        }
+        export interface TooManyRequestsException {
+            retryAfterSeconds?: String;            
+            message?: String;            
+        }
+        export interface UnauthorizedException {
+            message?: String;            
+        }
+        export interface UpdateAccountRequest {
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateApiKeyRequest {
+            apiKey: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateBasePathMappingRequest {
+            domainName: String;            
+            basePath: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateClientCertificateRequest {
+            clientCertificateId: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateDeploymentRequest {
+            restApiId: String;            
+            deploymentId: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateDomainNameRequest {
+            domainName: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateIntegrationRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateIntegrationResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateMethodRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateMethodResponseRequest {
+            restApiId: String;            
+            resourceId: String;            
+            httpMethod: String;            
+            statusCode: StatusCode;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateModelRequest {
+            restApiId: String;            
+            modelName: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateResourceRequest {
+            restApiId: String;            
+            resourceId: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateRestApiRequest {
+            restApiId: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
+        export interface UpdateStageRequest {
+            restApiId: String;            
+            stageName: String;            
+            patchOperations?: ListOfPatchOperation;            
+        }
 
-    export interface APIGatewayGetModelTemplateRequest {
-        restApiId: APIGatewayString;
-        modelName: APIGatewayString;
     }
-
-    export interface APIGatewayGetModelsRequest {
-        restApiId: APIGatewayString;
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetResourceRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-    }
-
-    export interface APIGatewayGetResourcesRequest {
-        restApiId: APIGatewayString;
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetRestApiRequest {
-        restApiId: APIGatewayString;
-    }
-
-    export interface APIGatewayGetRestApisRequest {
-        position?: APIGatewayString;
-        limit?: APIGatewayNullableInteger;
-    }
-
-    export interface APIGatewayGetSdkRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-        sdkType: APIGatewayString;
-        parameters?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayGetStageRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-    }
-
-    export interface APIGatewayGetStagesRequest {
-        restApiId: APIGatewayString;
-        deploymentId?: APIGatewayString;
-    }
-
-    export type APIGatewayInteger = number;
-    export interface APIGatewayIntegration {
-        type?: APIGatewayIntegrationType;
-        httpMethod?: APIGatewayString;
-        uri?: APIGatewayString;
-        credentials?: APIGatewayString;
-        requestParameters?: APIGatewayMapOfStringToString;
-        requestTemplates?: APIGatewayMapOfStringToString;
-        cacheNamespace?: APIGatewayString;
-        cacheKeyParameters?: APIGatewayListOfString;
-        integrationResponses?: APIGatewayMapOfIntegrationResponse;
-    }
-
-    export interface APIGatewayIntegrationResponse {
-        statusCode?: APIGatewayStatusCode;
-        selectionPattern?: APIGatewayString;
-        responseParameters?: APIGatewayMapOfStringToString;
-        responseTemplates?: APIGatewayMapOfStringToString;
-    }
-
-    export type APIGatewayIntegrationType = string;
-    export interface APIGatewayLimitExceededException {
-        retryAfterSeconds?: APIGatewayString;
-        message?: APIGatewayString;
-    }
-
-    export type APIGatewayListOfApiKey = Array<APIGatewayApiKey>;
-    export type APIGatewayListOfBasePathMapping = Array<APIGatewayBasePathMapping>;
-    export type APIGatewayListOfClientCertificate = Array<APIGatewayClientCertificate>;
-    export type APIGatewayListOfDeployment = Array<APIGatewayDeployment>;
-    export type APIGatewayListOfDomainName = Array<APIGatewayDomainName>;
-    export type APIGatewayListOfModel = Array<APIGatewayModel>;
-    export type APIGatewayListOfPatchOperation = Array<APIGatewayPatchOperation>;
-    export type APIGatewayListOfResource = Array<APIGatewayResource>;
-    export type APIGatewayListOfRestApi = Array<APIGatewayRestApi>;
-    export type APIGatewayListOfStage = Array<APIGatewayStage>;
-    export type APIGatewayListOfStageKeys = Array<APIGatewayStageKey>;
-    export type APIGatewayListOfString = Array<APIGatewayString>;
-    export type APIGatewayLong = number;
-    export type APIGatewayMapOfHeaderValues = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfIntegrationResponse = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfMethod = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfMethodResponse = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfMethodSettings = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfMethodSnapshot = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfStringToBoolean = any; // not really - it was 'map' instead - must fix this one
-    export type APIGatewayMapOfStringToString = any; // not really - it was 'map' instead - must fix this one
-    export interface APIGatewayMethod {
-        httpMethod?: APIGatewayString;
-        authorizationType?: APIGatewayString;
-        apiKeyRequired?: APIGatewayNullableBoolean;
-        requestParameters?: APIGatewayMapOfStringToBoolean;
-        requestModels?: APIGatewayMapOfStringToString;
-        methodResponses?: APIGatewayMapOfMethodResponse;
-        methodIntegration?: APIGatewayIntegration;
-    }
-
-    export interface APIGatewayMethodResponse {
-        statusCode?: APIGatewayStatusCode;
-        responseParameters?: APIGatewayMapOfStringToBoolean;
-        responseModels?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayMethodSetting {
-        metricsEnabled?: APIGatewayBoolean;
-        loggingLevel?: APIGatewayString;
-        dataTraceEnabled?: APIGatewayBoolean;
-        throttlingBurstLimit?: APIGatewayInteger;
-        throttlingRateLimit?: APIGatewayDouble;
-        cachingEnabled?: APIGatewayBoolean;
-        cacheTtlInSeconds?: APIGatewayInteger;
-        cacheDataEncrypted?: APIGatewayBoolean;
-    }
-
-    export interface APIGatewayMethodSnapshot {
-        authorizationType?: APIGatewayString;
-        apiKeyRequired?: APIGatewayBoolean;
-    }
-
-    export interface APIGatewayModel {
-        id?: APIGatewayString;
-        name?: APIGatewayString;
-        description?: APIGatewayString;
-        schema?: APIGatewayString;
-        contentType?: APIGatewayString;
-    }
-
-    export interface APIGatewayModels {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfModel;
-    }
-
-    export interface APIGatewayNotFoundException {
-        message?: APIGatewayString;
-    }
-
-    export type APIGatewayNullableBoolean = boolean;
-    export type APIGatewayNullableInteger = number;
-    export interface APIGatewayPatchOperation {
-        op?: APIGatewayop;
-        path?: APIGatewayString;
-        value?: APIGatewayString;
-        from?: APIGatewayString;
-    }
-
-    export type APIGatewayPathToMapOfMethodSnapshot = any; // not really - it was 'map' instead - must fix this one
-    export interface APIGatewayPutIntegrationRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        type: APIGatewayIntegrationType;
-        integrationHttpMethod?: APIGatewayString;
-        uri?: APIGatewayString;
-        credentials?: APIGatewayString;
-        requestParameters?: APIGatewayMapOfStringToString;
-        requestTemplates?: APIGatewayMapOfStringToString;
-        cacheNamespace?: APIGatewayString;
-        cacheKeyParameters?: APIGatewayListOfString;
-    }
-
-    export interface APIGatewayPutIntegrationResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-        selectionPattern?: APIGatewayString;
-        responseParameters?: APIGatewayMapOfStringToString;
-        responseTemplates?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayPutMethodRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        authorizationType: APIGatewayString;
-        apiKeyRequired?: APIGatewayBoolean;
-        requestParameters?: APIGatewayMapOfStringToBoolean;
-        requestModels?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayPutMethodResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-        responseParameters?: APIGatewayMapOfStringToBoolean;
-        responseModels?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayResource {
-        id?: APIGatewayString;
-        parentId?: APIGatewayString;
-        pathPart?: APIGatewayString;
-        path?: APIGatewayString;
-        resourceMethods?: APIGatewayMapOfMethod;
-    }
-
-    export interface APIGatewayResources {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfResource;
-    }
-
-    export interface APIGatewayRestApi {
-        id?: APIGatewayString;
-        name?: APIGatewayString;
-        description?: APIGatewayString;
-        createdDate?: APIGatewayTimestamp;
-    }
-
-    export interface APIGatewayRestApis {
-        position?: APIGatewayString;
-        items?: APIGatewayListOfRestApi;
-    }
-
-    export interface APIGatewaySdkResponse {
-        contentType?: APIGatewayString;
-        contentDisposition?: APIGatewayString;
-        body?: APIGatewayBlob;
-    }
-
-    export interface APIGatewayServiceUnavailableException {
-        retryAfterSeconds?: APIGatewayString;
-        message?: APIGatewayString;
-    }
-
-    export interface APIGatewayStage {
-        deploymentId?: APIGatewayString;
-        clientCertificateId?: APIGatewayString;
-        stageName?: APIGatewayString;
-        description?: APIGatewayString;
-        cacheClusterEnabled?: APIGatewayBoolean;
-        cacheClusterSize?: APIGatewayCacheClusterSize;
-        cacheClusterStatus?: APIGatewayCacheClusterStatus;
-        methodSettings?: APIGatewayMapOfMethodSettings;
-        variables?: APIGatewayMapOfStringToString;
-        createdDate?: APIGatewayTimestamp;
-        lastUpdatedDate?: APIGatewayTimestamp;
-    }
-
-    export interface APIGatewayStageKey {
-        restApiId?: APIGatewayString;
-        stageName?: APIGatewayString;
-    }
-
-    export interface APIGatewayStages {
-        item?: APIGatewayListOfStage;
-    }
-
-    export type APIGatewayStatusCode = string; // pattern: "[1-5]\d\d"
-    export type APIGatewayString = string;
-    export interface APIGatewayTemplate {
-        value?: APIGatewayString;
-    }
-
-    export interface APIGatewayTestInvokeMethodRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        pathWithQueryString?: APIGatewayString;
-        body?: APIGatewayString;
-        headers?: APIGatewayMapOfHeaderValues;
-        clientCertificateId?: APIGatewayString;
-        stageVariables?: APIGatewayMapOfStringToString;
-    }
-
-    export interface APIGatewayTestInvokeMethodResponse {
-        status?: APIGatewayInteger;
-        body?: APIGatewayString;
-        headers?: APIGatewayMapOfHeaderValues;
-        log?: APIGatewayString;
-        latency?: APIGatewayLong;
-    }
-
-    export interface APIGatewayThrottleSettings {
-        burstLimit?: APIGatewayInteger;
-        rateLimit?: APIGatewayDouble;
-    }
-
-    export type APIGatewayTimestamp = number;
-    export interface APIGatewayTooManyRequestsException {
-        retryAfterSeconds?: APIGatewayString;
-        message?: APIGatewayString;
-    }
-
-    export interface APIGatewayUnauthorizedException {
-        message?: APIGatewayString;
-    }
-
-    export interface APIGatewayUpdateAccountRequest {
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateApiKeyRequest {
-        apiKey: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateBasePathMappingRequest {
-        domainName: APIGatewayString;
-        basePath: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateClientCertificateRequest {
-        clientCertificateId: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateDeploymentRequest {
-        restApiId: APIGatewayString;
-        deploymentId: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateDomainNameRequest {
-        domainName: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateIntegrationRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateIntegrationResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateMethodRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateMethodResponseRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        httpMethod: APIGatewayString;
-        statusCode: APIGatewayStatusCode;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateModelRequest {
-        restApiId: APIGatewayString;
-        modelName: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateResourceRequest {
-        restApiId: APIGatewayString;
-        resourceId: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateRestApiRequest {
-        restApiId: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export interface APIGatewayUpdateStageRequest {
-        restApiId: APIGatewayString;
-        stageName: APIGatewayString;
-        patchOperations?: APIGatewayListOfPatchOperation;
-    }
-
-    export type APIGatewayop = string;
 }

--- a/output/aws-autoscaling.d.ts
+++ b/output/aws-autoscaling.d.ts
@@ -6,773 +6,679 @@ declare module "aws-sdk" {
 
     export class AutoScaling extends Service {
       constructor(options?: any);
-      attachInstances(params: AutoScalingAttachInstancesQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      attachLoadBalancers(params: AutoScalingAttachLoadBalancersType, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingAttachLoadBalancersResultType|any) => void): Request;
-      completeLifecycleAction(params: AutoScalingCompleteLifecycleActionType, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingCompleteLifecycleActionAnswer|any) => void): Request;
-      createAutoScalingGroup(params: AutoScalingCreateAutoScalingGroupType, callback?: (err: AutoScalingAlreadyExistsFault|AutoScalingLimitExceededFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      createLaunchConfiguration(params: AutoScalingCreateLaunchConfigurationType, callback?: (err: AutoScalingAlreadyExistsFault|AutoScalingLimitExceededFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      createOrUpdateTags(params: AutoScalingCreateOrUpdateTagsType, callback?: (err: AutoScalingLimitExceededFault|AutoScalingAlreadyExistsFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      deleteAutoScalingGroup(params: AutoScalingDeleteAutoScalingGroupType, callback?: (err: AutoScalingScalingActivityInProgressFault|AutoScalingResourceInUseFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      deleteLaunchConfiguration(params: AutoScalingLaunchConfigurationNameType, callback?: (err: AutoScalingResourceInUseFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      deleteLifecycleHook(params: AutoScalingDeleteLifecycleHookType, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDeleteLifecycleHookAnswer|any) => void): Request;
-      deleteNotificationConfiguration(params: AutoScalingDeleteNotificationConfigurationType, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      deletePolicy(params: AutoScalingDeletePolicyType, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      deleteScheduledAction(params: AutoScalingDeleteScheduledActionType, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      deleteTags(params: AutoScalingDeleteTagsType, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      describeAccountLimits(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeAccountLimitsAnswer|any) => void): Request;
-      describeAdjustmentTypes(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeAdjustmentTypesAnswer|any) => void): Request;
-      describeAutoScalingGroups(params: AutoScalingAutoScalingGroupNamesType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingAutoScalingGroupsType|any) => void): Request;
-      describeAutoScalingInstances(params: AutoScalingDescribeAutoScalingInstancesType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingAutoScalingInstancesType|any) => void): Request;
-      describeAutoScalingNotificationTypes(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeAutoScalingNotificationTypesAnswer|any) => void): Request;
-      describeLaunchConfigurations(params: AutoScalingLaunchConfigurationNamesType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingLaunchConfigurationsType|any) => void): Request;
-      describeLifecycleHookTypes(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeLifecycleHookTypesAnswer|any) => void): Request;
-      describeLifecycleHooks(params: AutoScalingDescribeLifecycleHooksType, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeLifecycleHooksAnswer|any) => void): Request;
-      describeLoadBalancers(params: AutoScalingDescribeLoadBalancersRequest, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeLoadBalancersResponse|any) => void): Request;
-      describeMetricCollectionTypes(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeMetricCollectionTypesAnswer|any) => void): Request;
-      describeNotificationConfigurations(params: AutoScalingDescribeNotificationConfigurationsType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingDescribeNotificationConfigurationsAnswer|any) => void): Request;
-      describePolicies(params: AutoScalingDescribePoliciesType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingPoliciesType|any) => void): Request;
-      describeScalingActivities(params: AutoScalingDescribeScalingActivitiesType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingActivitiesType|any) => void): Request;
-      describeScalingProcessTypes(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingProcessesType|any) => void): Request;
-      describeScheduledActions(params: AutoScalingDescribeScheduledActionsType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingScheduledActionsType|any) => void): Request;
-      describeTags(params: AutoScalingDescribeTagsType, callback?: (err: AutoScalingInvalidNextToken|AutoScalingResourceContentionFault|any, data: AutoScalingTagsType|any) => void): Request;
-      describeTerminationPolicyTypes(callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDescribeTerminationPolicyTypesAnswer|any) => void): Request;
-      detachInstances(params: AutoScalingDetachInstancesQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDetachInstancesAnswer|any) => void): Request;
-      detachLoadBalancers(params: AutoScalingDetachLoadBalancersType, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingDetachLoadBalancersResultType|any) => void): Request;
-      disableMetricsCollection(params: AutoScalingDisableMetricsCollectionQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      enableMetricsCollection(params: AutoScalingEnableMetricsCollectionQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      enterStandby(params: AutoScalingEnterStandbyQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingEnterStandbyAnswer|any) => void): Request;
-      executePolicy(params: AutoScalingExecutePolicyType, callback?: (err: AutoScalingScalingActivityInProgressFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      exitStandby(params: AutoScalingExitStandbyQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingExitStandbyAnswer|any) => void): Request;
-      putLifecycleHook(params: AutoScalingPutLifecycleHookType, callback?: (err: AutoScalingLimitExceededFault|AutoScalingResourceContentionFault|any, data: AutoScalingPutLifecycleHookAnswer|any) => void): Request;
-      putNotificationConfiguration(params: AutoScalingPutNotificationConfigurationType, callback?: (err: AutoScalingLimitExceededFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      putScalingPolicy(params: AutoScalingPutScalingPolicyType, callback?: (err: AutoScalingLimitExceededFault|AutoScalingResourceContentionFault|any, data: AutoScalingPolicyARNType|any) => void): Request;
-      putScheduledUpdateGroupAction(params: AutoScalingPutScheduledUpdateGroupActionType, callback?: (err: AutoScalingAlreadyExistsFault|AutoScalingLimitExceededFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      recordLifecycleActionHeartbeat(params: AutoScalingRecordLifecycleActionHeartbeatType, callback?: (err: AutoScalingResourceContentionFault|any, data: AutoScalingRecordLifecycleActionHeartbeatAnswer|any) => void): Request;
-      resumeProcesses(params: AutoScalingScalingProcessQuery, callback?: (err: AutoScalingResourceInUseFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      setDesiredCapacity(params: AutoScalingSetDesiredCapacityType, callback?: (err: AutoScalingScalingActivityInProgressFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      setInstanceHealth(params: AutoScalingSetInstanceHealthQuery, callback?: (err: AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      suspendProcesses(params: AutoScalingScalingProcessQuery, callback?: (err: AutoScalingResourceInUseFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-      terminateInstanceInAutoScalingGroup(params: AutoScalingTerminateInstanceInAutoScalingGroupType, callback?: (err: AutoScalingScalingActivityInProgressFault|AutoScalingResourceContentionFault|any, data: AutoScalingActivityType|any) => void): Request;
-      updateAutoScalingGroup(params: AutoScalingUpdateAutoScalingGroupType, callback?: (err: AutoScalingScalingActivityInProgressFault|AutoScalingResourceContentionFault|any, data: any) => void): Request;
-    }
-
-    export type AutoScalingActivities = Array<AutoScalingActivity>;
-    export interface AutoScalingActivitiesType {
-        Activities: AutoScalingActivities;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingActivity {
-        ActivityId: AutoScalingXmlString;
-        AutoScalingGroupName: AutoScalingXmlStringMaxLen255;
-        Description?: AutoScalingXmlString;
-        Cause: AutoScalingXmlStringMaxLen1023;
-        StartTime: AutoScalingTimestampType;
-        EndTime?: AutoScalingTimestampType;
-        StatusCode: AutoScalingScalingActivityStatusCode;
-        StatusMessage?: AutoScalingXmlStringMaxLen255;
-        Progress?: AutoScalingProgress;
-        Details?: AutoScalingXmlString;
-    }
-
-    export type AutoScalingActivityIds = Array<AutoScalingXmlString>;
-    export interface AutoScalingActivityType {
-        Activity?: AutoScalingActivity;
-    }
-
-    export interface AutoScalingAdjustmentType {
-        AdjustmentType?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingAdjustmentTypes = Array<AutoScalingAdjustmentType>;
-    export interface AutoScalingAlarm {
-        AlarmName?: AutoScalingXmlStringMaxLen255;
-        AlarmARN?: AutoScalingResourceName;
-    }
-
-    export type AutoScalingAlarms = Array<AutoScalingAlarm>;
-    export interface AutoScalingAlreadyExistsFault {
-        message?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingAsciiStringMaxLen255 = string; // pattern: "[A-Za-z0-9\-_\/]+"
-    export type AutoScalingAssociatePublicIpAddress = boolean;
-    export interface AutoScalingAttachInstancesQuery {
-        InstanceIds?: AutoScalingInstanceIds;
-        AutoScalingGroupName: AutoScalingResourceName;
-    }
-
-    export interface AutoScalingAttachLoadBalancersResultType {
-    }
-
-    export interface AutoScalingAttachLoadBalancersType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        LoadBalancerNames?: AutoScalingLoadBalancerNames;
-    }
-
-    export interface AutoScalingAutoScalingGroup {
-        AutoScalingGroupName: AutoScalingXmlStringMaxLen255;
-        AutoScalingGroupARN?: AutoScalingResourceName;
-        LaunchConfigurationName: AutoScalingXmlStringMaxLen255;
-        MinSize: AutoScalingAutoScalingGroupMinSize;
-        MaxSize: AutoScalingAutoScalingGroupMaxSize;
-        DesiredCapacity: AutoScalingAutoScalingGroupDesiredCapacity;
-        DefaultCooldown: AutoScalingCooldown;
-        AvailabilityZones: AutoScalingAvailabilityZones;
-        LoadBalancerNames?: AutoScalingLoadBalancerNames;
-        HealthCheckType: AutoScalingXmlStringMaxLen32;
-        HealthCheckGracePeriod?: AutoScalingHealthCheckGracePeriod;
-        Instances?: AutoScalingInstances;
-        CreatedTime: AutoScalingTimestampType;
-        SuspendedProcesses?: AutoScalingSuspendedProcesses;
-        PlacementGroup?: AutoScalingXmlStringMaxLen255;
-        VPCZoneIdentifier?: AutoScalingXmlStringMaxLen255;
-        EnabledMetrics?: AutoScalingEnabledMetrics;
-        Status?: AutoScalingXmlStringMaxLen255;
-        Tags?: AutoScalingTagDescriptionList;
-        TerminationPolicies?: AutoScalingTerminationPolicies;
-    }
-
-    export type AutoScalingAutoScalingGroupDesiredCapacity = number;
-    export type AutoScalingAutoScalingGroupMaxSize = number;
-    export type AutoScalingAutoScalingGroupMinSize = number;
-    export type AutoScalingAutoScalingGroupNames = Array<AutoScalingResourceName>;
-    export interface AutoScalingAutoScalingGroupNamesType {
-        AutoScalingGroupNames?: AutoScalingAutoScalingGroupNames;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export type AutoScalingAutoScalingGroups = Array<AutoScalingAutoScalingGroup>;
-    export interface AutoScalingAutoScalingGroupsType {
-        AutoScalingGroups: AutoScalingAutoScalingGroups;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingAutoScalingInstanceDetails {
-        InstanceId: AutoScalingXmlStringMaxLen16;
-        AutoScalingGroupName: AutoScalingXmlStringMaxLen255;
-        AvailabilityZone: AutoScalingXmlStringMaxLen255;
-        LifecycleState: AutoScalingXmlStringMaxLen32;
-        HealthStatus: AutoScalingXmlStringMaxLen32;
-        LaunchConfigurationName: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingAutoScalingInstances = Array<AutoScalingAutoScalingInstanceDetails>;
-    export interface AutoScalingAutoScalingInstancesType {
-        AutoScalingInstances?: AutoScalingAutoScalingInstances;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export type AutoScalingAutoScalingNotificationTypes = Array<AutoScalingXmlStringMaxLen255>;
-    export type AutoScalingAvailabilityZones = Array<AutoScalingXmlStringMaxLen255>;
-    export type AutoScalingBlockDeviceEbsDeleteOnTermination = boolean;
-    export type AutoScalingBlockDeviceEbsEncrypted = boolean;
-    export type AutoScalingBlockDeviceEbsIops = number;
-    export type AutoScalingBlockDeviceEbsVolumeSize = number;
-    export type AutoScalingBlockDeviceEbsVolumeType = string;
-    export interface AutoScalingBlockDeviceMapping {
-        VirtualName?: AutoScalingXmlStringMaxLen255;
-        DeviceName: AutoScalingXmlStringMaxLen255;
-        Ebs?: AutoScalingEbs;
-        NoDevice?: AutoScalingNoDevice;
-    }
-
-    export type AutoScalingBlockDeviceMappings = Array<AutoScalingBlockDeviceMapping>;
-    export type AutoScalingClassicLinkVPCSecurityGroups = Array<AutoScalingXmlStringMaxLen255>;
-    export interface AutoScalingCompleteLifecycleActionAnswer {
-    }
-
-    export interface AutoScalingCompleteLifecycleActionType {
-        LifecycleHookName: AutoScalingAsciiStringMaxLen255;
-        AutoScalingGroupName: AutoScalingResourceName;
-        LifecycleActionToken: AutoScalingLifecycleActionToken;
-        LifecycleActionResult: AutoScalingLifecycleActionResult;
-    }
-
-    export type AutoScalingCooldown = number;
-    export interface AutoScalingCreateAutoScalingGroupType {
-        AutoScalingGroupName: AutoScalingXmlStringMaxLen255;
-        LaunchConfigurationName?: AutoScalingResourceName;
-        InstanceId?: AutoScalingXmlStringMaxLen16;
-        MinSize: AutoScalingAutoScalingGroupMinSize;
-        MaxSize: AutoScalingAutoScalingGroupMaxSize;
-        DesiredCapacity?: AutoScalingAutoScalingGroupDesiredCapacity;
-        DefaultCooldown?: AutoScalingCooldown;
-        AvailabilityZones?: AutoScalingAvailabilityZones;
-        LoadBalancerNames?: AutoScalingLoadBalancerNames;
-        HealthCheckType?: AutoScalingXmlStringMaxLen32;
-        HealthCheckGracePeriod?: AutoScalingHealthCheckGracePeriod;
-        PlacementGroup?: AutoScalingXmlStringMaxLen255;
-        VPCZoneIdentifier?: AutoScalingXmlStringMaxLen255;
-        TerminationPolicies?: AutoScalingTerminationPolicies;
-        Tags?: AutoScalingTags;
-    }
-
-    export interface AutoScalingCreateLaunchConfigurationType {
-        LaunchConfigurationName: AutoScalingXmlStringMaxLen255;
-        ImageId?: AutoScalingXmlStringMaxLen255;
-        KeyName?: AutoScalingXmlStringMaxLen255;
-        SecurityGroups?: AutoScalingSecurityGroups;
-        ClassicLinkVPCId?: AutoScalingXmlStringMaxLen255;
-        ClassicLinkVPCSecurityGroups?: AutoScalingClassicLinkVPCSecurityGroups;
-        UserData?: AutoScalingXmlStringUserData;
-        InstanceId?: AutoScalingXmlStringMaxLen16;
-        InstanceType?: AutoScalingXmlStringMaxLen255;
-        KernelId?: AutoScalingXmlStringMaxLen255;
-        RamdiskId?: AutoScalingXmlStringMaxLen255;
-        BlockDeviceMappings?: AutoScalingBlockDeviceMappings;
-        InstanceMonitoring?: AutoScalingInstanceMonitoring;
-        SpotPrice?: AutoScalingSpotPrice;
-        IamInstanceProfile?: AutoScalingXmlStringMaxLen1600;
-        EbsOptimized?: AutoScalingEbsOptimized;
-        AssociatePublicIpAddress?: AutoScalingAssociatePublicIpAddress;
-        PlacementTenancy?: AutoScalingXmlStringMaxLen64;
-    }
-
-    export interface AutoScalingCreateOrUpdateTagsType {
-        Tags: AutoScalingTags;
-    }
-
-    export interface AutoScalingDeleteAutoScalingGroupType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        ForceDelete?: AutoScalingForceDelete;
-    }
-
-    export interface AutoScalingDeleteLifecycleHookAnswer {
-    }
-
-    export interface AutoScalingDeleteLifecycleHookType {
-        LifecycleHookName: AutoScalingAsciiStringMaxLen255;
-        AutoScalingGroupName: AutoScalingResourceName;
-    }
-
-    export interface AutoScalingDeleteNotificationConfigurationType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        TopicARN: AutoScalingResourceName;
-    }
-
-    export interface AutoScalingDeletePolicyType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        PolicyName: AutoScalingResourceName;
-    }
-
-    export interface AutoScalingDeleteScheduledActionType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        ScheduledActionName: AutoScalingResourceName;
-    }
-
-    export interface AutoScalingDeleteTagsType {
-        Tags: AutoScalingTags;
-    }
-
-    export interface AutoScalingDescribeAccountLimitsAnswer {
-        MaxNumberOfAutoScalingGroups?: AutoScalingMaxNumberOfAutoScalingGroups;
-        MaxNumberOfLaunchConfigurations?: AutoScalingMaxNumberOfLaunchConfigurations;
-    }
-
-    export interface AutoScalingDescribeAdjustmentTypesAnswer {
-        AdjustmentTypes?: AutoScalingAdjustmentTypes;
-    }
-
-    export interface AutoScalingDescribeAutoScalingInstancesType {
-        InstanceIds?: AutoScalingInstanceIds;
-        MaxRecords?: AutoScalingMaxRecords;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingDescribeAutoScalingNotificationTypesAnswer {
-        AutoScalingNotificationTypes?: AutoScalingAutoScalingNotificationTypes;
-    }
-
-    export interface AutoScalingDescribeLifecycleHookTypesAnswer {
-        LifecycleHookTypes?: AutoScalingAutoScalingNotificationTypes;
-    }
-
-    export interface AutoScalingDescribeLifecycleHooksAnswer {
-        LifecycleHooks?: AutoScalingLifecycleHooks;
-    }
-
-    export interface AutoScalingDescribeLifecycleHooksType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        LifecycleHookNames?: AutoScalingLifecycleHookNames;
-    }
-
-    export interface AutoScalingDescribeLoadBalancersRequest {
-        AutoScalingGroupName: AutoScalingResourceName;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export interface AutoScalingDescribeLoadBalancersResponse {
-        LoadBalancers?: AutoScalingLoadBalancerStates;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingDescribeMetricCollectionTypesAnswer {
-        Metrics?: AutoScalingMetricCollectionTypes;
-        Granularities?: AutoScalingMetricGranularityTypes;
-    }
-
-    export interface AutoScalingDescribeNotificationConfigurationsAnswer {
-        NotificationConfigurations: AutoScalingNotificationConfigurations;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingDescribeNotificationConfigurationsType {
-        AutoScalingGroupNames?: AutoScalingAutoScalingGroupNames;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export interface AutoScalingDescribePoliciesType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        PolicyNames?: AutoScalingPolicyNames;
-        PolicyTypes?: AutoScalingPolicyTypes;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export interface AutoScalingDescribeScalingActivitiesType {
-        ActivityIds?: AutoScalingActivityIds;
-        AutoScalingGroupName?: AutoScalingResourceName;
-        MaxRecords?: AutoScalingMaxRecords;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingDescribeScheduledActionsType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        ScheduledActionNames?: AutoScalingScheduledActionNames;
-        StartTime?: AutoScalingTimestampType;
-        EndTime?: AutoScalingTimestampType;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export interface AutoScalingDescribeTagsType {
-        Filters?: AutoScalingFilters;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export interface AutoScalingDescribeTerminationPolicyTypesAnswer {
-        TerminationPolicyTypes?: AutoScalingTerminationPolicies;
-    }
-
-    export interface AutoScalingDetachInstancesAnswer {
-        Activities?: AutoScalingActivities;
-    }
-
-    export interface AutoScalingDetachInstancesQuery {
-        InstanceIds?: AutoScalingInstanceIds;
-        AutoScalingGroupName: AutoScalingResourceName;
-        ShouldDecrementDesiredCapacity: AutoScalingShouldDecrementDesiredCapacity;
-    }
-
-    export interface AutoScalingDetachLoadBalancersResultType {
-    }
-
-    export interface AutoScalingDetachLoadBalancersType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        LoadBalancerNames?: AutoScalingLoadBalancerNames;
-    }
-
-    export interface AutoScalingDisableMetricsCollectionQuery {
-        AutoScalingGroupName: AutoScalingResourceName;
-        Metrics?: AutoScalingMetrics;
-    }
-
-    export interface AutoScalingEbs {
-        SnapshotId?: AutoScalingXmlStringMaxLen255;
-        VolumeSize?: AutoScalingBlockDeviceEbsVolumeSize;
-        VolumeType?: AutoScalingBlockDeviceEbsVolumeType;
-        DeleteOnTermination?: AutoScalingBlockDeviceEbsDeleteOnTermination;
-        Iops?: AutoScalingBlockDeviceEbsIops;
-        Encrypted?: AutoScalingBlockDeviceEbsEncrypted;
-    }
-
-    export type AutoScalingEbsOptimized = boolean;
-    export interface AutoScalingEnableMetricsCollectionQuery {
-        AutoScalingGroupName: AutoScalingResourceName;
-        Metrics?: AutoScalingMetrics;
-        Granularity: AutoScalingXmlStringMaxLen255;
-    }
-
-    export interface AutoScalingEnabledMetric {
-        Metric?: AutoScalingXmlStringMaxLen255;
-        Granularity?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingEnabledMetrics = Array<AutoScalingEnabledMetric>;
-    export interface AutoScalingEnterStandbyAnswer {
-        Activities?: AutoScalingActivities;
-    }
-
-    export interface AutoScalingEnterStandbyQuery {
-        InstanceIds?: AutoScalingInstanceIds;
-        AutoScalingGroupName: AutoScalingResourceName;
-        ShouldDecrementDesiredCapacity: AutoScalingShouldDecrementDesiredCapacity;
-    }
-
-    export type AutoScalingEstimatedInstanceWarmup = number;
-    export interface AutoScalingExecutePolicyType {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        PolicyName: AutoScalingResourceName;
-        HonorCooldown?: AutoScalingHonorCooldown;
-        MetricValue?: AutoScalingMetricScale;
-        BreachThreshold?: AutoScalingMetricScale;
-    }
-
-    export interface AutoScalingExitStandbyAnswer {
-        Activities?: AutoScalingActivities;
-    }
-
-    export interface AutoScalingExitStandbyQuery {
-        InstanceIds?: AutoScalingInstanceIds;
-        AutoScalingGroupName: AutoScalingResourceName;
-    }
-
-    export interface AutoScalingFilter {
-        Name?: AutoScalingXmlString;
-        Values?: AutoScalingValues;
-    }
-
-    export type AutoScalingFilters = Array<AutoScalingFilter>;
-    export type AutoScalingForceDelete = boolean;
-    export type AutoScalingGlobalTimeout = number;
-    export type AutoScalingHealthCheckGracePeriod = number;
-    export type AutoScalingHeartbeatTimeout = number;
-    export type AutoScalingHonorCooldown = boolean;
-    export interface AutoScalingInstance {
-        InstanceId: AutoScalingXmlStringMaxLen16;
-        AvailabilityZone: AutoScalingXmlStringMaxLen255;
-        LifecycleState: AutoScalingLifecycleState;
-        HealthStatus: AutoScalingXmlStringMaxLen32;
-        LaunchConfigurationName: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingInstanceIds = Array<AutoScalingXmlStringMaxLen16>;
-    export interface AutoScalingInstanceMonitoring {
-        Enabled?: AutoScalingMonitoringEnabled;
-    }
-
-    export type AutoScalingInstances = Array<AutoScalingInstance>;
-    export interface AutoScalingInvalidNextToken {
-        message?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export interface AutoScalingLaunchConfiguration {
-        LaunchConfigurationName: AutoScalingXmlStringMaxLen255;
-        LaunchConfigurationARN?: AutoScalingResourceName;
-        ImageId: AutoScalingXmlStringMaxLen255;
-        KeyName?: AutoScalingXmlStringMaxLen255;
-        SecurityGroups?: AutoScalingSecurityGroups;
-        ClassicLinkVPCId?: AutoScalingXmlStringMaxLen255;
-        ClassicLinkVPCSecurityGroups?: AutoScalingClassicLinkVPCSecurityGroups;
-        UserData?: AutoScalingXmlStringUserData;
-        InstanceType: AutoScalingXmlStringMaxLen255;
-        KernelId?: AutoScalingXmlStringMaxLen255;
-        RamdiskId?: AutoScalingXmlStringMaxLen255;
-        BlockDeviceMappings?: AutoScalingBlockDeviceMappings;
-        InstanceMonitoring?: AutoScalingInstanceMonitoring;
-        SpotPrice?: AutoScalingSpotPrice;
-        IamInstanceProfile?: AutoScalingXmlStringMaxLen1600;
-        CreatedTime: AutoScalingTimestampType;
-        EbsOptimized?: AutoScalingEbsOptimized;
-        AssociatePublicIpAddress?: AutoScalingAssociatePublicIpAddress;
-        PlacementTenancy?: AutoScalingXmlStringMaxLen64;
-    }
-
-    export interface AutoScalingLaunchConfigurationNameType {
-        LaunchConfigurationName: AutoScalingResourceName;
-    }
-
-    export type AutoScalingLaunchConfigurationNames = Array<AutoScalingResourceName>;
-    export interface AutoScalingLaunchConfigurationNamesType {
-        LaunchConfigurationNames?: AutoScalingLaunchConfigurationNames;
-        NextToken?: AutoScalingXmlString;
-        MaxRecords?: AutoScalingMaxRecords;
-    }
-
-    export type AutoScalingLaunchConfigurations = Array<AutoScalingLaunchConfiguration>;
-    export interface AutoScalingLaunchConfigurationsType {
-        LaunchConfigurations: AutoScalingLaunchConfigurations;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export type AutoScalingLifecycleActionResult = string;
-    export type AutoScalingLifecycleActionToken = string;
-    export interface AutoScalingLifecycleHook {
-        LifecycleHookName?: AutoScalingAsciiStringMaxLen255;
-        AutoScalingGroupName?: AutoScalingResourceName;
-        LifecycleTransition?: AutoScalingLifecycleTransition;
-        NotificationTargetARN?: AutoScalingResourceName;
-        RoleARN?: AutoScalingResourceName;
-        NotificationMetadata?: AutoScalingXmlStringMaxLen1023;
-        HeartbeatTimeout?: AutoScalingHeartbeatTimeout;
-        GlobalTimeout?: AutoScalingGlobalTimeout;
-        DefaultResult?: AutoScalingLifecycleActionResult;
-    }
-
-    export type AutoScalingLifecycleHookNames = Array<AutoScalingAsciiStringMaxLen255>;
-    export type AutoScalingLifecycleHooks = Array<AutoScalingLifecycleHook>;
-    export type AutoScalingLifecycleState = string;
-    export type AutoScalingLifecycleTransition = string;
-    export interface AutoScalingLimitExceededFault {
-        message?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingLoadBalancerNames = Array<AutoScalingXmlStringMaxLen255>;
-    export interface AutoScalingLoadBalancerState {
-        LoadBalancerName?: AutoScalingXmlStringMaxLen255;
-        State?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingLoadBalancerStates = Array<AutoScalingLoadBalancerState>;
-    export type AutoScalingMaxNumberOfAutoScalingGroups = number;
-    export type AutoScalingMaxNumberOfLaunchConfigurations = number;
-    export type AutoScalingMaxRecords = number;
-    export interface AutoScalingMetricCollectionType {
-        Metric?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingMetricCollectionTypes = Array<AutoScalingMetricCollectionType>;
-    export interface AutoScalingMetricGranularityType {
-        Granularity?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingMetricGranularityTypes = Array<AutoScalingMetricGranularityType>;
-    export type AutoScalingMetricScale = number;
-    export type AutoScalingMetrics = Array<AutoScalingXmlStringMaxLen255>;
-    export type AutoScalingMinAdjustmentMagnitude = number;
-    export type AutoScalingMinAdjustmentStep = number;
-    export type AutoScalingMonitoringEnabled = boolean;
-    export type AutoScalingNoDevice = boolean;
-    export interface AutoScalingNotificationConfiguration {
-        AutoScalingGroupName?: AutoScalingResourceName;
-        TopicARN?: AutoScalingResourceName;
-        NotificationType?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingNotificationConfigurations = Array<AutoScalingNotificationConfiguration>;
-    export interface AutoScalingPoliciesType {
-        ScalingPolicies?: AutoScalingScalingPolicies;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingPolicyARNType {
-        PolicyARN?: AutoScalingResourceName;
-    }
+      attachInstances(params: AutoScaling.AttachInstancesQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      attachLoadBalancers(params: AutoScaling.AttachLoadBalancersType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.AttachLoadBalancersResultType|any) => void): Request;
+      completeLifecycleAction(params: AutoScaling.CompleteLifecycleActionType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.CompleteLifecycleActionAnswer|any) => void): Request;
+      createAutoScalingGroup(params: AutoScaling.CreateAutoScalingGroupType, callback?: (err: AutoScaling.AlreadyExistsFault|AutoScaling.LimitExceededFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      createLaunchConfiguration(params: AutoScaling.CreateLaunchConfigurationType, callback?: (err: AutoScaling.AlreadyExistsFault|AutoScaling.LimitExceededFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      createOrUpdateTags(params: AutoScaling.CreateOrUpdateTagsType, callback?: (err: AutoScaling.LimitExceededFault|AutoScaling.AlreadyExistsFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      deleteAutoScalingGroup(params: AutoScaling.DeleteAutoScalingGroupType, callback?: (err: AutoScaling.ScalingActivityInProgressFault|AutoScaling.ResourceInUseFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      deleteLaunchConfiguration(params: AutoScaling.LaunchConfigurationNameType, callback?: (err: AutoScaling.ResourceInUseFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      deleteLifecycleHook(params: AutoScaling.DeleteLifecycleHookType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DeleteLifecycleHookAnswer|any) => void): Request;
+      deleteNotificationConfiguration(params: AutoScaling.DeleteNotificationConfigurationType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      deletePolicy(params: AutoScaling.DeletePolicyType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      deleteScheduledAction(params: AutoScaling.DeleteScheduledActionType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      deleteTags(params: AutoScaling.DeleteTagsType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      describeAccountLimits(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeAccountLimitsAnswer|any) => void): Request;
+      describeAdjustmentTypes(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeAdjustmentTypesAnswer|any) => void): Request;
+      describeAutoScalingGroups(params: AutoScaling.AutoScalingGroupNamesType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.AutoScalingGroupsType|any) => void): Request;
+      describeAutoScalingInstances(params: AutoScaling.DescribeAutoScalingInstancesType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.AutoScalingInstancesType|any) => void): Request;
+      describeAutoScalingNotificationTypes(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeAutoScalingNotificationTypesAnswer|any) => void): Request;
+      describeLaunchConfigurations(params: AutoScaling.LaunchConfigurationNamesType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.LaunchConfigurationsType|any) => void): Request;
+      describeLifecycleHookTypes(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeLifecycleHookTypesAnswer|any) => void): Request;
+      describeLifecycleHooks(params: AutoScaling.DescribeLifecycleHooksType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeLifecycleHooksAnswer|any) => void): Request;
+      describeLoadBalancers(params: AutoScaling.DescribeLoadBalancersRequest, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeLoadBalancersResponse|any) => void): Request;
+      describeMetricCollectionTypes(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeMetricCollectionTypesAnswer|any) => void): Request;
+      describeNotificationConfigurations(params: AutoScaling.DescribeNotificationConfigurationsType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeNotificationConfigurationsAnswer|any) => void): Request;
+      describePolicies(params: AutoScaling.DescribePoliciesType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.PoliciesType|any) => void): Request;
+      describeScalingActivities(params: AutoScaling.DescribeScalingActivitiesType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.ActivitiesType|any) => void): Request;
+      describeScalingProcessTypes(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.ProcessesType|any) => void): Request;
+      describeScheduledActions(params: AutoScaling.DescribeScheduledActionsType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.ScheduledActionsType|any) => void): Request;
+      describeTags(params: AutoScaling.DescribeTagsType, callback?: (err: AutoScaling.InvalidNextToken|AutoScaling.ResourceContentionFault|any, data: AutoScaling.TagsType|any) => void): Request;
+      describeTerminationPolicyTypes(callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DescribeTerminationPolicyTypesAnswer|any) => void): Request;
+      detachInstances(params: AutoScaling.DetachInstancesQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DetachInstancesAnswer|any) => void): Request;
+      detachLoadBalancers(params: AutoScaling.DetachLoadBalancersType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.DetachLoadBalancersResultType|any) => void): Request;
+      disableMetricsCollection(params: AutoScaling.DisableMetricsCollectionQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      enableMetricsCollection(params: AutoScaling.EnableMetricsCollectionQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      enterStandby(params: AutoScaling.EnterStandbyQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.EnterStandbyAnswer|any) => void): Request;
+      executePolicy(params: AutoScaling.ExecutePolicyType, callback?: (err: AutoScaling.ScalingActivityInProgressFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      exitStandby(params: AutoScaling.ExitStandbyQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.ExitStandbyAnswer|any) => void): Request;
+      putLifecycleHook(params: AutoScaling.PutLifecycleHookType, callback?: (err: AutoScaling.LimitExceededFault|AutoScaling.ResourceContentionFault|any, data: AutoScaling.PutLifecycleHookAnswer|any) => void): Request;
+      putNotificationConfiguration(params: AutoScaling.PutNotificationConfigurationType, callback?: (err: AutoScaling.LimitExceededFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      putScalingPolicy(params: AutoScaling.PutScalingPolicyType, callback?: (err: AutoScaling.LimitExceededFault|AutoScaling.ResourceContentionFault|any, data: AutoScaling.PolicyARNType|any) => void): Request;
+      putScheduledUpdateGroupAction(params: AutoScaling.PutScheduledUpdateGroupActionType, callback?: (err: AutoScaling.AlreadyExistsFault|AutoScaling.LimitExceededFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      recordLifecycleActionHeartbeat(params: AutoScaling.RecordLifecycleActionHeartbeatType, callback?: (err: AutoScaling.ResourceContentionFault|any, data: AutoScaling.RecordLifecycleActionHeartbeatAnswer|any) => void): Request;
+      resumeProcesses(params: AutoScaling.ScalingProcessQuery, callback?: (err: AutoScaling.ResourceInUseFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      setDesiredCapacity(params: AutoScaling.SetDesiredCapacityType, callback?: (err: AutoScaling.ScalingActivityInProgressFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      setInstanceHealth(params: AutoScaling.SetInstanceHealthQuery, callback?: (err: AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      suspendProcesses(params: AutoScaling.ScalingProcessQuery, callback?: (err: AutoScaling.ResourceInUseFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+      terminateInstanceInAutoScalingGroup(params: AutoScaling.TerminateInstanceInAutoScalingGroupType, callback?: (err: AutoScaling.ScalingActivityInProgressFault|AutoScaling.ResourceContentionFault|any, data: AutoScaling.ActivityType|any) => void): Request;
+      updateAutoScalingGroup(params: AutoScaling.UpdateAutoScalingGroupType, callback?: (err: AutoScaling.ScalingActivityInProgressFault|AutoScaling.ResourceContentionFault|any, data: any) => void): Request;
+    }
+    
+    export module AutoScaling {
+        export type Activities = Activity[];
+        export type ActivityIds = XmlString[];
+        export type AdjustmentTypes = AdjustmentType[];
+        export type Alarms = Alarm[];
+        export type AsciiStringMaxLen255 = string;    // pattern: &quot;[A-Za-z0-9\-_\/]+&quot;, max: 255, min: 1
+        export type AssociatePublicIpAddress = boolean;
+        export type AutoScalingGroupDesiredCapacity = number;
+        export type AutoScalingGroupMaxSize = number;
+        export type AutoScalingGroupMinSize = number;
+        export type AutoScalingGroupNames = ResourceName[];
+        export type AutoScalingGroups = AutoScalingGroup[];
+        export type AutoScalingInstances = AutoScalingInstanceDetails[];
+        export type AutoScalingNotificationTypes = XmlStringMaxLen255[];
+        export type AvailabilityZones = XmlStringMaxLen255[];    // min: 1
+        export type BlockDeviceEbsDeleteOnTermination = boolean;
+        export type BlockDeviceEbsEncrypted = boolean;
+        export type BlockDeviceEbsIops = number;    // max: 20000, min: 100
+        export type BlockDeviceEbsVolumeSize = number;    // max: 16384, min: 1
+        export type BlockDeviceEbsVolumeType = string;    // max: 255, min: 1
+        export type BlockDeviceMappings = BlockDeviceMapping[];
+        export type ClassicLinkVPCSecurityGroups = XmlStringMaxLen255[];
+        export type Cooldown = number;
+        export type EbsOptimized = boolean;
+        export type EnabledMetrics = EnabledMetric[];
+        export type EstimatedInstanceWarmup = number;
+        export type Filters = Filter[];
+        export type ForceDelete = boolean;
+        export type GlobalTimeout = number;
+        export type HealthCheckGracePeriod = number;
+        export type HeartbeatTimeout = number;
+        export type HonorCooldown = boolean;
+        export type InstanceIds = XmlStringMaxLen16[];
+        export type Instances = Instance[];
+        export type LaunchConfigurationNames = ResourceName[];
+        export type LaunchConfigurations = LaunchConfiguration[];
+        export type LifecycleActionResult = string;
+        export type LifecycleActionToken = string;    // max: 36, min: 36
+        export type LifecycleHookNames = AsciiStringMaxLen255[];
+        export type LifecycleHooks = LifecycleHook[];
+        export type LifecycleState = string;
+        export type LifecycleTransition = string;
+        export type LoadBalancerNames = XmlStringMaxLen255[];
+        export type LoadBalancerStates = LoadBalancerState[];
+        export type MaxNumberOfAutoScalingGroups = number;
+        export type MaxNumberOfLaunchConfigurations = number;
+        export type MaxRecords = number;
+        export type MetricCollectionTypes = MetricCollectionType[];
+        export type MetricGranularityTypes = MetricGranularityType[];
+        export type MetricScale = number;
+        export type Metrics = XmlStringMaxLen255[];
+        export type MinAdjustmentMagnitude = number;
+        export type MinAdjustmentStep = number;
+        export type MonitoringEnabled = boolean;
+        export type NoDevice = boolean;
+        export type NotificationConfigurations = NotificationConfiguration[];
+        export type PolicyIncrement = number;
+        export type PolicyNames = ResourceName[];
+        export type PolicyTypes = XmlStringMaxLen64[];
+        export type ProcessNames = XmlStringMaxLen255[];
+        export type Processes = ProcessType[];
+        export type Progress = number;
+        export type PropagateAtLaunch = boolean;
+        export type ResourceName = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 1600, min: 1
+        export type ScalingActivityStatusCode = string;
+        export type ScalingPolicies = ScalingPolicy[];
+        export type ScheduledActionNames = ResourceName[];
+        export type ScheduledUpdateGroupActions = ScheduledUpdateGroupAction[];
+        export type SecurityGroups = XmlString[];
+        export type ShouldDecrementDesiredCapacity = boolean;
+        export type ShouldRespectGracePeriod = boolean;
+        export type SpotPrice = string;    // max: 255, min: 1
+        export type StepAdjustments = StepAdjustment[];
+        export type SuspendedProcesses = SuspendedProcess[];
+        export type TagDescriptionList = TagDescription[];
+        export type TagKey = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 128, min: 1
+        export type TagValue = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 256
+        export type Tags = Tag[];
+        export type TerminationPolicies = XmlStringMaxLen1600[];
+        export type TimestampType = number;
+        export type Values = XmlString[];
+        export type XmlString = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;
+        export type XmlStringMaxLen1023 = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 1023, min: 1
+        export type XmlStringMaxLen16 = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 16, min: 1
+        export type XmlStringMaxLen1600 = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 1600, min: 1
+        export type XmlStringMaxLen255 = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 255, min: 1
+        export type XmlStringMaxLen32 = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 32, min: 1
+        export type XmlStringMaxLen64 = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 64, min: 1
+        export type XmlStringUserData = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 21847
+
+        export interface ActivitiesType {
+            Activities: Activities;            
+            NextToken?: XmlString;            
+        }
+        export interface Activity {
+            ActivityId: XmlString;            
+            AutoScalingGroupName: XmlStringMaxLen255;            
+            Description?: XmlString;            
+            Cause: XmlStringMaxLen1023;            
+            StartTime: TimestampType;            
+            EndTime?: TimestampType;            
+            StatusCode: ScalingActivityStatusCode;            
+            StatusMessage?: XmlStringMaxLen255;            
+            Progress?: Progress;            
+            Details?: XmlString;            
+        }
+        export interface ActivityType {
+            Activity?: Activity;            
+        }
+        export interface AdjustmentType {
+            AdjustmentType?: XmlStringMaxLen255;            
+        }
+        export interface Alarm {
+            AlarmName?: XmlStringMaxLen255;            
+            AlarmARN?: ResourceName;            
+        }
+        export interface AlreadyExistsFault {
+            message?: XmlStringMaxLen255;            
+        }
+        export interface AttachInstancesQuery {
+            InstanceIds?: InstanceIds;            
+            AutoScalingGroupName: ResourceName;            
+        }
+        export interface AttachLoadBalancersResultType {
+        }
+        export interface AttachLoadBalancersType {
+            AutoScalingGroupName?: ResourceName;            
+            LoadBalancerNames?: LoadBalancerNames;            
+        }
+        export interface AutoScalingGroup {
+            AutoScalingGroupName: XmlStringMaxLen255;            
+            AutoScalingGroupARN?: ResourceName;            
+            LaunchConfigurationName: XmlStringMaxLen255;            
+            MinSize: AutoScalingGroupMinSize;            
+            MaxSize: AutoScalingGroupMaxSize;            
+            DesiredCapacity: AutoScalingGroupDesiredCapacity;            
+            DefaultCooldown: Cooldown;            
+            AvailabilityZones: AvailabilityZones;            
+            LoadBalancerNames?: LoadBalancerNames;            
+            HealthCheckType: XmlStringMaxLen32;            
+            HealthCheckGracePeriod?: HealthCheckGracePeriod;            
+            Instances?: Instances;            
+            CreatedTime: TimestampType;            
+            SuspendedProcesses?: SuspendedProcesses;            
+            PlacementGroup?: XmlStringMaxLen255;            
+            VPCZoneIdentifier?: XmlStringMaxLen255;            
+            EnabledMetrics?: EnabledMetrics;            
+            Status?: XmlStringMaxLen255;            
+            Tags?: TagDescriptionList;            
+            TerminationPolicies?: TerminationPolicies;            
+        }
+        export interface AutoScalingGroupNamesType {
+            AutoScalingGroupNames?: AutoScalingGroupNames;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface AutoScalingGroupsType {
+            AutoScalingGroups: AutoScalingGroups;            
+            NextToken?: XmlString;            
+        }
+        export interface AutoScalingInstanceDetails {
+            InstanceId: XmlStringMaxLen16;            
+            AutoScalingGroupName: XmlStringMaxLen255;            
+            AvailabilityZone: XmlStringMaxLen255;            
+            LifecycleState: XmlStringMaxLen32;            
+            HealthStatus: XmlStringMaxLen32;            
+            LaunchConfigurationName: XmlStringMaxLen255;            
+        }
+        export interface AutoScalingInstancesType {
+            AutoScalingInstances?: AutoScalingInstances;            
+            NextToken?: XmlString;            
+        }
+        export interface BlockDeviceMapping {
+            VirtualName?: XmlStringMaxLen255;            
+            DeviceName: XmlStringMaxLen255;            
+            Ebs?: Ebs;            
+            NoDevice?: NoDevice;            
+        }
+        export interface CompleteLifecycleActionAnswer {
+        }
+        export interface CompleteLifecycleActionType {
+            LifecycleHookName: AsciiStringMaxLen255;            
+            AutoScalingGroupName: ResourceName;            
+            LifecycleActionToken: LifecycleActionToken;            
+            LifecycleActionResult: LifecycleActionResult;            
+        }
+        export interface CreateAutoScalingGroupType {
+            AutoScalingGroupName: XmlStringMaxLen255;            
+            LaunchConfigurationName?: ResourceName;            
+            InstanceId?: XmlStringMaxLen16;            
+            MinSize: AutoScalingGroupMinSize;            
+            MaxSize: AutoScalingGroupMaxSize;            
+            DesiredCapacity?: AutoScalingGroupDesiredCapacity;            
+            DefaultCooldown?: Cooldown;            
+            AvailabilityZones?: AvailabilityZones;            
+            LoadBalancerNames?: LoadBalancerNames;            
+            HealthCheckType?: XmlStringMaxLen32;            
+            HealthCheckGracePeriod?: HealthCheckGracePeriod;            
+            PlacementGroup?: XmlStringMaxLen255;            
+            VPCZoneIdentifier?: XmlStringMaxLen255;            
+            TerminationPolicies?: TerminationPolicies;            
+            Tags?: Tags;            
+        }
+        export interface CreateLaunchConfigurationType {
+            LaunchConfigurationName: XmlStringMaxLen255;            
+            ImageId?: XmlStringMaxLen255;            
+            KeyName?: XmlStringMaxLen255;            
+            SecurityGroups?: SecurityGroups;            
+            ClassicLinkVPCId?: XmlStringMaxLen255;            
+            ClassicLinkVPCSecurityGroups?: ClassicLinkVPCSecurityGroups;            
+            UserData?: XmlStringUserData;            
+            InstanceId?: XmlStringMaxLen16;            
+            InstanceType?: XmlStringMaxLen255;            
+            KernelId?: XmlStringMaxLen255;            
+            RamdiskId?: XmlStringMaxLen255;            
+            BlockDeviceMappings?: BlockDeviceMappings;            
+            InstanceMonitoring?: InstanceMonitoring;            
+            SpotPrice?: SpotPrice;            
+            IamInstanceProfile?: XmlStringMaxLen1600;            
+            EbsOptimized?: EbsOptimized;            
+            AssociatePublicIpAddress?: AssociatePublicIpAddress;            
+            PlacementTenancy?: XmlStringMaxLen64;            
+        }
+        export interface CreateOrUpdateTagsType {
+            Tags: Tags;            
+        }
+        export interface DeleteAutoScalingGroupType {
+            AutoScalingGroupName: ResourceName;            
+            ForceDelete?: ForceDelete;            
+        }
+        export interface DeleteLifecycleHookAnswer {
+        }
+        export interface DeleteLifecycleHookType {
+            LifecycleHookName: AsciiStringMaxLen255;            
+            AutoScalingGroupName: ResourceName;            
+        }
+        export interface DeleteNotificationConfigurationType {
+            AutoScalingGroupName: ResourceName;            
+            TopicARN: ResourceName;            
+        }
+        export interface DeletePolicyType {
+            AutoScalingGroupName?: ResourceName;            
+            PolicyName: ResourceName;            
+        }
+        export interface DeleteScheduledActionType {
+            AutoScalingGroupName?: ResourceName;            
+            ScheduledActionName: ResourceName;            
+        }
+        export interface DeleteTagsType {
+            Tags: Tags;            
+        }
+        export interface DescribeAccountLimitsAnswer {
+            MaxNumberOfAutoScalingGroups?: MaxNumberOfAutoScalingGroups;            
+            MaxNumberOfLaunchConfigurations?: MaxNumberOfLaunchConfigurations;            
+        }
+        export interface DescribeAdjustmentTypesAnswer {
+            AdjustmentTypes?: AdjustmentTypes;            
+        }
+        export interface DescribeAutoScalingInstancesType {
+            InstanceIds?: InstanceIds;            
+            MaxRecords?: MaxRecords;            
+            NextToken?: XmlString;            
+        }
+        export interface DescribeAutoScalingNotificationTypesAnswer {
+            AutoScalingNotificationTypes?: AutoScalingNotificationTypes;            
+        }
+        export interface DescribeLifecycleHookTypesAnswer {
+            LifecycleHookTypes?: AutoScalingNotificationTypes;            
+        }
+        export interface DescribeLifecycleHooksAnswer {
+            LifecycleHooks?: LifecycleHooks;            
+        }
+        export interface DescribeLifecycleHooksType {
+            AutoScalingGroupName: ResourceName;            
+            LifecycleHookNames?: LifecycleHookNames;            
+        }
+        export interface DescribeLoadBalancersRequest {
+            AutoScalingGroupName: ResourceName;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface DescribeLoadBalancersResponse {
+            LoadBalancers?: LoadBalancerStates;            
+            NextToken?: XmlString;            
+        }
+        export interface DescribeMetricCollectionTypesAnswer {
+            Metrics?: MetricCollectionTypes;            
+            Granularities?: MetricGranularityTypes;            
+        }
+        export interface DescribeNotificationConfigurationsAnswer {
+            NotificationConfigurations: NotificationConfigurations;            
+            NextToken?: XmlString;            
+        }
+        export interface DescribeNotificationConfigurationsType {
+            AutoScalingGroupNames?: AutoScalingGroupNames;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface DescribePoliciesType {
+            AutoScalingGroupName?: ResourceName;            
+            PolicyNames?: PolicyNames;            
+            PolicyTypes?: PolicyTypes;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface DescribeScalingActivitiesType {
+            ActivityIds?: ActivityIds;            
+            AutoScalingGroupName?: ResourceName;            
+            MaxRecords?: MaxRecords;            
+            NextToken?: XmlString;            
+        }
+        export interface DescribeScheduledActionsType {
+            AutoScalingGroupName?: ResourceName;            
+            ScheduledActionNames?: ScheduledActionNames;            
+            StartTime?: TimestampType;            
+            EndTime?: TimestampType;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface DescribeTagsType {
+            Filters?: Filters;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface DescribeTerminationPolicyTypesAnswer {
+            TerminationPolicyTypes?: TerminationPolicies;            
+        }
+        export interface DetachInstancesAnswer {
+            Activities?: Activities;            
+        }
+        export interface DetachInstancesQuery {
+            InstanceIds?: InstanceIds;            
+            AutoScalingGroupName: ResourceName;            
+            ShouldDecrementDesiredCapacity: ShouldDecrementDesiredCapacity;            
+        }
+        export interface DetachLoadBalancersResultType {
+        }
+        export interface DetachLoadBalancersType {
+            AutoScalingGroupName?: ResourceName;            
+            LoadBalancerNames?: LoadBalancerNames;            
+        }
+        export interface DisableMetricsCollectionQuery {
+            AutoScalingGroupName: ResourceName;            
+            Metrics?: Metrics;            
+        }
+        export interface Ebs {
+            SnapshotId?: XmlStringMaxLen255;            
+            VolumeSize?: BlockDeviceEbsVolumeSize;            
+            VolumeType?: BlockDeviceEbsVolumeType;            
+            DeleteOnTermination?: BlockDeviceEbsDeleteOnTermination;            
+            Iops?: BlockDeviceEbsIops;            
+            Encrypted?: BlockDeviceEbsEncrypted;            
+        }
+        export interface EnableMetricsCollectionQuery {
+            AutoScalingGroupName: ResourceName;            
+            Metrics?: Metrics;            
+            Granularity: XmlStringMaxLen255;            
+        }
+        export interface EnabledMetric {
+            Metric?: XmlStringMaxLen255;            
+            Granularity?: XmlStringMaxLen255;            
+        }
+        export interface EnterStandbyAnswer {
+            Activities?: Activities;            
+        }
+        export interface EnterStandbyQuery {
+            InstanceIds?: InstanceIds;            
+            AutoScalingGroupName: ResourceName;            
+            ShouldDecrementDesiredCapacity: ShouldDecrementDesiredCapacity;            
+        }
+        export interface ExecutePolicyType {
+            AutoScalingGroupName?: ResourceName;            
+            PolicyName: ResourceName;            
+            HonorCooldown?: HonorCooldown;            
+            MetricValue?: MetricScale;            
+            BreachThreshold?: MetricScale;            
+        }
+        export interface ExitStandbyAnswer {
+            Activities?: Activities;            
+        }
+        export interface ExitStandbyQuery {
+            InstanceIds?: InstanceIds;            
+            AutoScalingGroupName: ResourceName;            
+        }
+        export interface Filter {
+            Name?: XmlString;            
+            Values?: Values;            
+        }
+        export interface Instance {
+            InstanceId: XmlStringMaxLen16;            
+            AvailabilityZone: XmlStringMaxLen255;            
+            LifecycleState: LifecycleState;            
+            HealthStatus: XmlStringMaxLen32;            
+            LaunchConfigurationName: XmlStringMaxLen255;            
+        }
+        export interface InstanceMonitoring {
+            Enabled?: MonitoringEnabled;            
+        }
+        export interface InvalidNextToken {
+            message?: XmlStringMaxLen255;            
+        }
+        export interface LaunchConfiguration {
+            LaunchConfigurationName: XmlStringMaxLen255;            
+            LaunchConfigurationARN?: ResourceName;            
+            ImageId: XmlStringMaxLen255;            
+            KeyName?: XmlStringMaxLen255;            
+            SecurityGroups?: SecurityGroups;            
+            ClassicLinkVPCId?: XmlStringMaxLen255;            
+            ClassicLinkVPCSecurityGroups?: ClassicLinkVPCSecurityGroups;            
+            UserData?: XmlStringUserData;            
+            InstanceType: XmlStringMaxLen255;            
+            KernelId?: XmlStringMaxLen255;            
+            RamdiskId?: XmlStringMaxLen255;            
+            BlockDeviceMappings?: BlockDeviceMappings;            
+            InstanceMonitoring?: InstanceMonitoring;            
+            SpotPrice?: SpotPrice;            
+            IamInstanceProfile?: XmlStringMaxLen1600;            
+            CreatedTime: TimestampType;            
+            EbsOptimized?: EbsOptimized;            
+            AssociatePublicIpAddress?: AssociatePublicIpAddress;            
+            PlacementTenancy?: XmlStringMaxLen64;            
+        }
+        export interface LaunchConfigurationNameType {
+            LaunchConfigurationName: ResourceName;            
+        }
+        export interface LaunchConfigurationNamesType {
+            LaunchConfigurationNames?: LaunchConfigurationNames;            
+            NextToken?: XmlString;            
+            MaxRecords?: MaxRecords;            
+        }
+        export interface LaunchConfigurationsType {
+            LaunchConfigurations: LaunchConfigurations;            
+            NextToken?: XmlString;            
+        }
+        export interface LifecycleHook {
+            LifecycleHookName?: AsciiStringMaxLen255;            
+            AutoScalingGroupName?: ResourceName;            
+            LifecycleTransition?: LifecycleTransition;            
+            NotificationTargetARN?: ResourceName;            
+            RoleARN?: ResourceName;            
+            NotificationMetadata?: XmlStringMaxLen1023;            
+            HeartbeatTimeout?: HeartbeatTimeout;            
+            GlobalTimeout?: GlobalTimeout;            
+            DefaultResult?: LifecycleActionResult;            
+        }
+        export interface LimitExceededFault {
+            message?: XmlStringMaxLen255;            
+        }
+        export interface LoadBalancerState {
+            LoadBalancerName?: XmlStringMaxLen255;            
+            State?: XmlStringMaxLen255;            
+        }
+        export interface MetricCollectionType {
+            Metric?: XmlStringMaxLen255;            
+        }
+        export interface MetricGranularityType {
+            Granularity?: XmlStringMaxLen255;            
+        }
+        export interface NotificationConfiguration {
+            AutoScalingGroupName?: ResourceName;            
+            TopicARN?: ResourceName;            
+            NotificationType?: XmlStringMaxLen255;            
+        }
+        export interface PoliciesType {
+            ScalingPolicies?: ScalingPolicies;            
+            NextToken?: XmlString;            
+        }
+        export interface PolicyARNType {
+            PolicyARN?: ResourceName;            
+        }
+        export interface ProcessType {
+            ProcessName: XmlStringMaxLen255;            
+        }
+        export interface ProcessesType {
+            Processes?: Processes;            
+        }
+        export interface PutLifecycleHookAnswer {
+        }
+        export interface PutLifecycleHookType {
+            LifecycleHookName: AsciiStringMaxLen255;            
+            AutoScalingGroupName: ResourceName;            
+            LifecycleTransition?: LifecycleTransition;            
+            RoleARN?: ResourceName;            
+            NotificationTargetARN?: ResourceName;            
+            NotificationMetadata?: XmlStringMaxLen1023;            
+            HeartbeatTimeout?: HeartbeatTimeout;            
+            DefaultResult?: LifecycleActionResult;            
+        }
+        export interface PutNotificationConfigurationType {
+            AutoScalingGroupName: ResourceName;            
+            TopicARN: ResourceName;            
+            NotificationTypes: AutoScalingNotificationTypes;            
+        }
+        export interface PutScalingPolicyType {
+            AutoScalingGroupName: ResourceName;            
+            PolicyName: XmlStringMaxLen255;            
+            PolicyType?: XmlStringMaxLen64;            
+            AdjustmentType: XmlStringMaxLen255;            
+            MinAdjustmentStep?: MinAdjustmentStep;            
+            MinAdjustmentMagnitude?: MinAdjustmentMagnitude;            
+            ScalingAdjustment?: PolicyIncrement;            
+            Cooldown?: Cooldown;            
+            MetricAggregationType?: XmlStringMaxLen32;            
+            StepAdjustments?: StepAdjustments;            
+            EstimatedInstanceWarmup?: EstimatedInstanceWarmup;            
+        }
+        export interface PutScheduledUpdateGroupActionType {
+            AutoScalingGroupName: ResourceName;            
+            ScheduledActionName: XmlStringMaxLen255;            
+            Time?: TimestampType;            
+            StartTime?: TimestampType;            
+            EndTime?: TimestampType;            
+            Recurrence?: XmlStringMaxLen255;            
+            MinSize?: AutoScalingGroupMinSize;            
+            MaxSize?: AutoScalingGroupMaxSize;            
+            DesiredCapacity?: AutoScalingGroupDesiredCapacity;            
+        }
+        export interface RecordLifecycleActionHeartbeatAnswer {
+        }
+        export interface RecordLifecycleActionHeartbeatType {
+            LifecycleHookName: AsciiStringMaxLen255;            
+            AutoScalingGroupName: ResourceName;            
+            LifecycleActionToken: LifecycleActionToken;            
+        }
+        export interface ResourceContentionFault {
+            message?: XmlStringMaxLen255;            
+        }
+        export interface ResourceInUseFault {
+            message?: XmlStringMaxLen255;            
+        }
+        export interface ScalingActivityInProgressFault {
+            message?: XmlStringMaxLen255;            
+        }
+        export interface ScalingPolicy {
+            AutoScalingGroupName?: XmlStringMaxLen255;            
+            PolicyName?: XmlStringMaxLen255;            
+            PolicyARN?: ResourceName;            
+            PolicyType?: XmlStringMaxLen64;            
+            AdjustmentType?: XmlStringMaxLen255;            
+            MinAdjustmentStep?: MinAdjustmentStep;            
+            MinAdjustmentMagnitude?: MinAdjustmentMagnitude;            
+            ScalingAdjustment?: PolicyIncrement;            
+            Cooldown?: Cooldown;            
+            StepAdjustments?: StepAdjustments;            
+            MetricAggregationType?: XmlStringMaxLen32;            
+            EstimatedInstanceWarmup?: EstimatedInstanceWarmup;            
+            Alarms?: Alarms;            
+        }
+        export interface ScalingProcessQuery {
+            AutoScalingGroupName: ResourceName;            
+            ScalingProcesses?: ProcessNames;            
+        }
+        export interface ScheduledActionsType {
+            ScheduledUpdateGroupActions?: ScheduledUpdateGroupActions;            
+            NextToken?: XmlString;            
+        }
+        export interface ScheduledUpdateGroupAction {
+            AutoScalingGroupName?: XmlStringMaxLen255;            
+            ScheduledActionName?: XmlStringMaxLen255;            
+            ScheduledActionARN?: ResourceName;            
+            Time?: TimestampType;            
+            StartTime?: TimestampType;            
+            EndTime?: TimestampType;            
+            Recurrence?: XmlStringMaxLen255;            
+            MinSize?: AutoScalingGroupMinSize;            
+            MaxSize?: AutoScalingGroupMaxSize;            
+            DesiredCapacity?: AutoScalingGroupDesiredCapacity;            
+        }
+        export interface SetDesiredCapacityType {
+            AutoScalingGroupName: ResourceName;            
+            DesiredCapacity: AutoScalingGroupDesiredCapacity;            
+            HonorCooldown?: HonorCooldown;            
+        }
+        export interface SetInstanceHealthQuery {
+            InstanceId: XmlStringMaxLen16;            
+            HealthStatus: XmlStringMaxLen32;            
+            ShouldRespectGracePeriod?: ShouldRespectGracePeriod;            
+        }
+        export interface StepAdjustment {
+            MetricIntervalLowerBound?: MetricScale;            
+            MetricIntervalUpperBound?: MetricScale;            
+            ScalingAdjustment: PolicyIncrement;            
+        }
+        export interface SuspendedProcess {
+            ProcessName?: XmlStringMaxLen255;            
+            SuspensionReason?: XmlStringMaxLen255;            
+        }
+        export interface Tag {
+            ResourceId?: XmlString;            
+            ResourceType?: XmlString;            
+            Key: TagKey;            
+            Value?: TagValue;            
+            PropagateAtLaunch?: PropagateAtLaunch;            
+        }
+        export interface TagDescription {
+            ResourceId?: XmlString;            
+            ResourceType?: XmlString;            
+            Key?: TagKey;            
+            Value?: TagValue;            
+            PropagateAtLaunch?: PropagateAtLaunch;            
+        }
+        export interface TagsType {
+            Tags?: TagDescriptionList;            
+            NextToken?: XmlString;            
+        }
+        export interface TerminateInstanceInAutoScalingGroupType {
+            InstanceId: XmlStringMaxLen16;            
+            ShouldDecrementDesiredCapacity: ShouldDecrementDesiredCapacity;            
+        }
+        export interface UpdateAutoScalingGroupType {
+            AutoScalingGroupName: ResourceName;            
+            LaunchConfigurationName?: ResourceName;            
+            MinSize?: AutoScalingGroupMinSize;            
+            MaxSize?: AutoScalingGroupMaxSize;            
+            DesiredCapacity?: AutoScalingGroupDesiredCapacity;            
+            DefaultCooldown?: Cooldown;            
+            AvailabilityZones?: AvailabilityZones;            
+            HealthCheckType?: XmlStringMaxLen32;            
+            HealthCheckGracePeriod?: HealthCheckGracePeriod;            
+            PlacementGroup?: XmlStringMaxLen255;            
+            VPCZoneIdentifier?: XmlStringMaxLen255;            
+            TerminationPolicies?: TerminationPolicies;            
+        }
 
-    export type AutoScalingPolicyIncrement = number;
-    export type AutoScalingPolicyNames = Array<AutoScalingResourceName>;
-    export type AutoScalingPolicyTypes = Array<AutoScalingXmlStringMaxLen64>;
-    export type AutoScalingProcessNames = Array<AutoScalingXmlStringMaxLen255>;
-    export interface AutoScalingProcessType {
-        ProcessName: AutoScalingXmlStringMaxLen255;
     }
-
-    export type AutoScalingProcesses = Array<AutoScalingProcessType>;
-    export interface AutoScalingProcessesType {
-        Processes?: AutoScalingProcesses;
-    }
-
-    export type AutoScalingProgress = number;
-    export type AutoScalingPropagateAtLaunch = boolean;
-    export interface AutoScalingPutLifecycleHookAnswer {
-    }
-
-    export interface AutoScalingPutLifecycleHookType {
-        LifecycleHookName: AutoScalingAsciiStringMaxLen255;
-        AutoScalingGroupName: AutoScalingResourceName;
-        LifecycleTransition?: AutoScalingLifecycleTransition;
-        RoleARN?: AutoScalingResourceName;
-        NotificationTargetARN?: AutoScalingResourceName;
-        NotificationMetadata?: AutoScalingXmlStringMaxLen1023;
-        HeartbeatTimeout?: AutoScalingHeartbeatTimeout;
-        DefaultResult?: AutoScalingLifecycleActionResult;
-    }
-
-    export interface AutoScalingPutNotificationConfigurationType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        TopicARN: AutoScalingResourceName;
-        NotificationTypes: AutoScalingAutoScalingNotificationTypes;
-    }
-
-    export interface AutoScalingPutScalingPolicyType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        PolicyName: AutoScalingXmlStringMaxLen255;
-        PolicyType?: AutoScalingXmlStringMaxLen64;
-        AdjustmentType: AutoScalingXmlStringMaxLen255;
-        MinAdjustmentStep?: AutoScalingMinAdjustmentStep;
-        MinAdjustmentMagnitude?: AutoScalingMinAdjustmentMagnitude;
-        ScalingAdjustment?: AutoScalingPolicyIncrement;
-        Cooldown?: AutoScalingCooldown;
-        MetricAggregationType?: AutoScalingXmlStringMaxLen32;
-        StepAdjustments?: AutoScalingStepAdjustments;
-        EstimatedInstanceWarmup?: AutoScalingEstimatedInstanceWarmup;
-    }
-
-    export interface AutoScalingPutScheduledUpdateGroupActionType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        ScheduledActionName: AutoScalingXmlStringMaxLen255;
-        Time?: AutoScalingTimestampType;
-        StartTime?: AutoScalingTimestampType;
-        EndTime?: AutoScalingTimestampType;
-        Recurrence?: AutoScalingXmlStringMaxLen255;
-        MinSize?: AutoScalingAutoScalingGroupMinSize;
-        MaxSize?: AutoScalingAutoScalingGroupMaxSize;
-        DesiredCapacity?: AutoScalingAutoScalingGroupDesiredCapacity;
-    }
-
-    export interface AutoScalingRecordLifecycleActionHeartbeatAnswer {
-    }
-
-    export interface AutoScalingRecordLifecycleActionHeartbeatType {
-        LifecycleHookName: AutoScalingAsciiStringMaxLen255;
-        AutoScalingGroupName: AutoScalingResourceName;
-        LifecycleActionToken: AutoScalingLifecycleActionToken;
-    }
-
-    export interface AutoScalingResourceContentionFault {
-        message?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export interface AutoScalingResourceInUseFault {
-        message?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingResourceName = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export interface AutoScalingScalingActivityInProgressFault {
-        message?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingScalingActivityStatusCode = string;
-    export type AutoScalingScalingPolicies = Array<AutoScalingScalingPolicy>;
-    export interface AutoScalingScalingPolicy {
-        AutoScalingGroupName?: AutoScalingXmlStringMaxLen255;
-        PolicyName?: AutoScalingXmlStringMaxLen255;
-        PolicyARN?: AutoScalingResourceName;
-        PolicyType?: AutoScalingXmlStringMaxLen64;
-        AdjustmentType?: AutoScalingXmlStringMaxLen255;
-        MinAdjustmentStep?: AutoScalingMinAdjustmentStep;
-        MinAdjustmentMagnitude?: AutoScalingMinAdjustmentMagnitude;
-        ScalingAdjustment?: AutoScalingPolicyIncrement;
-        Cooldown?: AutoScalingCooldown;
-        StepAdjustments?: AutoScalingStepAdjustments;
-        MetricAggregationType?: AutoScalingXmlStringMaxLen32;
-        EstimatedInstanceWarmup?: AutoScalingEstimatedInstanceWarmup;
-        Alarms?: AutoScalingAlarms;
-    }
-
-    export interface AutoScalingScalingProcessQuery {
-        AutoScalingGroupName: AutoScalingResourceName;
-        ScalingProcesses?: AutoScalingProcessNames;
-    }
-
-    export type AutoScalingScheduledActionNames = Array<AutoScalingResourceName>;
-    export interface AutoScalingScheduledActionsType {
-        ScheduledUpdateGroupActions?: AutoScalingScheduledUpdateGroupActions;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingScheduledUpdateGroupAction {
-        AutoScalingGroupName?: AutoScalingXmlStringMaxLen255;
-        ScheduledActionName?: AutoScalingXmlStringMaxLen255;
-        ScheduledActionARN?: AutoScalingResourceName;
-        Time?: AutoScalingTimestampType;
-        StartTime?: AutoScalingTimestampType;
-        EndTime?: AutoScalingTimestampType;
-        Recurrence?: AutoScalingXmlStringMaxLen255;
-        MinSize?: AutoScalingAutoScalingGroupMinSize;
-        MaxSize?: AutoScalingAutoScalingGroupMaxSize;
-        DesiredCapacity?: AutoScalingAutoScalingGroupDesiredCapacity;
-    }
-
-    export type AutoScalingScheduledUpdateGroupActions = Array<AutoScalingScheduledUpdateGroupAction>;
-    export type AutoScalingSecurityGroups = Array<AutoScalingXmlString>;
-    export interface AutoScalingSetDesiredCapacityType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        DesiredCapacity: AutoScalingAutoScalingGroupDesiredCapacity;
-        HonorCooldown?: AutoScalingHonorCooldown;
-    }
-
-    export interface AutoScalingSetInstanceHealthQuery {
-        InstanceId: AutoScalingXmlStringMaxLen16;
-        HealthStatus: AutoScalingXmlStringMaxLen32;
-        ShouldRespectGracePeriod?: AutoScalingShouldRespectGracePeriod;
-    }
-
-    export type AutoScalingShouldDecrementDesiredCapacity = boolean;
-    export type AutoScalingShouldRespectGracePeriod = boolean;
-    export type AutoScalingSpotPrice = string;
-    export interface AutoScalingStepAdjustment {
-        MetricIntervalLowerBound?: AutoScalingMetricScale;
-        MetricIntervalUpperBound?: AutoScalingMetricScale;
-        ScalingAdjustment: AutoScalingPolicyIncrement;
-    }
-
-    export type AutoScalingStepAdjustments = Array<AutoScalingStepAdjustment>;
-    export interface AutoScalingSuspendedProcess {
-        ProcessName?: AutoScalingXmlStringMaxLen255;
-        SuspensionReason?: AutoScalingXmlStringMaxLen255;
-    }
-
-    export type AutoScalingSuspendedProcesses = Array<AutoScalingSuspendedProcess>;
-    export interface AutoScalingTag {
-        ResourceId?: AutoScalingXmlString;
-        ResourceType?: AutoScalingXmlString;
-        Key: AutoScalingTagKey;
-        Value?: AutoScalingTagValue;
-        PropagateAtLaunch?: AutoScalingPropagateAtLaunch;
-    }
-
-    export interface AutoScalingTagDescription {
-        ResourceId?: AutoScalingXmlString;
-        ResourceType?: AutoScalingXmlString;
-        Key?: AutoScalingTagKey;
-        Value?: AutoScalingTagValue;
-        PropagateAtLaunch?: AutoScalingPropagateAtLaunch;
-    }
-
-    export type AutoScalingTagDescriptionList = Array<AutoScalingTagDescription>;
-    export type AutoScalingTagKey = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingTagValue = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingTags = Array<AutoScalingTag>;
-    export interface AutoScalingTagsType {
-        Tags?: AutoScalingTagDescriptionList;
-        NextToken?: AutoScalingXmlString;
-    }
-
-    export interface AutoScalingTerminateInstanceInAutoScalingGroupType {
-        InstanceId: AutoScalingXmlStringMaxLen16;
-        ShouldDecrementDesiredCapacity: AutoScalingShouldDecrementDesiredCapacity;
-    }
-
-    export type AutoScalingTerminationPolicies = Array<AutoScalingXmlStringMaxLen1600>;
-    export type AutoScalingTimestampType = number;
-    export interface AutoScalingUpdateAutoScalingGroupType {
-        AutoScalingGroupName: AutoScalingResourceName;
-        LaunchConfigurationName?: AutoScalingResourceName;
-        MinSize?: AutoScalingAutoScalingGroupMinSize;
-        MaxSize?: AutoScalingAutoScalingGroupMaxSize;
-        DesiredCapacity?: AutoScalingAutoScalingGroupDesiredCapacity;
-        DefaultCooldown?: AutoScalingCooldown;
-        AvailabilityZones?: AutoScalingAvailabilityZones;
-        HealthCheckType?: AutoScalingXmlStringMaxLen32;
-        HealthCheckGracePeriod?: AutoScalingHealthCheckGracePeriod;
-        PlacementGroup?: AutoScalingXmlStringMaxLen255;
-        VPCZoneIdentifier?: AutoScalingXmlStringMaxLen255;
-        TerminationPolicies?: AutoScalingTerminationPolicies;
-    }
-
-    export type AutoScalingValues = Array<AutoScalingXmlString>;
-    export type AutoScalingXmlString = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringMaxLen1023 = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringMaxLen16 = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringMaxLen1600 = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringMaxLen255 = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringMaxLen32 = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringMaxLen64 = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type AutoScalingXmlStringUserData = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
 }

--- a/output/aws-cloudformation.d.ts
+++ b/output/aws-cloudformation.d.ts
@@ -6,397 +6,353 @@ declare module "aws-sdk" {
 
     export class CloudFormation extends Service {
       constructor(options?: any);
-      cancelUpdateStack(params: CloudFormationCancelUpdateStackInput, callback?: (err: any, data: any) => void): Request;
-      createStack(params: CloudFormationCreateStackInput, callback?: (err: CloudFormationLimitExceededException|CloudFormationAlreadyExistsException|CloudFormationInsufficientCapabilitiesException|any, data: CloudFormationCreateStackOutput|any) => void): Request;
-      deleteStack(params: CloudFormationDeleteStackInput, callback?: (err: any, data: any) => void): Request;
-      describeAccountLimits(params: CloudFormationDescribeAccountLimitsInput, callback?: (err: any, data: CloudFormationDescribeAccountLimitsOutput|any) => void): Request;
-      describeStackEvents(params: CloudFormationDescribeStackEventsInput, callback?: (err: any, data: CloudFormationDescribeStackEventsOutput|any) => void): Request;
-      describeStackResource(params: CloudFormationDescribeStackResourceInput, callback?: (err: any, data: CloudFormationDescribeStackResourceOutput|any) => void): Request;
-      describeStackResources(params: CloudFormationDescribeStackResourcesInput, callback?: (err: any, data: CloudFormationDescribeStackResourcesOutput|any) => void): Request;
-      describeStacks(params: CloudFormationDescribeStacksInput, callback?: (err: any, data: CloudFormationDescribeStacksOutput|any) => void): Request;
-      estimateTemplateCost(params: CloudFormationEstimateTemplateCostInput, callback?: (err: any, data: CloudFormationEstimateTemplateCostOutput|any) => void): Request;
-      getStackPolicy(params: CloudFormationGetStackPolicyInput, callback?: (err: any, data: CloudFormationGetStackPolicyOutput|any) => void): Request;
-      getTemplate(params: CloudFormationGetTemplateInput, callback?: (err: any, data: CloudFormationGetTemplateOutput|any) => void): Request;
-      getTemplateSummary(params: CloudFormationGetTemplateSummaryInput, callback?: (err: any, data: CloudFormationGetTemplateSummaryOutput|any) => void): Request;
-      listStackResources(params: CloudFormationListStackResourcesInput, callback?: (err: any, data: CloudFormationListStackResourcesOutput|any) => void): Request;
-      listStacks(params: CloudFormationListStacksInput, callback?: (err: any, data: CloudFormationListStacksOutput|any) => void): Request;
-      setStackPolicy(params: CloudFormationSetStackPolicyInput, callback?: (err: any, data: any) => void): Request;
-      signalResource(params: CloudFormationSignalResourceInput, callback?: (err: any, data: any) => void): Request;
-      updateStack(params: CloudFormationUpdateStackInput, callback?: (err: CloudFormationInsufficientCapabilitiesException|any, data: CloudFormationUpdateStackOutput|any) => void): Request;
-      validateTemplate(params: CloudFormationValidateTemplateInput, callback?: (err: any, data: CloudFormationValidateTemplateOutput|any) => void): Request;
+      cancelUpdateStack(params: CloudFormation.CancelUpdateStackInput, callback?: (err: any, data: any) => void): Request;
+      createStack(params: CloudFormation.CreateStackInput, callback?: (err: CloudFormation.LimitExceededException|CloudFormation.AlreadyExistsException|CloudFormation.InsufficientCapabilitiesException|any, data: CloudFormation.CreateStackOutput|any) => void): Request;
+      deleteStack(params: CloudFormation.DeleteStackInput, callback?: (err: any, data: any) => void): Request;
+      describeAccountLimits(params: CloudFormation.DescribeAccountLimitsInput, callback?: (err: any, data: CloudFormation.DescribeAccountLimitsOutput|any) => void): Request;
+      describeStackEvents(params: CloudFormation.DescribeStackEventsInput, callback?: (err: any, data: CloudFormation.DescribeStackEventsOutput|any) => void): Request;
+      describeStackResource(params: CloudFormation.DescribeStackResourceInput, callback?: (err: any, data: CloudFormation.DescribeStackResourceOutput|any) => void): Request;
+      describeStackResources(params: CloudFormation.DescribeStackResourcesInput, callback?: (err: any, data: CloudFormation.DescribeStackResourcesOutput|any) => void): Request;
+      describeStacks(params: CloudFormation.DescribeStacksInput, callback?: (err: any, data: CloudFormation.DescribeStacksOutput|any) => void): Request;
+      estimateTemplateCost(params: CloudFormation.EstimateTemplateCostInput, callback?: (err: any, data: CloudFormation.EstimateTemplateCostOutput|any) => void): Request;
+      getStackPolicy(params: CloudFormation.GetStackPolicyInput, callback?: (err: any, data: CloudFormation.GetStackPolicyOutput|any) => void): Request;
+      getTemplate(params: CloudFormation.GetTemplateInput, callback?: (err: any, data: CloudFormation.GetTemplateOutput|any) => void): Request;
+      getTemplateSummary(params: CloudFormation.GetTemplateSummaryInput, callback?: (err: any, data: CloudFormation.GetTemplateSummaryOutput|any) => void): Request;
+      listStackResources(params: CloudFormation.ListStackResourcesInput, callback?: (err: any, data: CloudFormation.ListStackResourcesOutput|any) => void): Request;
+      listStacks(params: CloudFormation.ListStacksInput, callback?: (err: any, data: CloudFormation.ListStacksOutput|any) => void): Request;
+      setStackPolicy(params: CloudFormation.SetStackPolicyInput, callback?: (err: any, data: any) => void): Request;
+      signalResource(params: CloudFormation.SignalResourceInput, callback?: (err: any, data: any) => void): Request;
+      updateStack(params: CloudFormation.UpdateStackInput, callback?: (err: CloudFormation.InsufficientCapabilitiesException|any, data: CloudFormation.UpdateStackOutput|any) => void): Request;
+      validateTemplate(params: CloudFormation.ValidateTemplateInput, callback?: (err: any, data: CloudFormation.ValidateTemplateOutput|any) => void): Request;
     }
+    
+    export module CloudFormation {
+        export type AccountLimitList = AccountLimit[];
+        export type AllowedValue = string;
+        export type AllowedValues = AllowedValue[];
+        export type Capabilities = Capability[];
+        export type CapabilitiesReason = string;
+        export type Capability = string;
+        export type CreationTime = number;
+        export type DeletionTime = number;
+        export type Description = string;
+        export type DisableRollback = boolean;
+        export type EventId = string;
+        export type LastUpdatedTime = number;
+        export type LimitName = string;
+        export type LimitValue = number;
+        export type LogicalResourceId = string;
+        export type Metadata = string;
+        export type NextToken = string;    // max: 1024, min: 1
+        export type NoEcho = boolean;
+        export type NotificationARN = string;
+        export type NotificationARNs = NotificationARN[];    // max: 5
+        export type OnFailure = string;
+        export type OutputKey = string;
+        export type OutputValue = string;
+        export type Outputs = Output[];
+        export type ParameterDeclarations = ParameterDeclaration[];
+        export type ParameterKey = string;
+        export type ParameterType = string;
+        export type ParameterValue = string;
+        export type Parameters = Parameter[];
+        export type PhysicalResourceId = string;
+        export type ResourceProperties = string;
+        export type ResourceSignalStatus = string;
+        export type ResourceSignalUniqueId = string;    // max: 64, min: 1
+        export type ResourceStatus = string;
+        export type ResourceStatusReason = string;
+        export type ResourceType = string;
+        export type ResourceTypes = ResourceType[];
+        export type StackEvents = StackEvent[];
+        export type StackId = string;
+        export type StackName = string;
+        export type StackNameOrId = string;    // pattern: &quot;([a-zA-Z][-a-zA-Z0-9]*)|(arn:\b(aws|aws-us-gov|aws-cn)\b:[-a-zA-Z0-9:/._+]*)&quot;, min: 1
+        export type StackPolicyBody = string;    // max: 16384, min: 1
+        export type StackPolicyDuringUpdateBody = string;    // max: 16384, min: 1
+        export type StackPolicyDuringUpdateURL = string;    // max: 1350, min: 1
+        export type StackPolicyURL = string;    // max: 1350, min: 1
+        export type StackResourceSummaries = StackResourceSummary[];
+        export type StackResources = StackResource[];
+        export type StackStatus = string;
+        export type StackStatusFilter = StackStatus[];
+        export type StackStatusReason = string;
+        export type StackSummaries = StackSummary[];
+        export type Stacks = Stack[];
+        export type TagKey = string;
+        export type TagValue = string;
+        export type Tags = Tag[];
+        export type TemplateBody = string;    // min: 1
+        export type TemplateDescription = string;
+        export type TemplateParameters = TemplateParameter[];
+        export type TemplateURL = string;    // max: 1024, min: 1
+        export type TimeoutMinutes = number;    // min: 1
+        export type Timestamp = number;
+        export type Url = string;
+        export type UsePreviousTemplate = boolean;
+        export type UsePreviousValue = boolean;
+        export type Version = string;
 
-    export interface CloudFormationAccountLimit {
-        Name?: CloudFormationLimitName;
-        Value?: CloudFormationLimitValue;
+        export interface AccountLimit {
+            Name?: LimitName;            
+            Value?: LimitValue;            
+        }
+        export interface AlreadyExistsException {
+        }
+        export interface CancelUpdateStackInput {
+            StackName: StackName;            
+        }
+        export interface CreateStackInput {
+            StackName: StackName;            
+            TemplateBody?: TemplateBody;            
+            TemplateURL?: TemplateURL;            
+            Parameters?: Parameters;            
+            DisableRollback?: DisableRollback;            
+            TimeoutInMinutes?: TimeoutMinutes;            
+            NotificationARNs?: NotificationARNs;            
+            Capabilities?: Capabilities;            
+            ResourceTypes?: ResourceTypes;            
+            OnFailure?: OnFailure;            
+            StackPolicyBody?: StackPolicyBody;            
+            StackPolicyURL?: StackPolicyURL;            
+            Tags?: Tags;            
+        }
+        export interface CreateStackOutput {
+            StackId?: StackId;            
+        }
+        export interface DeleteStackInput {
+            StackName: StackName;            
+        }
+        export interface DescribeAccountLimitsInput {
+            NextToken?: NextToken;            
+        }
+        export interface DescribeAccountLimitsOutput {
+            AccountLimits?: AccountLimitList;            
+            NextToken?: NextToken;            
+        }
+        export interface DescribeStackEventsInput {
+            StackName?: StackName;            
+            NextToken?: NextToken;            
+        }
+        export interface DescribeStackEventsOutput {
+            StackEvents?: StackEvents;            
+            NextToken?: NextToken;            
+        }
+        export interface DescribeStackResourceInput {
+            StackName: StackName;            
+            LogicalResourceId: LogicalResourceId;            
+        }
+        export interface DescribeStackResourceOutput {
+            StackResourceDetail?: StackResourceDetail;            
+        }
+        export interface DescribeStackResourcesInput {
+            StackName?: StackName;            
+            LogicalResourceId?: LogicalResourceId;            
+            PhysicalResourceId?: PhysicalResourceId;            
+        }
+        export interface DescribeStackResourcesOutput {
+            StackResources?: StackResources;            
+        }
+        export interface DescribeStacksInput {
+            StackName?: StackName;            
+            NextToken?: NextToken;            
+        }
+        export interface DescribeStacksOutput {
+            Stacks?: Stacks;            
+            NextToken?: NextToken;            
+        }
+        export interface EstimateTemplateCostInput {
+            TemplateBody?: TemplateBody;            
+            TemplateURL?: TemplateURL;            
+            Parameters?: Parameters;            
+        }
+        export interface EstimateTemplateCostOutput {
+            Url?: Url;            
+        }
+        export interface GetStackPolicyInput {
+            StackName: StackName;            
+        }
+        export interface GetStackPolicyOutput {
+            StackPolicyBody?: StackPolicyBody;            
+        }
+        export interface GetTemplateInput {
+            StackName: StackName;            
+        }
+        export interface GetTemplateOutput {
+            TemplateBody?: TemplateBody;            
+        }
+        export interface GetTemplateSummaryInput {
+            TemplateBody?: TemplateBody;            
+            TemplateURL?: TemplateURL;            
+            StackName?: StackNameOrId;            
+        }
+        export interface GetTemplateSummaryOutput {
+            Parameters?: ParameterDeclarations;            
+            Description?: Description;            
+            Capabilities?: Capabilities;            
+            CapabilitiesReason?: CapabilitiesReason;            
+            ResourceTypes?: ResourceTypes;            
+            Version?: Version;            
+            Metadata?: Metadata;            
+        }
+        export interface InsufficientCapabilitiesException {
+        }
+        export interface LimitExceededException {
+        }
+        export interface ListStackResourcesInput {
+            StackName: StackName;            
+            NextToken?: NextToken;            
+        }
+        export interface ListStackResourcesOutput {
+            StackResourceSummaries?: StackResourceSummaries;            
+            NextToken?: NextToken;            
+        }
+        export interface ListStacksInput {
+            NextToken?: NextToken;            
+            StackStatusFilter?: StackStatusFilter;            
+        }
+        export interface ListStacksOutput {
+            StackSummaries?: StackSummaries;            
+            NextToken?: NextToken;            
+        }
+        export interface Output {
+            OutputKey?: OutputKey;            
+            OutputValue?: OutputValue;            
+            Description?: Description;            
+        }
+        export interface Parameter {
+            ParameterKey?: ParameterKey;            
+            ParameterValue?: ParameterValue;            
+            UsePreviousValue?: UsePreviousValue;            
+        }
+        export interface ParameterConstraints {
+            AllowedValues?: AllowedValues;            
+        }
+        export interface ParameterDeclaration {
+            ParameterKey?: ParameterKey;            
+            DefaultValue?: ParameterValue;            
+            ParameterType?: ParameterType;            
+            NoEcho?: NoEcho;            
+            Description?: Description;            
+            ParameterConstraints?: ParameterConstraints;            
+        }
+        export interface SetStackPolicyInput {
+            StackName: StackName;            
+            StackPolicyBody?: StackPolicyBody;            
+            StackPolicyURL?: StackPolicyURL;            
+        }
+        export interface SignalResourceInput {
+            StackName: StackNameOrId;            
+            LogicalResourceId: LogicalResourceId;            
+            UniqueId: ResourceSignalUniqueId;            
+            Status: ResourceSignalStatus;            
+        }
+        export interface Stack {
+            StackId?: StackId;            
+            StackName: StackName;            
+            Description?: Description;            
+            Parameters?: Parameters;            
+            CreationTime: CreationTime;            
+            LastUpdatedTime?: LastUpdatedTime;            
+            StackStatus: StackStatus;            
+            StackStatusReason?: StackStatusReason;            
+            DisableRollback?: DisableRollback;            
+            NotificationARNs?: NotificationARNs;            
+            TimeoutInMinutes?: TimeoutMinutes;            
+            Capabilities?: Capabilities;            
+            Outputs?: Outputs;            
+            Tags?: Tags;            
+        }
+        export interface StackEvent {
+            StackId: StackId;            
+            EventId: EventId;            
+            StackName: StackName;            
+            LogicalResourceId?: LogicalResourceId;            
+            PhysicalResourceId?: PhysicalResourceId;            
+            ResourceType?: ResourceType;            
+            Timestamp: Timestamp;            
+            ResourceStatus?: ResourceStatus;            
+            ResourceStatusReason?: ResourceStatusReason;            
+            ResourceProperties?: ResourceProperties;            
+        }
+        export interface StackResource {
+            StackName?: StackName;            
+            StackId?: StackId;            
+            LogicalResourceId: LogicalResourceId;            
+            PhysicalResourceId?: PhysicalResourceId;            
+            ResourceType: ResourceType;            
+            Timestamp: Timestamp;            
+            ResourceStatus: ResourceStatus;            
+            ResourceStatusReason?: ResourceStatusReason;            
+            Description?: Description;            
+        }
+        export interface StackResourceDetail {
+            StackName?: StackName;            
+            StackId?: StackId;            
+            LogicalResourceId: LogicalResourceId;            
+            PhysicalResourceId?: PhysicalResourceId;            
+            ResourceType: ResourceType;            
+            LastUpdatedTimestamp: Timestamp;            
+            ResourceStatus: ResourceStatus;            
+            ResourceStatusReason?: ResourceStatusReason;            
+            Description?: Description;            
+            Metadata?: Metadata;            
+        }
+        export interface StackResourceSummary {
+            LogicalResourceId: LogicalResourceId;            
+            PhysicalResourceId?: PhysicalResourceId;            
+            ResourceType: ResourceType;            
+            LastUpdatedTimestamp: Timestamp;            
+            ResourceStatus: ResourceStatus;            
+            ResourceStatusReason?: ResourceStatusReason;            
+        }
+        export interface StackSummary {
+            StackId?: StackId;            
+            StackName: StackName;            
+            TemplateDescription?: TemplateDescription;            
+            CreationTime: CreationTime;            
+            LastUpdatedTime?: LastUpdatedTime;            
+            DeletionTime?: DeletionTime;            
+            StackStatus: StackStatus;            
+            StackStatusReason?: StackStatusReason;            
+        }
+        export interface Tag {
+            Key?: TagKey;            
+            Value?: TagValue;            
+        }
+        export interface TemplateParameter {
+            ParameterKey?: ParameterKey;            
+            DefaultValue?: ParameterValue;            
+            NoEcho?: NoEcho;            
+            Description?: Description;            
+        }
+        export interface UpdateStackInput {
+            StackName: StackName;            
+            TemplateBody?: TemplateBody;            
+            TemplateURL?: TemplateURL;            
+            UsePreviousTemplate?: UsePreviousTemplate;            
+            StackPolicyDuringUpdateBody?: StackPolicyDuringUpdateBody;            
+            StackPolicyDuringUpdateURL?: StackPolicyDuringUpdateURL;            
+            Parameters?: Parameters;            
+            Capabilities?: Capabilities;            
+            ResourceTypes?: ResourceTypes;            
+            StackPolicyBody?: StackPolicyBody;            
+            StackPolicyURL?: StackPolicyURL;            
+            NotificationARNs?: NotificationARNs;            
+        }
+        export interface UpdateStackOutput {
+            StackId?: StackId;            
+        }
+        export interface ValidateTemplateInput {
+            TemplateBody?: TemplateBody;            
+            TemplateURL?: TemplateURL;            
+        }
+        export interface ValidateTemplateOutput {
+            Parameters?: TemplateParameters;            
+            Description?: Description;            
+            Capabilities?: Capabilities;            
+            CapabilitiesReason?: CapabilitiesReason;            
+        }
+
     }
-
-    export type CloudFormationAccountLimitList = Array<CloudFormationAccountLimit>;
-    export type CloudFormationAllowedValue = string;
-    export type CloudFormationAllowedValues = Array<CloudFormationAllowedValue>;
-    export interface CloudFormationAlreadyExistsException {
-    }
-
-    export interface CloudFormationCancelUpdateStackInput {
-        StackName: CloudFormationStackName;
-    }
-
-    export type CloudFormationCapabilities = Array<CloudFormationCapability>;
-    export type CloudFormationCapabilitiesReason = string;
-    export type CloudFormationCapability = string;
-    export interface CloudFormationCreateStackInput {
-        StackName: CloudFormationStackName;
-        TemplateBody?: CloudFormationTemplateBody;
-        TemplateURL?: CloudFormationTemplateURL;
-        Parameters?: CloudFormationParameters;
-        DisableRollback?: CloudFormationDisableRollback;
-        TimeoutInMinutes?: CloudFormationTimeoutMinutes;
-        NotificationARNs?: CloudFormationNotificationARNs;
-        Capabilities?: CloudFormationCapabilities;
-        ResourceTypes?: CloudFormationResourceTypes;
-        OnFailure?: CloudFormationOnFailure;
-        StackPolicyBody?: CloudFormationStackPolicyBody;
-        StackPolicyURL?: CloudFormationStackPolicyURL;
-        Tags?: CloudFormationTags;
-    }
-
-    export interface CloudFormationCreateStackOutput {
-        StackId?: CloudFormationStackId;
-    }
-
-    export type CloudFormationCreationTime = number;
-    export interface CloudFormationDeleteStackInput {
-        StackName: CloudFormationStackName;
-    }
-
-    export type CloudFormationDeletionTime = number;
-    export interface CloudFormationDescribeAccountLimitsInput {
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationDescribeAccountLimitsOutput {
-        AccountLimits?: CloudFormationAccountLimitList;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationDescribeStackEventsInput {
-        StackName?: CloudFormationStackName;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationDescribeStackEventsOutput {
-        StackEvents?: CloudFormationStackEvents;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationDescribeStackResourceInput {
-        StackName: CloudFormationStackName;
-        LogicalResourceId: CloudFormationLogicalResourceId;
-    }
-
-    export interface CloudFormationDescribeStackResourceOutput {
-        StackResourceDetail?: CloudFormationStackResourceDetail;
-    }
-
-    export interface CloudFormationDescribeStackResourcesInput {
-        StackName?: CloudFormationStackName;
-        LogicalResourceId?: CloudFormationLogicalResourceId;
-        PhysicalResourceId?: CloudFormationPhysicalResourceId;
-    }
-
-    export interface CloudFormationDescribeStackResourcesOutput {
-        StackResources?: CloudFormationStackResources;
-    }
-
-    export interface CloudFormationDescribeStacksInput {
-        StackName?: CloudFormationStackName;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationDescribeStacksOutput {
-        Stacks?: CloudFormationStacks;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export type CloudFormationDescription = string;
-    export type CloudFormationDisableRollback = boolean;
-    export interface CloudFormationEstimateTemplateCostInput {
-        TemplateBody?: CloudFormationTemplateBody;
-        TemplateURL?: CloudFormationTemplateURL;
-        Parameters?: CloudFormationParameters;
-    }
-
-    export interface CloudFormationEstimateTemplateCostOutput {
-        Url?: CloudFormationUrl;
-    }
-
-    export type CloudFormationEventId = string;
-    export interface CloudFormationGetStackPolicyInput {
-        StackName: CloudFormationStackName;
-    }
-
-    export interface CloudFormationGetStackPolicyOutput {
-        StackPolicyBody?: CloudFormationStackPolicyBody;
-    }
-
-    export interface CloudFormationGetTemplateInput {
-        StackName: CloudFormationStackName;
-    }
-
-    export interface CloudFormationGetTemplateOutput {
-        TemplateBody?: CloudFormationTemplateBody;
-    }
-
-    export interface CloudFormationGetTemplateSummaryInput {
-        TemplateBody?: CloudFormationTemplateBody;
-        TemplateURL?: CloudFormationTemplateURL;
-        StackName?: CloudFormationStackNameOrId;
-    }
-
-    export interface CloudFormationGetTemplateSummaryOutput {
-        Parameters?: CloudFormationParameterDeclarations;
-        Description?: CloudFormationDescription;
-        Capabilities?: CloudFormationCapabilities;
-        CapabilitiesReason?: CloudFormationCapabilitiesReason;
-        ResourceTypes?: CloudFormationResourceTypes;
-        Version?: CloudFormationVersion;
-        Metadata?: CloudFormationMetadata;
-    }
-
-    export interface CloudFormationInsufficientCapabilitiesException {
-    }
-
-    export type CloudFormationLastUpdatedTime = number;
-    export interface CloudFormationLimitExceededException {
-    }
-
-    export type CloudFormationLimitName = string;
-    export type CloudFormationLimitValue = number;
-    export interface CloudFormationListStackResourcesInput {
-        StackName: CloudFormationStackName;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationListStackResourcesOutput {
-        StackResourceSummaries?: CloudFormationStackResourceSummaries;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export interface CloudFormationListStacksInput {
-        NextToken?: CloudFormationNextToken;
-        StackStatusFilter?: CloudFormationStackStatusFilter;
-    }
-
-    export interface CloudFormationListStacksOutput {
-        StackSummaries?: CloudFormationStackSummaries;
-        NextToken?: CloudFormationNextToken;
-    }
-
-    export type CloudFormationLogicalResourceId = string;
-    export type CloudFormationMetadata = string;
-    export type CloudFormationNextToken = string;
-    export type CloudFormationNoEcho = boolean;
-    export type CloudFormationNotificationARN = string;
-    export type CloudFormationNotificationARNs = Array<CloudFormationNotificationARN>; // max: 5
-    export type CloudFormationOnFailure = string;
-    export interface CloudFormationOutput {
-        OutputKey?: CloudFormationOutputKey;
-        OutputValue?: CloudFormationOutputValue;
-        Description?: CloudFormationDescription;
-    }
-
-    export type CloudFormationOutputKey = string;
-    export type CloudFormationOutputValue = string;
-    export type CloudFormationOutputs = Array<CloudFormationOutput>;
-    export interface CloudFormationParameter {
-        ParameterKey?: CloudFormationParameterKey;
-        ParameterValue?: CloudFormationParameterValue;
-        UsePreviousValue?: CloudFormationUsePreviousValue;
-    }
-
-    export interface CloudFormationParameterConstraints {
-        AllowedValues?: CloudFormationAllowedValues;
-    }
-
-    export interface CloudFormationParameterDeclaration {
-        ParameterKey?: CloudFormationParameterKey;
-        DefaultValue?: CloudFormationParameterValue;
-        ParameterType?: CloudFormationParameterType;
-        NoEcho?: CloudFormationNoEcho;
-        Description?: CloudFormationDescription;
-        ParameterConstraints?: CloudFormationParameterConstraints;
-    }
-
-    export type CloudFormationParameterDeclarations = Array<CloudFormationParameterDeclaration>;
-    export type CloudFormationParameterKey = string;
-    export type CloudFormationParameterType = string;
-    export type CloudFormationParameterValue = string;
-    export type CloudFormationParameters = Array<CloudFormationParameter>;
-    export type CloudFormationPhysicalResourceId = string;
-    export type CloudFormationResourceProperties = string;
-    export type CloudFormationResourceSignalStatus = string;
-    export type CloudFormationResourceSignalUniqueId = string;
-    export type CloudFormationResourceStatus = string;
-    export type CloudFormationResourceStatusReason = string;
-    export type CloudFormationResourceType = string;
-    export type CloudFormationResourceTypes = Array<CloudFormationResourceType>;
-    export interface CloudFormationSetStackPolicyInput {
-        StackName: CloudFormationStackName;
-        StackPolicyBody?: CloudFormationStackPolicyBody;
-        StackPolicyURL?: CloudFormationStackPolicyURL;
-    }
-
-    export interface CloudFormationSignalResourceInput {
-        StackName: CloudFormationStackNameOrId;
-        LogicalResourceId: CloudFormationLogicalResourceId;
-        UniqueId: CloudFormationResourceSignalUniqueId;
-        Status: CloudFormationResourceSignalStatus;
-    }
-
-    export interface CloudFormationStack {
-        StackId?: CloudFormationStackId;
-        StackName: CloudFormationStackName;
-        Description?: CloudFormationDescription;
-        Parameters?: CloudFormationParameters;
-        CreationTime: CloudFormationCreationTime;
-        LastUpdatedTime?: CloudFormationLastUpdatedTime;
-        StackStatus: CloudFormationStackStatus;
-        StackStatusReason?: CloudFormationStackStatusReason;
-        DisableRollback?: CloudFormationDisableRollback;
-        NotificationARNs?: CloudFormationNotificationARNs;
-        TimeoutInMinutes?: CloudFormationTimeoutMinutes;
-        Capabilities?: CloudFormationCapabilities;
-        Outputs?: CloudFormationOutputs;
-        Tags?: CloudFormationTags;
-    }
-
-    export interface CloudFormationStackEvent {
-        StackId: CloudFormationStackId;
-        EventId: CloudFormationEventId;
-        StackName: CloudFormationStackName;
-        LogicalResourceId?: CloudFormationLogicalResourceId;
-        PhysicalResourceId?: CloudFormationPhysicalResourceId;
-        ResourceType?: CloudFormationResourceType;
-        Timestamp: CloudFormationTimestamp;
-        ResourceStatus?: CloudFormationResourceStatus;
-        ResourceStatusReason?: CloudFormationResourceStatusReason;
-        ResourceProperties?: CloudFormationResourceProperties;
-    }
-
-    export type CloudFormationStackEvents = Array<CloudFormationStackEvent>;
-    export type CloudFormationStackId = string;
-    export type CloudFormationStackName = string;
-    export type CloudFormationStackNameOrId = string; // pattern: "([a-zA-Z][-a-zA-Z0-9]*)|(arn:\b(aws|aws-us-gov|aws-cn)\b:[-a-zA-Z0-9:/._+]*)"
-    export type CloudFormationStackPolicyBody = string;
-    export type CloudFormationStackPolicyDuringUpdateBody = string;
-    export type CloudFormationStackPolicyDuringUpdateURL = string;
-    export type CloudFormationStackPolicyURL = string;
-    export interface CloudFormationStackResource {
-        StackName?: CloudFormationStackName;
-        StackId?: CloudFormationStackId;
-        LogicalResourceId: CloudFormationLogicalResourceId;
-        PhysicalResourceId?: CloudFormationPhysicalResourceId;
-        ResourceType: CloudFormationResourceType;
-        Timestamp: CloudFormationTimestamp;
-        ResourceStatus: CloudFormationResourceStatus;
-        ResourceStatusReason?: CloudFormationResourceStatusReason;
-        Description?: CloudFormationDescription;
-    }
-
-    export interface CloudFormationStackResourceDetail {
-        StackName?: CloudFormationStackName;
-        StackId?: CloudFormationStackId;
-        LogicalResourceId: CloudFormationLogicalResourceId;
-        PhysicalResourceId?: CloudFormationPhysicalResourceId;
-        ResourceType: CloudFormationResourceType;
-        LastUpdatedTimestamp: CloudFormationTimestamp;
-        ResourceStatus: CloudFormationResourceStatus;
-        ResourceStatusReason?: CloudFormationResourceStatusReason;
-        Description?: CloudFormationDescription;
-        Metadata?: CloudFormationMetadata;
-    }
-
-    export type CloudFormationStackResourceSummaries = Array<CloudFormationStackResourceSummary>;
-    export interface CloudFormationStackResourceSummary {
-        LogicalResourceId: CloudFormationLogicalResourceId;
-        PhysicalResourceId?: CloudFormationPhysicalResourceId;
-        ResourceType: CloudFormationResourceType;
-        LastUpdatedTimestamp: CloudFormationTimestamp;
-        ResourceStatus: CloudFormationResourceStatus;
-        ResourceStatusReason?: CloudFormationResourceStatusReason;
-    }
-
-    export type CloudFormationStackResources = Array<CloudFormationStackResource>;
-    export type CloudFormationStackStatus = string;
-    export type CloudFormationStackStatusFilter = Array<CloudFormationStackStatus>;
-    export type CloudFormationStackStatusReason = string;
-    export type CloudFormationStackSummaries = Array<CloudFormationStackSummary>;
-    export interface CloudFormationStackSummary {
-        StackId?: CloudFormationStackId;
-        StackName: CloudFormationStackName;
-        TemplateDescription?: CloudFormationTemplateDescription;
-        CreationTime: CloudFormationCreationTime;
-        LastUpdatedTime?: CloudFormationLastUpdatedTime;
-        DeletionTime?: CloudFormationDeletionTime;
-        StackStatus: CloudFormationStackStatus;
-        StackStatusReason?: CloudFormationStackStatusReason;
-    }
-
-    export type CloudFormationStacks = Array<CloudFormationStack>;
-    export interface CloudFormationTag {
-        Key?: CloudFormationTagKey;
-        Value?: CloudFormationTagValue;
-    }
-
-    export type CloudFormationTagKey = string;
-    export type CloudFormationTagValue = string;
-    export type CloudFormationTags = Array<CloudFormationTag>;
-    export type CloudFormationTemplateBody = string;
-    export type CloudFormationTemplateDescription = string;
-    export interface CloudFormationTemplateParameter {
-        ParameterKey?: CloudFormationParameterKey;
-        DefaultValue?: CloudFormationParameterValue;
-        NoEcho?: CloudFormationNoEcho;
-        Description?: CloudFormationDescription;
-    }
-
-    export type CloudFormationTemplateParameters = Array<CloudFormationTemplateParameter>;
-    export type CloudFormationTemplateURL = string;
-    export type CloudFormationTimeoutMinutes = number;
-    export type CloudFormationTimestamp = number;
-    export interface CloudFormationUpdateStackInput {
-        StackName: CloudFormationStackName;
-        TemplateBody?: CloudFormationTemplateBody;
-        TemplateURL?: CloudFormationTemplateURL;
-        UsePreviousTemplate?: CloudFormationUsePreviousTemplate;
-        StackPolicyDuringUpdateBody?: CloudFormationStackPolicyDuringUpdateBody;
-        StackPolicyDuringUpdateURL?: CloudFormationStackPolicyDuringUpdateURL;
-        Parameters?: CloudFormationParameters;
-        Capabilities?: CloudFormationCapabilities;
-        ResourceTypes?: CloudFormationResourceTypes;
-        StackPolicyBody?: CloudFormationStackPolicyBody;
-        StackPolicyURL?: CloudFormationStackPolicyURL;
-        NotificationARNs?: CloudFormationNotificationARNs;
-    }
-
-    export interface CloudFormationUpdateStackOutput {
-        StackId?: CloudFormationStackId;
-    }
-
-    export type CloudFormationUrl = string;
-    export type CloudFormationUsePreviousTemplate = boolean;
-    export type CloudFormationUsePreviousValue = boolean;
-    export interface CloudFormationValidateTemplateInput {
-        TemplateBody?: CloudFormationTemplateBody;
-        TemplateURL?: CloudFormationTemplateURL;
-    }
-
-    export interface CloudFormationValidateTemplateOutput {
-        Parameters?: CloudFormationTemplateParameters;
-        Description?: CloudFormationDescription;
-        Capabilities?: CloudFormationCapabilities;
-        CapabilitiesReason?: CloudFormationCapabilitiesReason;
-    }
-
-    export type CloudFormationVersion = string;
 }

--- a/output/aws-cloudfront.d.ts
+++ b/output/aws-cloudfront.d.ts
@@ -6,764 +6,633 @@ declare module "aws-sdk" {
 
     export class CloudFront extends Service {
       constructor(options?: any);
-      createCloudFrontOriginAccessIdentity(params: CloudFrontCreateCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFrontCloudFrontOriginAccessIdentityAlreadyExists|CloudFrontMissingBody|CloudFrontTooManyCloudFrontOriginAccessIdentities|CloudFrontInvalidArgument|CloudFrontInconsistentQuantities|any, data: CloudFrontCreateCloudFrontOriginAccessIdentityResult|any) => void): Request;
-      createDistribution(params: CloudFrontCreateDistributionRequest, callback?: (err: CloudFrontCNAMEAlreadyExists|CloudFrontDistributionAlreadyExists|CloudFrontInvalidOrigin|CloudFrontInvalidOriginAccessIdentity|CloudFrontAccessDenied|CloudFrontTooManyTrustedSigners|CloudFrontTrustedSignerDoesNotExist|CloudFrontInvalidViewerCertificate|CloudFrontInvalidMinimumProtocolVersion|CloudFrontMissingBody|CloudFrontTooManyDistributionCNAMEs|CloudFrontTooManyDistributions|CloudFrontInvalidDefaultRootObject|CloudFrontInvalidRelativePath|CloudFrontInvalidErrorCode|CloudFrontInvalidResponseCode|CloudFrontInvalidArgument|CloudFrontInvalidRequiredProtocol|CloudFrontNoSuchOrigin|CloudFrontTooManyOrigins|CloudFrontTooManyCacheBehaviors|CloudFrontTooManyCookieNamesInWhiteList|CloudFrontInvalidForwardCookies|CloudFrontTooManyHeadersInForwardedValues|CloudFrontInvalidHeadersForS3Origin|CloudFrontInconsistentQuantities|CloudFrontTooManyCertificates|CloudFrontInvalidLocationCode|CloudFrontInvalidGeoRestrictionParameter|CloudFrontInvalidProtocolSettings|CloudFrontInvalidTTLOrder|CloudFrontInvalidWebACLId|any, data: CloudFrontCreateDistributionResult|any) => void): Request;
-      createInvalidation(params: CloudFrontCreateInvalidationRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontMissingBody|CloudFrontInvalidArgument|CloudFrontNoSuchDistribution|CloudFrontBatchTooLarge|CloudFrontTooManyInvalidationsInProgress|CloudFrontInconsistentQuantities|any, data: CloudFrontCreateInvalidationResult|any) => void): Request;
-      createStreamingDistribution(params: CloudFrontCreateStreamingDistributionRequest, callback?: (err: CloudFrontCNAMEAlreadyExists|CloudFrontStreamingDistributionAlreadyExists|CloudFrontInvalidOrigin|CloudFrontInvalidOriginAccessIdentity|CloudFrontAccessDenied|CloudFrontTooManyTrustedSigners|CloudFrontTrustedSignerDoesNotExist|CloudFrontMissingBody|CloudFrontTooManyStreamingDistributionCNAMEs|CloudFrontTooManyStreamingDistributions|CloudFrontInvalidArgument|CloudFrontInconsistentQuantities|any, data: CloudFrontCreateStreamingDistributionResult|any) => void): Request;
-      deleteCloudFrontOriginAccessIdentity(params: CloudFrontDeleteCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontInvalidIfMatchVersion|CloudFrontNoSuchCloudFrontOriginAccessIdentity|CloudFrontPreconditionFailed|CloudFrontCloudFrontOriginAccessIdentityInUse|any, data: any) => void): Request;
-      deleteDistribution(params: CloudFrontDeleteDistributionRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontDistributionNotDisabled|CloudFrontInvalidIfMatchVersion|CloudFrontNoSuchDistribution|CloudFrontPreconditionFailed|any, data: any) => void): Request;
-      deleteStreamingDistribution(params: CloudFrontDeleteStreamingDistributionRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontStreamingDistributionNotDisabled|CloudFrontInvalidIfMatchVersion|CloudFrontNoSuchStreamingDistribution|CloudFrontPreconditionFailed|any, data: any) => void): Request;
-      getCloudFrontOriginAccessIdentity(params: CloudFrontGetCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFrontNoSuchCloudFrontOriginAccessIdentity|CloudFrontAccessDenied|any, data: CloudFrontGetCloudFrontOriginAccessIdentityResult|any) => void): Request;
-      getCloudFrontOriginAccessIdentityConfig(params: CloudFrontGetCloudFrontOriginAccessIdentityConfigRequest, callback?: (err: CloudFrontNoSuchCloudFrontOriginAccessIdentity|CloudFrontAccessDenied|any, data: CloudFrontGetCloudFrontOriginAccessIdentityConfigResult|any) => void): Request;
-      getDistribution(params: CloudFrontGetDistributionRequest, callback?: (err: CloudFrontNoSuchDistribution|CloudFrontAccessDenied|any, data: CloudFrontGetDistributionResult|any) => void): Request;
-      getDistributionConfig(params: CloudFrontGetDistributionConfigRequest, callback?: (err: CloudFrontNoSuchDistribution|CloudFrontAccessDenied|any, data: CloudFrontGetDistributionConfigResult|any) => void): Request;
-      getInvalidation(params: CloudFrontGetInvalidationRequest, callback?: (err: CloudFrontNoSuchInvalidation|CloudFrontNoSuchDistribution|CloudFrontAccessDenied|any, data: CloudFrontGetInvalidationResult|any) => void): Request;
-      getStreamingDistribution(params: CloudFrontGetStreamingDistributionRequest, callback?: (err: CloudFrontNoSuchStreamingDistribution|CloudFrontAccessDenied|any, data: CloudFrontGetStreamingDistributionResult|any) => void): Request;
-      getStreamingDistributionConfig(params: CloudFrontGetStreamingDistributionConfigRequest, callback?: (err: CloudFrontNoSuchStreamingDistribution|CloudFrontAccessDenied|any, data: CloudFrontGetStreamingDistributionConfigResult|any) => void): Request;
-      listCloudFrontOriginAccessIdentities(params: CloudFrontListCloudFrontOriginAccessIdentitiesRequest, callback?: (err: CloudFrontInvalidArgument|any, data: CloudFrontListCloudFrontOriginAccessIdentitiesResult|any) => void): Request;
-      listDistributions(params: CloudFrontListDistributionsRequest, callback?: (err: CloudFrontInvalidArgument|any, data: CloudFrontListDistributionsResult|any) => void): Request;
-      listDistributionsByWebACLId(params: CloudFrontListDistributionsByWebACLIdRequest, callback?: (err: CloudFrontInvalidArgument|CloudFrontInvalidWebACLId|any, data: CloudFrontListDistributionsByWebACLIdResult|any) => void): Request;
-      listInvalidations(params: CloudFrontListInvalidationsRequest, callback?: (err: CloudFrontInvalidArgument|CloudFrontNoSuchDistribution|CloudFrontAccessDenied|any, data: CloudFrontListInvalidationsResult|any) => void): Request;
-      listStreamingDistributions(params: CloudFrontListStreamingDistributionsRequest, callback?: (err: CloudFrontInvalidArgument|any, data: CloudFrontListStreamingDistributionsResult|any) => void): Request;
-      updateCloudFrontOriginAccessIdentity(params: CloudFrontUpdateCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontIllegalUpdate|CloudFrontInvalidIfMatchVersion|CloudFrontMissingBody|CloudFrontNoSuchCloudFrontOriginAccessIdentity|CloudFrontPreconditionFailed|CloudFrontInvalidArgument|CloudFrontInconsistentQuantities|any, data: CloudFrontUpdateCloudFrontOriginAccessIdentityResult|any) => void): Request;
-      updateDistribution(params: CloudFrontUpdateDistributionRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontCNAMEAlreadyExists|CloudFrontIllegalUpdate|CloudFrontInvalidIfMatchVersion|CloudFrontMissingBody|CloudFrontNoSuchDistribution|CloudFrontPreconditionFailed|CloudFrontTooManyDistributionCNAMEs|CloudFrontInvalidDefaultRootObject|CloudFrontInvalidRelativePath|CloudFrontInvalidErrorCode|CloudFrontInvalidResponseCode|CloudFrontInvalidArgument|CloudFrontInvalidOriginAccessIdentity|CloudFrontTooManyTrustedSigners|CloudFrontTrustedSignerDoesNotExist|CloudFrontInvalidViewerCertificate|CloudFrontInvalidMinimumProtocolVersion|CloudFrontInvalidRequiredProtocol|CloudFrontNoSuchOrigin|CloudFrontTooManyOrigins|CloudFrontTooManyCacheBehaviors|CloudFrontTooManyCookieNamesInWhiteList|CloudFrontInvalidForwardCookies|CloudFrontTooManyHeadersInForwardedValues|CloudFrontInvalidHeadersForS3Origin|CloudFrontInconsistentQuantities|CloudFrontTooManyCertificates|CloudFrontInvalidLocationCode|CloudFrontInvalidGeoRestrictionParameter|CloudFrontInvalidTTLOrder|CloudFrontInvalidWebACLId|any, data: CloudFrontUpdateDistributionResult|any) => void): Request;
-      updateStreamingDistribution(params: CloudFrontUpdateStreamingDistributionRequest, callback?: (err: CloudFrontAccessDenied|CloudFrontCNAMEAlreadyExists|CloudFrontIllegalUpdate|CloudFrontInvalidIfMatchVersion|CloudFrontMissingBody|CloudFrontNoSuchStreamingDistribution|CloudFrontPreconditionFailed|CloudFrontTooManyStreamingDistributionCNAMEs|CloudFrontInvalidArgument|CloudFrontInvalidOriginAccessIdentity|CloudFrontTooManyTrustedSigners|CloudFrontTrustedSignerDoesNotExist|CloudFrontInconsistentQuantities|any, data: CloudFrontUpdateStreamingDistributionResult|any) => void): Request;
-    }
-
-    export interface CloudFrontAccessDenied {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontActiveTrustedSigners {
-        Enabled: CloudFrontboolean;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontSignerList;
-    }
-
-    export type CloudFrontAliasList = Array<CloudFrontstring>;
-    export interface CloudFrontAliases {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontAliasList;
-    }
-
-    export interface CloudFrontAllowedMethods {
-        Quantity: CloudFrontinteger;
-        Items: CloudFrontMethodsList;
-        CachedMethods?: CloudFrontCachedMethods;
-    }
-
-    export type CloudFrontAwsAccountNumberList = Array<CloudFrontstring>;
-    export interface CloudFrontBatchTooLarge {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCNAMEAlreadyExists {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCacheBehavior {
-        PathPattern: CloudFrontstring;
-        TargetOriginId: CloudFrontstring;
-        ForwardedValues: CloudFrontForwardedValues;
-        TrustedSigners: CloudFrontTrustedSigners;
-        ViewerProtocolPolicy: CloudFrontViewerProtocolPolicy;
-        MinTTL: CloudFrontlong;
-        AllowedMethods?: CloudFrontAllowedMethods;
-        SmoothStreaming?: CloudFrontboolean;
-        DefaultTTL?: CloudFrontlong;
-        MaxTTL?: CloudFrontlong;
-    }
-
-    export type CloudFrontCacheBehaviorList = Array<CloudFrontCacheBehavior>;
-    export interface CloudFrontCacheBehaviors {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontCacheBehaviorList;
-    }
-
-    export interface CloudFrontCachedMethods {
-        Quantity: CloudFrontinteger;
-        Items: CloudFrontMethodsList;
-    }
-
-    export interface CloudFrontCloudFrontOriginAccessIdentity {
-        Id: CloudFrontstring;
-        S3CanonicalUserId: CloudFrontstring;
-        CloudFrontOriginAccessIdentityConfig?: CloudFrontCloudFrontOriginAccessIdentityConfig;
-    }
-
-    export interface CloudFrontCloudFrontOriginAccessIdentityAlreadyExists {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCloudFrontOriginAccessIdentityConfig {
-        CallerReference: CloudFrontstring;
-        Comment: CloudFrontstring;
-    }
-
-    export interface CloudFrontCloudFrontOriginAccessIdentityInUse {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCloudFrontOriginAccessIdentityList {
-        Marker: CloudFrontstring;
-        NextMarker?: CloudFrontstring;
-        MaxItems: CloudFrontinteger;
-        IsTruncated: CloudFrontboolean;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontCloudFrontOriginAccessIdentitySummaryList;
-    }
-
-    export interface CloudFrontCloudFrontOriginAccessIdentitySummary {
-        Id: CloudFrontstring;
-        S3CanonicalUserId: CloudFrontstring;
-        Comment: CloudFrontstring;
-    }
-
-    export type CloudFrontCloudFrontOriginAccessIdentitySummaryList = Array<CloudFrontCloudFrontOriginAccessIdentitySummary>;
-    export type CloudFrontCookieNameList = Array<CloudFrontstring>;
-    export interface CloudFrontCookieNames {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontCookieNameList;
-    }
-
-    export interface CloudFrontCookiePreference {
-        Forward: CloudFrontItemSelection;
-        WhitelistedNames?: CloudFrontCookieNames;
-    }
-
-    export interface CloudFrontCreateCloudFrontOriginAccessIdentityRequest {
-        CloudFrontOriginAccessIdentityConfig: CloudFrontCloudFrontOriginAccessIdentityConfig;
-    }
-
-    export interface CloudFrontCreateCloudFrontOriginAccessIdentityResult {
-        CloudFrontOriginAccessIdentity?: CloudFrontCloudFrontOriginAccessIdentity;
-        Location?: CloudFrontstring;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCreateDistributionRequest {
-        DistributionConfig: CloudFrontDistributionConfig;
-    }
-
-    export interface CloudFrontCreateDistributionResult {
-        Distribution?: CloudFrontDistribution;
-        Location?: CloudFrontstring;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCreateInvalidationRequest {
-        DistributionId: CloudFrontstring;
-        InvalidationBatch: CloudFrontInvalidationBatch;
-    }
-
-    export interface CloudFrontCreateInvalidationResult {
-        Location?: CloudFrontstring;
-        Invalidation?: CloudFrontInvalidation;
-    }
-
-    export interface CloudFrontCreateStreamingDistributionRequest {
-        StreamingDistributionConfig: CloudFrontStreamingDistributionConfig;
-    }
-
-    export interface CloudFrontCreateStreamingDistributionResult {
-        StreamingDistribution?: CloudFrontStreamingDistribution;
-        Location?: CloudFrontstring;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontCustomErrorResponse {
-        ErrorCode: CloudFrontinteger;
-        ResponsePagePath?: CloudFrontstring;
-        ResponseCode?: CloudFrontstring;
-        ErrorCachingMinTTL?: CloudFrontlong;
-    }
-
-    export type CloudFrontCustomErrorResponseList = Array<CloudFrontCustomErrorResponse>;
-    export interface CloudFrontCustomErrorResponses {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontCustomErrorResponseList;
-    }
-
-    export interface CloudFrontCustomOriginConfig {
-        HTTPPort: CloudFrontinteger;
-        HTTPSPort: CloudFrontinteger;
-        OriginProtocolPolicy: CloudFrontOriginProtocolPolicy;
-    }
-
-    export interface CloudFrontDefaultCacheBehavior {
-        TargetOriginId: CloudFrontstring;
-        ForwardedValues: CloudFrontForwardedValues;
-        TrustedSigners: CloudFrontTrustedSigners;
-        ViewerProtocolPolicy: CloudFrontViewerProtocolPolicy;
-        MinTTL: CloudFrontlong;
-        AllowedMethods?: CloudFrontAllowedMethods;
-        SmoothStreaming?: CloudFrontboolean;
-        DefaultTTL?: CloudFrontlong;
-        MaxTTL?: CloudFrontlong;
-    }
-
-    export interface CloudFrontDeleteCloudFrontOriginAccessIdentityRequest {
-        Id: CloudFrontstring;
-        IfMatch?: CloudFrontstring;
-    }
-
-    export interface CloudFrontDeleteDistributionRequest {
-        Id: CloudFrontstring;
-        IfMatch?: CloudFrontstring;
-    }
-
-    export interface CloudFrontDeleteStreamingDistributionRequest {
-        Id: CloudFrontstring;
-        IfMatch?: CloudFrontstring;
-    }
-
-    export interface CloudFrontDistribution {
-        Id: CloudFrontstring;
-        Status: CloudFrontstring;
-        LastModifiedTime: CloudFronttimestamp;
-        InProgressInvalidationBatches: CloudFrontinteger;
-        DomainName: CloudFrontstring;
-        ActiveTrustedSigners: CloudFrontActiveTrustedSigners;
-        DistributionConfig: CloudFrontDistributionConfig;
-    }
-
-    export interface CloudFrontDistributionAlreadyExists {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontDistributionConfig {
-        CallerReference: CloudFrontstring;
-        Aliases?: CloudFrontAliases;
-        DefaultRootObject?: CloudFrontstring;
-        Origins: CloudFrontOrigins;
-        DefaultCacheBehavior: CloudFrontDefaultCacheBehavior;
-        CacheBehaviors?: CloudFrontCacheBehaviors;
-        CustomErrorResponses?: CloudFrontCustomErrorResponses;
-        Comment: CloudFrontstring;
-        Logging?: CloudFrontLoggingConfig;
-        PriceClass?: CloudFrontPriceClass;
-        Enabled: CloudFrontboolean;
-        ViewerCertificate?: CloudFrontViewerCertificate;
-        Restrictions?: CloudFrontRestrictions;
-        WebACLId?: CloudFrontstring;
-    }
-
-    export interface CloudFrontDistributionList {
-        Marker: CloudFrontstring;
-        NextMarker?: CloudFrontstring;
-        MaxItems: CloudFrontinteger;
-        IsTruncated: CloudFrontboolean;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontDistributionSummaryList;
-    }
-
-    export interface CloudFrontDistributionNotDisabled {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontDistributionSummary {
-        Id: CloudFrontstring;
-        Status: CloudFrontstring;
-        LastModifiedTime: CloudFronttimestamp;
-        DomainName: CloudFrontstring;
-        Aliases: CloudFrontAliases;
-        Origins: CloudFrontOrigins;
-        DefaultCacheBehavior: CloudFrontDefaultCacheBehavior;
-        CacheBehaviors: CloudFrontCacheBehaviors;
-        CustomErrorResponses: CloudFrontCustomErrorResponses;
-        Comment: CloudFrontstring;
-        PriceClass: CloudFrontPriceClass;
-        Enabled: CloudFrontboolean;
-        ViewerCertificate: CloudFrontViewerCertificate;
-        Restrictions: CloudFrontRestrictions;
-        WebACLId: CloudFrontstring;
-    }
-
-    export type CloudFrontDistributionSummaryList = Array<CloudFrontDistributionSummary>;
-    export interface CloudFrontForwardedValues {
-        QueryString: CloudFrontboolean;
-        Cookies: CloudFrontCookiePreference;
-        Headers?: CloudFrontHeaders;
-    }
-
-    export interface CloudFrontGeoRestriction {
-        RestrictionType: CloudFrontGeoRestrictionType;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontLocationList;
-    }
-
-    export type CloudFrontGeoRestrictionType = string;
-    export interface CloudFrontGetCloudFrontOriginAccessIdentityConfigRequest {
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetCloudFrontOriginAccessIdentityConfigResult {
-        CloudFrontOriginAccessIdentityConfig?: CloudFrontCloudFrontOriginAccessIdentityConfig;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetCloudFrontOriginAccessIdentityRequest {
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetCloudFrontOriginAccessIdentityResult {
-        CloudFrontOriginAccessIdentity?: CloudFrontCloudFrontOriginAccessIdentity;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetDistributionConfigRequest {
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetDistributionConfigResult {
-        DistributionConfig?: CloudFrontDistributionConfig;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetDistributionRequest {
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetDistributionResult {
-        Distribution?: CloudFrontDistribution;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetInvalidationRequest {
-        DistributionId: CloudFrontstring;
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetInvalidationResult {
-        Invalidation?: CloudFrontInvalidation;
-    }
-
-    export interface CloudFrontGetStreamingDistributionConfigRequest {
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetStreamingDistributionConfigResult {
-        StreamingDistributionConfig?: CloudFrontStreamingDistributionConfig;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetStreamingDistributionRequest {
-        Id: CloudFrontstring;
-    }
-
-    export interface CloudFrontGetStreamingDistributionResult {
-        StreamingDistribution?: CloudFrontStreamingDistribution;
-        ETag?: CloudFrontstring;
-    }
-
-    export type CloudFrontHeaderList = Array<CloudFrontstring>;
-    export interface CloudFrontHeaders {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontHeaderList;
-    }
-
-    export interface CloudFrontIllegalUpdate {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInconsistentQuantities {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidArgument {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidDefaultRootObject {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidErrorCode {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidForwardCookies {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidGeoRestrictionParameter {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidHeadersForS3Origin {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidIfMatchVersion {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidLocationCode {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidMinimumProtocolVersion {
-        Message?: CloudFrontstring;
-    }
+      createCloudFrontOriginAccessIdentity(params: CloudFront.CreateCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFront.CloudFrontOriginAccessIdentityAlreadyExists|CloudFront.MissingBody|CloudFront.TooManyCloudFrontOriginAccessIdentities|CloudFront.InvalidArgument|CloudFront.InconsistentQuantities|any, data: CloudFront.CreateCloudFrontOriginAccessIdentityResult|any) => void): Request;
+      createDistribution(params: CloudFront.CreateDistributionRequest, callback?: (err: CloudFront.CNAMEAlreadyExists|CloudFront.DistributionAlreadyExists|CloudFront.InvalidOrigin|CloudFront.InvalidOriginAccessIdentity|CloudFront.AccessDenied|CloudFront.TooManyTrustedSigners|CloudFront.TrustedSignerDoesNotExist|CloudFront.InvalidViewerCertificate|CloudFront.InvalidMinimumProtocolVersion|CloudFront.MissingBody|CloudFront.TooManyDistributionCNAMEs|CloudFront.TooManyDistributions|CloudFront.InvalidDefaultRootObject|CloudFront.InvalidRelativePath|CloudFront.InvalidErrorCode|CloudFront.InvalidResponseCode|CloudFront.InvalidArgument|CloudFront.InvalidRequiredProtocol|CloudFront.NoSuchOrigin|CloudFront.TooManyOrigins|CloudFront.TooManyCacheBehaviors|CloudFront.TooManyCookieNamesInWhiteList|CloudFront.InvalidForwardCookies|CloudFront.TooManyHeadersInForwardedValues|CloudFront.InvalidHeadersForS3Origin|CloudFront.InconsistentQuantities|CloudFront.TooManyCertificates|CloudFront.InvalidLocationCode|CloudFront.InvalidGeoRestrictionParameter|CloudFront.InvalidProtocolSettings|CloudFront.InvalidTTLOrder|CloudFront.InvalidWebACLId|any, data: CloudFront.CreateDistributionResult|any) => void): Request;
+      createInvalidation(params: CloudFront.CreateInvalidationRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.MissingBody|CloudFront.InvalidArgument|CloudFront.NoSuchDistribution|CloudFront.BatchTooLarge|CloudFront.TooManyInvalidationsInProgress|CloudFront.InconsistentQuantities|any, data: CloudFront.CreateInvalidationResult|any) => void): Request;
+      createStreamingDistribution(params: CloudFront.CreateStreamingDistributionRequest, callback?: (err: CloudFront.CNAMEAlreadyExists|CloudFront.StreamingDistributionAlreadyExists|CloudFront.InvalidOrigin|CloudFront.InvalidOriginAccessIdentity|CloudFront.AccessDenied|CloudFront.TooManyTrustedSigners|CloudFront.TrustedSignerDoesNotExist|CloudFront.MissingBody|CloudFront.TooManyStreamingDistributionCNAMEs|CloudFront.TooManyStreamingDistributions|CloudFront.InvalidArgument|CloudFront.InconsistentQuantities|any, data: CloudFront.CreateStreamingDistributionResult|any) => void): Request;
+      deleteCloudFrontOriginAccessIdentity(params: CloudFront.DeleteCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.InvalidIfMatchVersion|CloudFront.NoSuchCloudFrontOriginAccessIdentity|CloudFront.PreconditionFailed|CloudFront.CloudFrontOriginAccessIdentityInUse|any, data: any) => void): Request;
+      deleteDistribution(params: CloudFront.DeleteDistributionRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.DistributionNotDisabled|CloudFront.InvalidIfMatchVersion|CloudFront.NoSuchDistribution|CloudFront.PreconditionFailed|any, data: any) => void): Request;
+      deleteStreamingDistribution(params: CloudFront.DeleteStreamingDistributionRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.StreamingDistributionNotDisabled|CloudFront.InvalidIfMatchVersion|CloudFront.NoSuchStreamingDistribution|CloudFront.PreconditionFailed|any, data: any) => void): Request;
+      getCloudFrontOriginAccessIdentity(params: CloudFront.GetCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFront.NoSuchCloudFrontOriginAccessIdentity|CloudFront.AccessDenied|any, data: CloudFront.GetCloudFrontOriginAccessIdentityResult|any) => void): Request;
+      getCloudFrontOriginAccessIdentityConfig(params: CloudFront.GetCloudFrontOriginAccessIdentityConfigRequest, callback?: (err: CloudFront.NoSuchCloudFrontOriginAccessIdentity|CloudFront.AccessDenied|any, data: CloudFront.GetCloudFrontOriginAccessIdentityConfigResult|any) => void): Request;
+      getDistribution(params: CloudFront.GetDistributionRequest, callback?: (err: CloudFront.NoSuchDistribution|CloudFront.AccessDenied|any, data: CloudFront.GetDistributionResult|any) => void): Request;
+      getDistributionConfig(params: CloudFront.GetDistributionConfigRequest, callback?: (err: CloudFront.NoSuchDistribution|CloudFront.AccessDenied|any, data: CloudFront.GetDistributionConfigResult|any) => void): Request;
+      getInvalidation(params: CloudFront.GetInvalidationRequest, callback?: (err: CloudFront.NoSuchInvalidation|CloudFront.NoSuchDistribution|CloudFront.AccessDenied|any, data: CloudFront.GetInvalidationResult|any) => void): Request;
+      getStreamingDistribution(params: CloudFront.GetStreamingDistributionRequest, callback?: (err: CloudFront.NoSuchStreamingDistribution|CloudFront.AccessDenied|any, data: CloudFront.GetStreamingDistributionResult|any) => void): Request;
+      getStreamingDistributionConfig(params: CloudFront.GetStreamingDistributionConfigRequest, callback?: (err: CloudFront.NoSuchStreamingDistribution|CloudFront.AccessDenied|any, data: CloudFront.GetStreamingDistributionConfigResult|any) => void): Request;
+      listCloudFrontOriginAccessIdentities(params: CloudFront.ListCloudFrontOriginAccessIdentitiesRequest, callback?: (err: CloudFront.InvalidArgument|any, data: CloudFront.ListCloudFrontOriginAccessIdentitiesResult|any) => void): Request;
+      listDistributions(params: CloudFront.ListDistributionsRequest, callback?: (err: CloudFront.InvalidArgument|any, data: CloudFront.ListDistributionsResult|any) => void): Request;
+      listDistributionsByWebACLId(params: CloudFront.ListDistributionsByWebACLIdRequest, callback?: (err: CloudFront.InvalidArgument|CloudFront.InvalidWebACLId|any, data: CloudFront.ListDistributionsByWebACLIdResult|any) => void): Request;
+      listInvalidations(params: CloudFront.ListInvalidationsRequest, callback?: (err: CloudFront.InvalidArgument|CloudFront.NoSuchDistribution|CloudFront.AccessDenied|any, data: CloudFront.ListInvalidationsResult|any) => void): Request;
+      listStreamingDistributions(params: CloudFront.ListStreamingDistributionsRequest, callback?: (err: CloudFront.InvalidArgument|any, data: CloudFront.ListStreamingDistributionsResult|any) => void): Request;
+      updateCloudFrontOriginAccessIdentity(params: CloudFront.UpdateCloudFrontOriginAccessIdentityRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.IllegalUpdate|CloudFront.InvalidIfMatchVersion|CloudFront.MissingBody|CloudFront.NoSuchCloudFrontOriginAccessIdentity|CloudFront.PreconditionFailed|CloudFront.InvalidArgument|CloudFront.InconsistentQuantities|any, data: CloudFront.UpdateCloudFrontOriginAccessIdentityResult|any) => void): Request;
+      updateDistribution(params: CloudFront.UpdateDistributionRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.CNAMEAlreadyExists|CloudFront.IllegalUpdate|CloudFront.InvalidIfMatchVersion|CloudFront.MissingBody|CloudFront.NoSuchDistribution|CloudFront.PreconditionFailed|CloudFront.TooManyDistributionCNAMEs|CloudFront.InvalidDefaultRootObject|CloudFront.InvalidRelativePath|CloudFront.InvalidErrorCode|CloudFront.InvalidResponseCode|CloudFront.InvalidArgument|CloudFront.InvalidOriginAccessIdentity|CloudFront.TooManyTrustedSigners|CloudFront.TrustedSignerDoesNotExist|CloudFront.InvalidViewerCertificate|CloudFront.InvalidMinimumProtocolVersion|CloudFront.InvalidRequiredProtocol|CloudFront.NoSuchOrigin|CloudFront.TooManyOrigins|CloudFront.TooManyCacheBehaviors|CloudFront.TooManyCookieNamesInWhiteList|CloudFront.InvalidForwardCookies|CloudFront.TooManyHeadersInForwardedValues|CloudFront.InvalidHeadersForS3Origin|CloudFront.InconsistentQuantities|CloudFront.TooManyCertificates|CloudFront.InvalidLocationCode|CloudFront.InvalidGeoRestrictionParameter|CloudFront.InvalidTTLOrder|CloudFront.InvalidWebACLId|any, data: CloudFront.UpdateDistributionResult|any) => void): Request;
+      updateStreamingDistribution(params: CloudFront.UpdateStreamingDistributionRequest, callback?: (err: CloudFront.AccessDenied|CloudFront.CNAMEAlreadyExists|CloudFront.IllegalUpdate|CloudFront.InvalidIfMatchVersion|CloudFront.MissingBody|CloudFront.NoSuchStreamingDistribution|CloudFront.PreconditionFailed|CloudFront.TooManyStreamingDistributionCNAMEs|CloudFront.InvalidArgument|CloudFront.InvalidOriginAccessIdentity|CloudFront.TooManyTrustedSigners|CloudFront.TrustedSignerDoesNotExist|CloudFront.InconsistentQuantities|any, data: CloudFront.UpdateStreamingDistributionResult|any) => void): Request;
+    }
+    
+    export module CloudFront {
+        export type AliasList = string[];
+        export type AwsAccountNumberList = string[];
+        export type CacheBehaviorList = CacheBehavior[];
+        export type CloudFrontOriginAccessIdentitySummaryList = CloudFrontOriginAccessIdentitySummary[];
+        export type CookieNameList = string[];
+        export type CustomErrorResponseList = CustomErrorResponse[];
+        export type DistributionSummaryList = DistributionSummary[];
+        export type GeoRestrictionType = string;
+        export type HeaderList = string[];
+        export type InvalidationSummaryList = InvalidationSummary[];
+        export type ItemSelection = string;
+        export type KeyPairIdList = string[];
+        export type LocationList = string[];
+        export type Method = string;
+        export type MethodsList = Method[];
+        export type MinimumProtocolVersion = string;
+        export type OriginList = Origin[];    // min: 1
+        export type OriginProtocolPolicy = string;
+        export type PathList = string[];
+        export type PriceClass = string;
+        export type SSLSupportMethod = string;
+        export type SignerList = Signer[];
+        export type StreamingDistributionSummaryList = StreamingDistributionSummary[];
+        export type ViewerProtocolPolicy = string;
+        export type integer = number;
+        export type long = number;
+        export type timestamp = number;
+
+        export interface AccessDenied {
+            Message?: string;            
+        }
+        export interface ActiveTrustedSigners {
+            Enabled: boolean;            
+            Quantity: integer;            
+            Items?: SignerList;            
+        }
+        export interface Aliases {
+            Quantity: integer;            
+            Items?: AliasList;            
+        }
+        export interface AllowedMethods {
+            Quantity: integer;            
+            Items: MethodsList;            
+            CachedMethods?: CachedMethods;            
+        }
+        export interface BatchTooLarge {
+            Message?: string;            
+        }
+        export interface CNAMEAlreadyExists {
+            Message?: string;            
+        }
+        export interface CacheBehavior {
+            PathPattern: string;            
+            TargetOriginId: string;            
+            ForwardedValues: ForwardedValues;            
+            TrustedSigners: TrustedSigners;            
+            ViewerProtocolPolicy: ViewerProtocolPolicy;            
+            MinTTL: long;            
+            AllowedMethods?: AllowedMethods;            
+            SmoothStreaming?: boolean;            
+            DefaultTTL?: long;            
+            MaxTTL?: long;            
+        }
+        export interface CacheBehaviors {
+            Quantity: integer;            
+            Items?: CacheBehaviorList;            
+        }
+        export interface CachedMethods {
+            Quantity: integer;            
+            Items: MethodsList;            
+        }
+        export interface CloudFrontOriginAccessIdentity {
+            Id: string;            
+            S3CanonicalUserId: string;            
+            CloudFrontOriginAccessIdentityConfig?: CloudFrontOriginAccessIdentityConfig;            
+        }
+        export interface CloudFrontOriginAccessIdentityAlreadyExists {
+            Message?: string;            
+        }
+        export interface CloudFrontOriginAccessIdentityConfig {
+            CallerReference: string;            
+            Comment: string;            
+        }
+        export interface CloudFrontOriginAccessIdentityInUse {
+            Message?: string;            
+        }
+        export interface CloudFrontOriginAccessIdentityList {
+            Marker: string;            
+            NextMarker?: string;            
+            MaxItems: integer;            
+            IsTruncated: boolean;            
+            Quantity: integer;            
+            Items?: CloudFrontOriginAccessIdentitySummaryList;            
+        }
+        export interface CloudFrontOriginAccessIdentitySummary {
+            Id: string;            
+            S3CanonicalUserId: string;            
+            Comment: string;            
+        }
+        export interface CookieNames {
+            Quantity: integer;            
+            Items?: CookieNameList;            
+        }
+        export interface CookiePreference {
+            Forward: ItemSelection;            
+            WhitelistedNames?: CookieNames;            
+        }
+        export interface CreateCloudFrontOriginAccessIdentityRequest {
+            CloudFrontOriginAccessIdentityConfig: CloudFrontOriginAccessIdentityConfig;            
+        }
+        export interface CreateCloudFrontOriginAccessIdentityResult {
+            CloudFrontOriginAccessIdentity?: CloudFrontOriginAccessIdentity;            
+            Location?: string;            
+            ETag?: string;            
+        }
+        export interface CreateDistributionRequest {
+            DistributionConfig: DistributionConfig;            
+        }
+        export interface CreateDistributionResult {
+            Distribution?: Distribution;            
+            Location?: string;            
+            ETag?: string;            
+        }
+        export interface CreateInvalidationRequest {
+            DistributionId: string;            
+            InvalidationBatch: InvalidationBatch;            
+        }
+        export interface CreateInvalidationResult {
+            Location?: string;            
+            Invalidation?: Invalidation;            
+        }
+        export interface CreateStreamingDistributionRequest {
+            StreamingDistributionConfig: StreamingDistributionConfig;            
+        }
+        export interface CreateStreamingDistributionResult {
+            StreamingDistribution?: StreamingDistribution;            
+            Location?: string;            
+            ETag?: string;            
+        }
+        export interface CustomErrorResponse {
+            ErrorCode: integer;            
+            ResponsePagePath?: string;            
+            ResponseCode?: string;            
+            ErrorCachingMinTTL?: long;            
+        }
+        export interface CustomErrorResponses {
+            Quantity: integer;            
+            Items?: CustomErrorResponseList;            
+        }
+        export interface CustomOriginConfig {
+            HTTPPort: integer;            
+            HTTPSPort: integer;            
+            OriginProtocolPolicy: OriginProtocolPolicy;            
+        }
+        export interface DefaultCacheBehavior {
+            TargetOriginId: string;            
+            ForwardedValues: ForwardedValues;            
+            TrustedSigners: TrustedSigners;            
+            ViewerProtocolPolicy: ViewerProtocolPolicy;            
+            MinTTL: long;            
+            AllowedMethods?: AllowedMethods;            
+            SmoothStreaming?: boolean;            
+            DefaultTTL?: long;            
+            MaxTTL?: long;            
+        }
+        export interface DeleteCloudFrontOriginAccessIdentityRequest {
+            Id: string;            
+            IfMatch?: string;            
+        }
+        export interface DeleteDistributionRequest {
+            Id: string;            
+            IfMatch?: string;            
+        }
+        export interface DeleteStreamingDistributionRequest {
+            Id: string;            
+            IfMatch?: string;            
+        }
+        export interface Distribution {
+            Id: string;            
+            Status: string;            
+            LastModifiedTime: timestamp;            
+            InProgressInvalidationBatches: integer;            
+            DomainName: string;            
+            ActiveTrustedSigners: ActiveTrustedSigners;            
+            DistributionConfig: DistributionConfig;            
+        }
+        export interface DistributionAlreadyExists {
+            Message?: string;            
+        }
+        export interface DistributionConfig {
+            CallerReference: string;            
+            Aliases?: Aliases;            
+            DefaultRootObject?: string;            
+            Origins: Origins;            
+            DefaultCacheBehavior: DefaultCacheBehavior;            
+            CacheBehaviors?: CacheBehaviors;            
+            CustomErrorResponses?: CustomErrorResponses;            
+            Comment: string;            
+            Logging?: LoggingConfig;            
+            PriceClass?: PriceClass;            
+            Enabled: boolean;            
+            ViewerCertificate?: ViewerCertificate;            
+            Restrictions?: Restrictions;            
+            WebACLId?: string;            
+        }
+        export interface DistributionList {
+            Marker: string;            
+            NextMarker?: string;            
+            MaxItems: integer;            
+            IsTruncated: boolean;            
+            Quantity: integer;            
+            Items?: DistributionSummaryList;            
+        }
+        export interface DistributionNotDisabled {
+            Message?: string;            
+        }
+        export interface DistributionSummary {
+            Id: string;            
+            Status: string;            
+            LastModifiedTime: timestamp;            
+            DomainName: string;            
+            Aliases: Aliases;            
+            Origins: Origins;            
+            DefaultCacheBehavior: DefaultCacheBehavior;            
+            CacheBehaviors: CacheBehaviors;            
+            CustomErrorResponses: CustomErrorResponses;            
+            Comment: string;            
+            PriceClass: PriceClass;            
+            Enabled: boolean;            
+            ViewerCertificate: ViewerCertificate;            
+            Restrictions: Restrictions;            
+            WebACLId: string;            
+        }
+        export interface ForwardedValues {
+            QueryString: boolean;            
+            Cookies: CookiePreference;            
+            Headers?: Headers;            
+        }
+        export interface GeoRestriction {
+            RestrictionType: GeoRestrictionType;            
+            Quantity: integer;            
+            Items?: LocationList;            
+        }
+        export interface GetCloudFrontOriginAccessIdentityConfigRequest {
+            Id: string;            
+        }
+        export interface GetCloudFrontOriginAccessIdentityConfigResult {
+            CloudFrontOriginAccessIdentityConfig?: CloudFrontOriginAccessIdentityConfig;            
+            ETag?: string;            
+        }
+        export interface GetCloudFrontOriginAccessIdentityRequest {
+            Id: string;            
+        }
+        export interface GetCloudFrontOriginAccessIdentityResult {
+            CloudFrontOriginAccessIdentity?: CloudFrontOriginAccessIdentity;            
+            ETag?: string;            
+        }
+        export interface GetDistributionConfigRequest {
+            Id: string;            
+        }
+        export interface GetDistributionConfigResult {
+            DistributionConfig?: DistributionConfig;            
+            ETag?: string;            
+        }
+        export interface GetDistributionRequest {
+            Id: string;            
+        }
+        export interface GetDistributionResult {
+            Distribution?: Distribution;            
+            ETag?: string;            
+        }
+        export interface GetInvalidationRequest {
+            DistributionId: string;            
+            Id: string;            
+        }
+        export interface GetInvalidationResult {
+            Invalidation?: Invalidation;            
+        }
+        export interface GetStreamingDistributionConfigRequest {
+            Id: string;            
+        }
+        export interface GetStreamingDistributionConfigResult {
+            StreamingDistributionConfig?: StreamingDistributionConfig;            
+            ETag?: string;            
+        }
+        export interface GetStreamingDistributionRequest {
+            Id: string;            
+        }
+        export interface GetStreamingDistributionResult {
+            StreamingDistribution?: StreamingDistribution;            
+            ETag?: string;            
+        }
+        export interface Headers {
+            Quantity: integer;            
+            Items?: HeaderList;            
+        }
+        export interface IllegalUpdate {
+            Message?: string;            
+        }
+        export interface InconsistentQuantities {
+            Message?: string;            
+        }
+        export interface InvalidArgument {
+            Message?: string;            
+        }
+        export interface InvalidDefaultRootObject {
+            Message?: string;            
+        }
+        export interface InvalidErrorCode {
+            Message?: string;            
+        }
+        export interface InvalidForwardCookies {
+            Message?: string;            
+        }
+        export interface InvalidGeoRestrictionParameter {
+            Message?: string;            
+        }
+        export interface InvalidHeadersForS3Origin {
+            Message?: string;            
+        }
+        export interface InvalidIfMatchVersion {
+            Message?: string;            
+        }
+        export interface InvalidLocationCode {
+            Message?: string;            
+        }
+        export interface InvalidMinimumProtocolVersion {
+            Message?: string;            
+        }
+        export interface InvalidOrigin {
+            Message?: string;            
+        }
+        export interface InvalidOriginAccessIdentity {
+            Message?: string;            
+        }
+        export interface InvalidProtocolSettings {
+            Message?: string;            
+        }
+        export interface InvalidRelativePath {
+            Message?: string;            
+        }
+        export interface InvalidRequiredProtocol {
+            Message?: string;            
+        }
+        export interface InvalidResponseCode {
+            Message?: string;            
+        }
+        export interface InvalidTTLOrder {
+            Message?: string;            
+        }
+        export interface InvalidViewerCertificate {
+            Message?: string;            
+        }
+        export interface InvalidWebACLId {
+            Message?: string;            
+        }
+        export interface Invalidation {
+            Id: string;            
+            Status: string;            
+            CreateTime: timestamp;            
+            InvalidationBatch: InvalidationBatch;            
+        }
+        export interface InvalidationBatch {
+            Paths: Paths;            
+            CallerReference: string;            
+        }
+        export interface InvalidationList {
+            Marker: string;            
+            NextMarker?: string;            
+            MaxItems: integer;            
+            IsTruncated: boolean;            
+            Quantity: integer;            
+            Items?: InvalidationSummaryList;            
+        }
+        export interface InvalidationSummary {
+            Id: string;            
+            CreateTime: timestamp;            
+            Status: string;            
+        }
+        export interface KeyPairIds {
+            Quantity: integer;            
+            Items?: KeyPairIdList;            
+        }
+        export interface ListCloudFrontOriginAccessIdentitiesRequest {
+            Marker?: string;            
+            MaxItems?: string;            
+        }
+        export interface ListCloudFrontOriginAccessIdentitiesResult {
+            CloudFrontOriginAccessIdentityList?: CloudFrontOriginAccessIdentityList;            
+        }
+        export interface ListDistributionsByWebACLIdRequest {
+            Marker?: string;            
+            MaxItems?: string;            
+            WebACLId: string;            
+        }
+        export interface ListDistributionsByWebACLIdResult {
+            DistributionList?: DistributionList;            
+        }
+        export interface ListDistributionsRequest {
+            Marker?: string;            
+            MaxItems?: string;            
+        }
+        export interface ListDistributionsResult {
+            DistributionList?: DistributionList;            
+        }
+        export interface ListInvalidationsRequest {
+            DistributionId: string;            
+            Marker?: string;            
+            MaxItems?: string;            
+        }
+        export interface ListInvalidationsResult {
+            InvalidationList?: InvalidationList;            
+        }
+        export interface ListStreamingDistributionsRequest {
+            Marker?: string;            
+            MaxItems?: string;            
+        }
+        export interface ListStreamingDistributionsResult {
+            StreamingDistributionList?: StreamingDistributionList;            
+        }
+        export interface LoggingConfig {
+            Enabled: boolean;            
+            IncludeCookies: boolean;            
+            Bucket: string;            
+            Prefix: string;            
+        }
+        export interface MissingBody {
+            Message?: string;            
+        }
+        export interface NoSuchCloudFrontOriginAccessIdentity {
+            Message?: string;            
+        }
+        export interface NoSuchDistribution {
+            Message?: string;            
+        }
+        export interface NoSuchInvalidation {
+            Message?: string;            
+        }
+        export interface NoSuchOrigin {
+            Message?: string;            
+        }
+        export interface NoSuchStreamingDistribution {
+            Message?: string;            
+        }
+        export interface Origin {
+            Id: string;            
+            DomainName: string;            
+            OriginPath?: string;            
+            S3OriginConfig?: S3OriginConfig;            
+            CustomOriginConfig?: CustomOriginConfig;            
+        }
+        export interface Origins {
+            Quantity: integer;            
+            Items?: OriginList;            
+        }
+        export interface Paths {
+            Quantity: integer;            
+            Items?: PathList;            
+        }
+        export interface PreconditionFailed {
+            Message?: string;            
+        }
+        export interface Restrictions {
+            GeoRestriction: GeoRestriction;            
+        }
+        export interface S3Origin {
+            DomainName: string;            
+            OriginAccessIdentity: string;            
+        }
+        export interface S3OriginConfig {
+            OriginAccessIdentity: string;            
+        }
+        export interface Signer {
+            AwsAccountNumber?: string;            
+            KeyPairIds?: KeyPairIds;            
+        }
+        export interface StreamingDistribution {
+            Id: string;            
+            Status: string;            
+            LastModifiedTime?: timestamp;            
+            DomainName: string;            
+            ActiveTrustedSigners: ActiveTrustedSigners;            
+            StreamingDistributionConfig: StreamingDistributionConfig;            
+        }
+        export interface StreamingDistributionAlreadyExists {
+            Message?: string;            
+        }
+        export interface StreamingDistributionConfig {
+            CallerReference: string;            
+            S3Origin: S3Origin;            
+            Aliases?: Aliases;            
+            Comment: string;            
+            Logging?: StreamingLoggingConfig;            
+            TrustedSigners: TrustedSigners;            
+            PriceClass?: PriceClass;            
+            Enabled: boolean;            
+        }
+        export interface StreamingDistributionList {
+            Marker: string;            
+            NextMarker?: string;            
+            MaxItems: integer;            
+            IsTruncated: boolean;            
+            Quantity: integer;            
+            Items?: StreamingDistributionSummaryList;            
+        }
+        export interface StreamingDistributionNotDisabled {
+            Message?: string;            
+        }
+        export interface StreamingDistributionSummary {
+            Id: string;            
+            Status: string;            
+            LastModifiedTime: timestamp;            
+            DomainName: string;            
+            S3Origin: S3Origin;            
+            Aliases: Aliases;            
+            TrustedSigners: TrustedSigners;            
+            Comment: string;            
+            PriceClass: PriceClass;            
+            Enabled: boolean;            
+        }
+        export interface StreamingLoggingConfig {
+            Enabled: boolean;            
+            Bucket: string;            
+            Prefix: string;            
+        }
+        export interface TooManyCacheBehaviors {
+            Message?: string;            
+        }
+        export interface TooManyCertificates {
+            Message?: string;            
+        }
+        export interface TooManyCloudFrontOriginAccessIdentities {
+            Message?: string;            
+        }
+        export interface TooManyCookieNamesInWhiteList {
+            Message?: string;            
+        }
+        export interface TooManyDistributionCNAMEs {
+            Message?: string;            
+        }
+        export interface TooManyDistributions {
+            Message?: string;            
+        }
+        export interface TooManyHeadersInForwardedValues {
+            Message?: string;            
+        }
+        export interface TooManyInvalidationsInProgress {
+            Message?: string;            
+        }
+        export interface TooManyOrigins {
+            Message?: string;            
+        }
+        export interface TooManyStreamingDistributionCNAMEs {
+            Message?: string;            
+        }
+        export interface TooManyStreamingDistributions {
+            Message?: string;            
+        }
+        export interface TooManyTrustedSigners {
+            Message?: string;            
+        }
+        export interface TrustedSignerDoesNotExist {
+            Message?: string;            
+        }
+        export interface TrustedSigners {
+            Enabled: boolean;            
+            Quantity: integer;            
+            Items?: AwsAccountNumberList;            
+        }
+        export interface UpdateCloudFrontOriginAccessIdentityRequest {
+            CloudFrontOriginAccessIdentityConfig: CloudFrontOriginAccessIdentityConfig;            
+            Id: string;            
+            IfMatch?: string;            
+        }
+        export interface UpdateCloudFrontOriginAccessIdentityResult {
+            CloudFrontOriginAccessIdentity?: CloudFrontOriginAccessIdentity;            
+            ETag?: string;            
+        }
+        export interface UpdateDistributionRequest {
+            DistributionConfig: DistributionConfig;            
+            Id: string;            
+            IfMatch?: string;            
+        }
+        export interface UpdateDistributionResult {
+            Distribution?: Distribution;            
+            ETag?: string;            
+        }
+        export interface UpdateStreamingDistributionRequest {
+            StreamingDistributionConfig: StreamingDistributionConfig;            
+            Id: string;            
+            IfMatch?: string;            
+        }
+        export interface UpdateStreamingDistributionResult {
+            StreamingDistribution?: StreamingDistribution;            
+            ETag?: string;            
+        }
+        export interface ViewerCertificate {
+            IAMCertificateId?: string;            
+            CloudFrontDefaultCertificate?: boolean;            
+            SSLSupportMethod?: SSLSupportMethod;            
+            MinimumProtocolVersion?: MinimumProtocolVersion;            
+        }
 
-    export interface CloudFrontInvalidOrigin {
-        Message?: CloudFrontstring;
     }
-
-    export interface CloudFrontInvalidOriginAccessIdentity {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidProtocolSettings {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidRelativePath {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidRequiredProtocol {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidResponseCode {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidTTLOrder {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidViewerCertificate {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidWebACLId {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidation {
-        Id: CloudFrontstring;
-        Status: CloudFrontstring;
-        CreateTime: CloudFronttimestamp;
-        InvalidationBatch: CloudFrontInvalidationBatch;
-    }
-
-    export interface CloudFrontInvalidationBatch {
-        Paths: CloudFrontPaths;
-        CallerReference: CloudFrontstring;
-    }
-
-    export interface CloudFrontInvalidationList {
-        Marker: CloudFrontstring;
-        NextMarker?: CloudFrontstring;
-        MaxItems: CloudFrontinteger;
-        IsTruncated: CloudFrontboolean;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontInvalidationSummaryList;
-    }
-
-    export interface CloudFrontInvalidationSummary {
-        Id: CloudFrontstring;
-        CreateTime: CloudFronttimestamp;
-        Status: CloudFrontstring;
-    }
-
-    export type CloudFrontInvalidationSummaryList = Array<CloudFrontInvalidationSummary>;
-    export type CloudFrontItemSelection = string;
-    export type CloudFrontKeyPairIdList = Array<CloudFrontstring>;
-    export interface CloudFrontKeyPairIds {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontKeyPairIdList;
-    }
-
-    export interface CloudFrontListCloudFrontOriginAccessIdentitiesRequest {
-        Marker?: CloudFrontstring;
-        MaxItems?: CloudFrontstring;
-    }
-
-    export interface CloudFrontListCloudFrontOriginAccessIdentitiesResult {
-        CloudFrontOriginAccessIdentityList?: CloudFrontCloudFrontOriginAccessIdentityList;
-    }
-
-    export interface CloudFrontListDistributionsByWebACLIdRequest {
-        Marker?: CloudFrontstring;
-        MaxItems?: CloudFrontstring;
-        WebACLId: CloudFrontstring;
-    }
-
-    export interface CloudFrontListDistributionsByWebACLIdResult {
-        DistributionList?: CloudFrontDistributionList;
-    }
-
-    export interface CloudFrontListDistributionsRequest {
-        Marker?: CloudFrontstring;
-        MaxItems?: CloudFrontstring;
-    }
-
-    export interface CloudFrontListDistributionsResult {
-        DistributionList?: CloudFrontDistributionList;
-    }
-
-    export interface CloudFrontListInvalidationsRequest {
-        DistributionId: CloudFrontstring;
-        Marker?: CloudFrontstring;
-        MaxItems?: CloudFrontstring;
-    }
-
-    export interface CloudFrontListInvalidationsResult {
-        InvalidationList?: CloudFrontInvalidationList;
-    }
-
-    export interface CloudFrontListStreamingDistributionsRequest {
-        Marker?: CloudFrontstring;
-        MaxItems?: CloudFrontstring;
-    }
-
-    export interface CloudFrontListStreamingDistributionsResult {
-        StreamingDistributionList?: CloudFrontStreamingDistributionList;
-    }
-
-    export type CloudFrontLocationList = Array<CloudFrontstring>;
-    export interface CloudFrontLoggingConfig {
-        Enabled: CloudFrontboolean;
-        IncludeCookies: CloudFrontboolean;
-        Bucket: CloudFrontstring;
-        Prefix: CloudFrontstring;
-    }
-
-    export type CloudFrontMethod = string;
-    export type CloudFrontMethodsList = Array<CloudFrontMethod>;
-    export type CloudFrontMinimumProtocolVersion = string;
-    export interface CloudFrontMissingBody {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontNoSuchCloudFrontOriginAccessIdentity {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontNoSuchDistribution {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontNoSuchInvalidation {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontNoSuchOrigin {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontNoSuchStreamingDistribution {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontOrigin {
-        Id: CloudFrontstring;
-        DomainName: CloudFrontstring;
-        OriginPath?: CloudFrontstring;
-        S3OriginConfig?: CloudFrontS3OriginConfig;
-        CustomOriginConfig?: CloudFrontCustomOriginConfig;
-    }
-
-    export type CloudFrontOriginList = Array<CloudFrontOrigin>;
-    export type CloudFrontOriginProtocolPolicy = string;
-    export interface CloudFrontOrigins {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontOriginList;
-    }
-
-    export type CloudFrontPathList = Array<CloudFrontstring>;
-    export interface CloudFrontPaths {
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontPathList;
-    }
-
-    export interface CloudFrontPreconditionFailed {
-        Message?: CloudFrontstring;
-    }
-
-    export type CloudFrontPriceClass = string;
-    export interface CloudFrontRestrictions {
-        GeoRestriction: CloudFrontGeoRestriction;
-    }
-
-    export interface CloudFrontS3Origin {
-        DomainName: CloudFrontstring;
-        OriginAccessIdentity: CloudFrontstring;
-    }
-
-    export interface CloudFrontS3OriginConfig {
-        OriginAccessIdentity: CloudFrontstring;
-    }
-
-    export type CloudFrontSSLSupportMethod = string;
-    export interface CloudFrontSigner {
-        AwsAccountNumber?: CloudFrontstring;
-        KeyPairIds?: CloudFrontKeyPairIds;
-    }
-
-    export type CloudFrontSignerList = Array<CloudFrontSigner>;
-    export interface CloudFrontStreamingDistribution {
-        Id: CloudFrontstring;
-        Status: CloudFrontstring;
-        LastModifiedTime?: CloudFronttimestamp;
-        DomainName: CloudFrontstring;
-        ActiveTrustedSigners: CloudFrontActiveTrustedSigners;
-        StreamingDistributionConfig: CloudFrontStreamingDistributionConfig;
-    }
-
-    export interface CloudFrontStreamingDistributionAlreadyExists {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontStreamingDistributionConfig {
-        CallerReference: CloudFrontstring;
-        S3Origin: CloudFrontS3Origin;
-        Aliases?: CloudFrontAliases;
-        Comment: CloudFrontstring;
-        Logging?: CloudFrontStreamingLoggingConfig;
-        TrustedSigners: CloudFrontTrustedSigners;
-        PriceClass?: CloudFrontPriceClass;
-        Enabled: CloudFrontboolean;
-    }
-
-    export interface CloudFrontStreamingDistributionList {
-        Marker: CloudFrontstring;
-        NextMarker?: CloudFrontstring;
-        MaxItems: CloudFrontinteger;
-        IsTruncated: CloudFrontboolean;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontStreamingDistributionSummaryList;
-    }
-
-    export interface CloudFrontStreamingDistributionNotDisabled {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontStreamingDistributionSummary {
-        Id: CloudFrontstring;
-        Status: CloudFrontstring;
-        LastModifiedTime: CloudFronttimestamp;
-        DomainName: CloudFrontstring;
-        S3Origin: CloudFrontS3Origin;
-        Aliases: CloudFrontAliases;
-        TrustedSigners: CloudFrontTrustedSigners;
-        Comment: CloudFrontstring;
-        PriceClass: CloudFrontPriceClass;
-        Enabled: CloudFrontboolean;
-    }
-
-    export type CloudFrontStreamingDistributionSummaryList = Array<CloudFrontStreamingDistributionSummary>;
-    export interface CloudFrontStreamingLoggingConfig {
-        Enabled: CloudFrontboolean;
-        Bucket: CloudFrontstring;
-        Prefix: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyCacheBehaviors {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyCertificates {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyCloudFrontOriginAccessIdentities {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyCookieNamesInWhiteList {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyDistributionCNAMEs {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyDistributions {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyHeadersInForwardedValues {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyInvalidationsInProgress {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyOrigins {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyStreamingDistributionCNAMEs {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyStreamingDistributions {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTooManyTrustedSigners {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTrustedSignerDoesNotExist {
-        Message?: CloudFrontstring;
-    }
-
-    export interface CloudFrontTrustedSigners {
-        Enabled: CloudFrontboolean;
-        Quantity: CloudFrontinteger;
-        Items?: CloudFrontAwsAccountNumberList;
-    }
-
-    export interface CloudFrontUpdateCloudFrontOriginAccessIdentityRequest {
-        CloudFrontOriginAccessIdentityConfig: CloudFrontCloudFrontOriginAccessIdentityConfig;
-        Id: CloudFrontstring;
-        IfMatch?: CloudFrontstring;
-    }
-
-    export interface CloudFrontUpdateCloudFrontOriginAccessIdentityResult {
-        CloudFrontOriginAccessIdentity?: CloudFrontCloudFrontOriginAccessIdentity;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontUpdateDistributionRequest {
-        DistributionConfig: CloudFrontDistributionConfig;
-        Id: CloudFrontstring;
-        IfMatch?: CloudFrontstring;
-    }
-
-    export interface CloudFrontUpdateDistributionResult {
-        Distribution?: CloudFrontDistribution;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontUpdateStreamingDistributionRequest {
-        StreamingDistributionConfig: CloudFrontStreamingDistributionConfig;
-        Id: CloudFrontstring;
-        IfMatch?: CloudFrontstring;
-    }
-
-    export interface CloudFrontUpdateStreamingDistributionResult {
-        StreamingDistribution?: CloudFrontStreamingDistribution;
-        ETag?: CloudFrontstring;
-    }
-
-    export interface CloudFrontViewerCertificate {
-        IAMCertificateId?: CloudFrontstring;
-        CloudFrontDefaultCertificate?: CloudFrontboolean;
-        SSLSupportMethod?: CloudFrontSSLSupportMethod;
-        MinimumProtocolVersion?: CloudFrontMinimumProtocolVersion;
-    }
-
-    export type CloudFrontViewerProtocolPolicy = string;
-    export type CloudFrontboolean = boolean;
-    export type CloudFrontinteger = number;
-    export type CloudFrontlong = number;
-    export type CloudFrontstring = string;
-    export type CloudFronttimestamp = number;
 }

--- a/output/aws-cloudhsm.d.ts
+++ b/output/aws-cloudhsm.d.ts
@@ -6,259 +6,226 @@ declare module "aws-sdk" {
 
     export class CloudHSM extends Service {
       constructor(options?: any);
-      createHapg(params: CloudHSMCreateHapgRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMCreateHapgResponse|any) => void): Request;
-      createHsm(params: CloudHSMCreateHsmRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMCreateHsmResponse|any) => void): Request;
-      createLunaClient(params: CloudHSMCreateLunaClientRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMCreateLunaClientResponse|any) => void): Request;
-      deleteHapg(params: CloudHSMDeleteHapgRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMDeleteHapgResponse|any) => void): Request;
-      deleteHsm(params: CloudHSMDeleteHsmRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMDeleteHsmResponse|any) => void): Request;
-      deleteLunaClient(params: CloudHSMDeleteLunaClientRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMDeleteLunaClientResponse|any) => void): Request;
-      describeHapg(params: CloudHSMDescribeHapgRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMDescribeHapgResponse|any) => void): Request;
-      describeHsm(params: CloudHSMDescribeHsmRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMDescribeHsmResponse|any) => void): Request;
-      describeLunaClient(params: CloudHSMDescribeLunaClientRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMDescribeLunaClientResponse|any) => void): Request;
-      getConfig(params: CloudHSMGetConfigRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMGetConfigResponse|any) => void): Request;
-      listAvailableZones(params: CloudHSMListAvailableZonesRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMListAvailableZonesResponse|any) => void): Request;
-      listHapgs(params: CloudHSMListHapgsRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMListHapgsResponse|any) => void): Request;
-      listHsms(params: CloudHSMListHsmsRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMListHsmsResponse|any) => void): Request;
-      listLunaClients(params: CloudHSMListLunaClientsRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMListLunaClientsResponse|any) => void): Request;
-      modifyHapg(params: CloudHSMModifyHapgRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMModifyHapgResponse|any) => void): Request;
-      modifyHsm(params: CloudHSMModifyHsmRequest, callback?: (err: CloudHSMCloudHsmServiceException|CloudHSMCloudHsmInternalException|CloudHSMInvalidRequestException|any, data: CloudHSMModifyHsmResponse|any) => void): Request;
-      modifyLunaClient(params: CloudHSMModifyLunaClientRequest, callback?: (err: CloudHSMCloudHsmServiceException|any, data: CloudHSMModifyLunaClientResponse|any) => void): Request;
+      createHapg(params: CloudHSM.CreateHapgRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.CreateHapgResponse|any) => void): Request;
+      createHsm(params: CloudHSM.CreateHsmRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.CreateHsmResponse|any) => void): Request;
+      createLunaClient(params: CloudHSM.CreateLunaClientRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.CreateLunaClientResponse|any) => void): Request;
+      deleteHapg(params: CloudHSM.DeleteHapgRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.DeleteHapgResponse|any) => void): Request;
+      deleteHsm(params: CloudHSM.DeleteHsmRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.DeleteHsmResponse|any) => void): Request;
+      deleteLunaClient(params: CloudHSM.DeleteLunaClientRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.DeleteLunaClientResponse|any) => void): Request;
+      describeHapg(params: CloudHSM.DescribeHapgRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.DescribeHapgResponse|any) => void): Request;
+      describeHsm(params: CloudHSM.DescribeHsmRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.DescribeHsmResponse|any) => void): Request;
+      describeLunaClient(params: CloudHSM.DescribeLunaClientRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.DescribeLunaClientResponse|any) => void): Request;
+      getConfig(params: CloudHSM.GetConfigRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.GetConfigResponse|any) => void): Request;
+      listAvailableZones(params: CloudHSM.ListAvailableZonesRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.ListAvailableZonesResponse|any) => void): Request;
+      listHapgs(params: CloudHSM.ListHapgsRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.ListHapgsResponse|any) => void): Request;
+      listHsms(params: CloudHSM.ListHsmsRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.ListHsmsResponse|any) => void): Request;
+      listLunaClients(params: CloudHSM.ListLunaClientsRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.ListLunaClientsResponse|any) => void): Request;
+      modifyHapg(params: CloudHSM.ModifyHapgRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.ModifyHapgResponse|any) => void): Request;
+      modifyHsm(params: CloudHSM.ModifyHsmRequest, callback?: (err: CloudHSM.CloudHsmServiceException|CloudHSM.CloudHsmInternalException|CloudHSM.InvalidRequestException|any, data: CloudHSM.ModifyHsmResponse|any) => void): Request;
+      modifyLunaClient(params: CloudHSM.ModifyLunaClientRequest, callback?: (err: CloudHSM.CloudHsmServiceException|any, data: CloudHSM.ModifyLunaClientResponse|any) => void): Request;
     }
+    
+    export module CloudHSM {
+        export type AZ = string;    // pattern: &quot;[a-zA-Z0-9\-]*&quot;
+        export type AZList = AZ[];
+        export type Boolean = boolean;
+        export type Certificate = string;    // pattern: &quot;[\w :+=./\n-]*&quot;, max: 2400, min: 600
+        export type CertificateFingerprint = string;    // pattern: &quot;([0-9a-fA-F][0-9a-fA-F]:){15}[0-9a-fA-F][0-9a-fA-F]&quot;
+        export type ClientArn = string;    // pattern: &quot;arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:client-[0-9a-f]{8}&quot;
+        export type ClientLabel = string;    // pattern: &quot;[a-zA-Z0-9_.-]{2,64}&quot;
+        export type ClientList = ClientArn[];
+        export type ClientToken = string;    // pattern: &quot;[a-zA-Z0-9]{1,64}&quot;
+        export type ClientVersion = string;
+        export type CloudHsmObjectState = string;
+        export type EniId = string;    // pattern: &quot;eni-[0-9a-f]{8}&quot;
+        export type ExternalId = string;    // pattern: &quot;[\w :+=./-]*&quot;
+        export type HapgArn = string;    // pattern: &quot;arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:hapg-[0-9a-f]{8}&quot;
+        export type HapgList = HapgArn[];
+        export type HsmArn = string;    // pattern: &quot;arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:hsm-[0-9a-f]{8}&quot;
+        export type HsmList = HsmArn[];
+        export type HsmSerialNumber = string;    // pattern: &quot;\d{1,16}&quot;
+        export type HsmStatus = string;
+        export type IamRoleArn = string;    // pattern: &quot;arn:aws(-iso)?:iam::[0-9]{12}:role/[a-zA-Z0-9_\+=,\.\-@]{1,64}&quot;
+        export type IpAddress = string;    // pattern: &quot;\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}&quot;
+        export type Label = string;    // pattern: &quot;[a-zA-Z0-9_.-]{1,64}&quot;
+        export type PaginationToken = string;    // pattern: &quot;[a-zA-Z0-9+/]*&quot;
+        export type PartitionArn = string;    // pattern: &quot;arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:hsm-[0-9a-f]{8}/partition-[0-9]{6,12}&quot;
+        export type PartitionList = PartitionArn[];
+        export type PartitionSerial = string;    // pattern: &quot;\d{9}&quot;
+        export type PartitionSerialList = PartitionSerial[];
+        export type SshKey = string;    // pattern: &quot;[a-zA-Z0-9+/= ._:\\@-]*&quot;
+        export type String = string;    // pattern: &quot;[\w :+=./\\-]*&quot;
+        export type SubnetId = string;    // pattern: &quot;subnet-[0-9a-f]{8}&quot;
+        export type SubscriptionType = string;
+        export type Timestamp = string;    // pattern: &quot;\d*&quot;
+        export type VpcId = string;    // pattern: &quot;vpc-[0-9a-f]{8}&quot;
 
-    export type CloudHSMAZ = string; // pattern: "[a-zA-Z0-9\-]*"
-    export type CloudHSMAZList = Array<CloudHSMAZ>;
-    export type CloudHSMBoolean = boolean;
-    export type CloudHSMCertificate = string; // pattern: "[\w :+=./\n-]*"
-    export type CloudHSMCertificateFingerprint = string; // pattern: "([0-9a-fA-F][0-9a-fA-F]:){15}[0-9a-fA-F][0-9a-fA-F]"
-    export type CloudHSMClientArn = string; // pattern: "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:client-[0-9a-f]{8}"
-    export type CloudHSMClientLabel = string; // pattern: "[a-zA-Z0-9_.-]{2,64}"
-    export type CloudHSMClientList = Array<CloudHSMClientArn>;
-    export type CloudHSMClientToken = string; // pattern: "[a-zA-Z0-9]{1,64}"
-    export type CloudHSMClientVersion = string;
-    export interface CloudHSMCloudHsmInternalException {
+        export interface CloudHsmInternalException {
+        }
+        export interface CloudHsmServiceException {
+            message?: String;            
+            retryable?: Boolean;            
+        }
+        export interface CreateHapgRequest {
+            Label: Label;            
+        }
+        export interface CreateHapgResponse {
+            HapgArn?: HapgArn;            
+        }
+        export interface CreateHsmRequest {
+            SubnetId: SubnetId;            
+            SshKey: SshKey;            
+            EniIp?: IpAddress;            
+            IamRoleArn: IamRoleArn;            
+            ExternalId?: ExternalId;            
+            SubscriptionType: SubscriptionType;            
+            ClientToken?: ClientToken;            
+            SyslogIp?: IpAddress;            
+        }
+        export interface CreateHsmResponse {
+            HsmArn?: HsmArn;            
+        }
+        export interface CreateLunaClientRequest {
+            Label?: ClientLabel;            
+            Certificate: Certificate;            
+        }
+        export interface CreateLunaClientResponse {
+            ClientArn?: ClientArn;            
+        }
+        export interface DeleteHapgRequest {
+            HapgArn: HapgArn;            
+        }
+        export interface DeleteHapgResponse {
+            Status: String;            
+        }
+        export interface DeleteHsmRequest {
+            HsmArn: HsmArn;            
+        }
+        export interface DeleteHsmResponse {
+            Status: String;            
+        }
+        export interface DeleteLunaClientRequest {
+            ClientArn: ClientArn;            
+        }
+        export interface DeleteLunaClientResponse {
+            Status: String;            
+        }
+        export interface DescribeHapgRequest {
+            HapgArn: HapgArn;            
+        }
+        export interface DescribeHapgResponse {
+            HapgArn?: HapgArn;            
+            HapgSerial?: String;            
+            HsmsLastActionFailed?: HsmList;            
+            HsmsPendingDeletion?: HsmList;            
+            HsmsPendingRegistration?: HsmList;            
+            Label?: Label;            
+            LastModifiedTimestamp?: Timestamp;            
+            PartitionSerialList?: PartitionSerialList;            
+            State?: CloudHsmObjectState;            
+        }
+        export interface DescribeHsmRequest {
+            HsmArn?: HsmArn;            
+            HsmSerialNumber?: HsmSerialNumber;            
+        }
+        export interface DescribeHsmResponse {
+            HsmArn?: HsmArn;            
+            Status?: HsmStatus;            
+            StatusDetails?: String;            
+            AvailabilityZone?: AZ;            
+            EniId?: EniId;            
+            EniIp?: IpAddress;            
+            SubscriptionType?: SubscriptionType;            
+            SubscriptionStartDate?: Timestamp;            
+            SubscriptionEndDate?: Timestamp;            
+            VpcId?: VpcId;            
+            SubnetId?: SubnetId;            
+            IamRoleArn?: IamRoleArn;            
+            SerialNumber?: HsmSerialNumber;            
+            VendorName?: String;            
+            HsmType?: String;            
+            SoftwareVersion?: String;            
+            SshPublicKey?: SshKey;            
+            SshKeyLastUpdated?: Timestamp;            
+            ServerCertUri?: String;            
+            ServerCertLastUpdated?: Timestamp;            
+            Partitions?: PartitionList;            
+        }
+        export interface DescribeLunaClientRequest {
+            ClientArn?: ClientArn;            
+            CertificateFingerprint?: CertificateFingerprint;            
+        }
+        export interface DescribeLunaClientResponse {
+            ClientArn?: ClientArn;            
+            Certificate?: Certificate;            
+            CertificateFingerprint?: CertificateFingerprint;            
+            LastModifiedTimestamp?: Timestamp;            
+            Label?: Label;            
+        }
+        export interface GetConfigRequest {
+            ClientArn: ClientArn;            
+            ClientVersion: ClientVersion;            
+            HapgList: HapgList;            
+        }
+        export interface GetConfigResponse {
+            ConfigType?: String;            
+            ConfigFile?: String;            
+            ConfigCred?: String;            
+        }
+        export interface InvalidRequestException {
+        }
+        export interface ListAvailableZonesRequest {
+        }
+        export interface ListAvailableZonesResponse {
+            AZList?: AZList;            
+        }
+        export interface ListHapgsRequest {
+            NextToken?: PaginationToken;            
+        }
+        export interface ListHapgsResponse {
+            HapgList: HapgList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface ListHsmsRequest {
+            NextToken?: PaginationToken;            
+        }
+        export interface ListHsmsResponse {
+            HsmList?: HsmList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface ListLunaClientsRequest {
+            NextToken?: PaginationToken;            
+        }
+        export interface ListLunaClientsResponse {
+            ClientList: ClientList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface ModifyHapgRequest {
+            HapgArn: HapgArn;            
+            Label?: Label;            
+            PartitionSerialList?: PartitionSerialList;            
+        }
+        export interface ModifyHapgResponse {
+            HapgArn?: HapgArn;            
+        }
+        export interface ModifyHsmRequest {
+            HsmArn: HsmArn;            
+            SubnetId?: SubnetId;            
+            EniIp?: IpAddress;            
+            IamRoleArn?: IamRoleArn;            
+            ExternalId?: ExternalId;            
+            SyslogIp?: IpAddress;            
+        }
+        export interface ModifyHsmResponse {
+            HsmArn?: HsmArn;            
+        }
+        export interface ModifyLunaClientRequest {
+            ClientArn: ClientArn;            
+            Certificate: Certificate;            
+        }
+        export interface ModifyLunaClientResponse {
+            ClientArn?: ClientArn;            
+        }
+
     }
-
-    export type CloudHSMCloudHsmObjectState = string;
-    export interface CloudHSMCloudHsmServiceException {
-        message?: CloudHSMString;
-        retryable?: CloudHSMBoolean;
-    }
-
-    export interface CloudHSMCreateHapgRequest {
-        Label: CloudHSMLabel;
-    }
-
-    export interface CloudHSMCreateHapgResponse {
-        HapgArn?: CloudHSMHapgArn;
-    }
-
-    export interface CloudHSMCreateHsmRequest {
-        SubnetId: CloudHSMSubnetId;
-        SshKey: CloudHSMSshKey;
-        EniIp?: CloudHSMIpAddress;
-        IamRoleArn: CloudHSMIamRoleArn;
-        ExternalId?: CloudHSMExternalId;
-        SubscriptionType: CloudHSMSubscriptionType;
-        ClientToken?: CloudHSMClientToken;
-        SyslogIp?: CloudHSMIpAddress;
-    }
-
-    export interface CloudHSMCreateHsmResponse {
-        HsmArn?: CloudHSMHsmArn;
-    }
-
-    export interface CloudHSMCreateLunaClientRequest {
-        Label?: CloudHSMClientLabel;
-        Certificate: CloudHSMCertificate;
-    }
-
-    export interface CloudHSMCreateLunaClientResponse {
-        ClientArn?: CloudHSMClientArn;
-    }
-
-    export interface CloudHSMDeleteHapgRequest {
-        HapgArn: CloudHSMHapgArn;
-    }
-
-    export interface CloudHSMDeleteHapgResponse {
-        Status: CloudHSMString;
-    }
-
-    export interface CloudHSMDeleteHsmRequest {
-        HsmArn: CloudHSMHsmArn;
-    }
-
-    export interface CloudHSMDeleteHsmResponse {
-        Status: CloudHSMString;
-    }
-
-    export interface CloudHSMDeleteLunaClientRequest {
-        ClientArn: CloudHSMClientArn;
-    }
-
-    export interface CloudHSMDeleteLunaClientResponse {
-        Status: CloudHSMString;
-    }
-
-    export interface CloudHSMDescribeHapgRequest {
-        HapgArn: CloudHSMHapgArn;
-    }
-
-    export interface CloudHSMDescribeHapgResponse {
-        HapgArn?: CloudHSMHapgArn;
-        HapgSerial?: CloudHSMString;
-        HsmsLastActionFailed?: CloudHSMHsmList;
-        HsmsPendingDeletion?: CloudHSMHsmList;
-        HsmsPendingRegistration?: CloudHSMHsmList;
-        Label?: CloudHSMLabel;
-        LastModifiedTimestamp?: CloudHSMTimestamp;
-        PartitionSerialList?: CloudHSMPartitionSerialList;
-        State?: CloudHSMCloudHsmObjectState;
-    }
-
-    export interface CloudHSMDescribeHsmRequest {
-        HsmArn?: CloudHSMHsmArn;
-        HsmSerialNumber?: CloudHSMHsmSerialNumber;
-    }
-
-    export interface CloudHSMDescribeHsmResponse {
-        HsmArn?: CloudHSMHsmArn;
-        Status?: CloudHSMHsmStatus;
-        StatusDetails?: CloudHSMString;
-        AvailabilityZone?: CloudHSMAZ;
-        EniId?: CloudHSMEniId;
-        EniIp?: CloudHSMIpAddress;
-        SubscriptionType?: CloudHSMSubscriptionType;
-        SubscriptionStartDate?: CloudHSMTimestamp;
-        SubscriptionEndDate?: CloudHSMTimestamp;
-        VpcId?: CloudHSMVpcId;
-        SubnetId?: CloudHSMSubnetId;
-        IamRoleArn?: CloudHSMIamRoleArn;
-        SerialNumber?: CloudHSMHsmSerialNumber;
-        VendorName?: CloudHSMString;
-        HsmType?: CloudHSMString;
-        SoftwareVersion?: CloudHSMString;
-        SshPublicKey?: CloudHSMSshKey;
-        SshKeyLastUpdated?: CloudHSMTimestamp;
-        ServerCertUri?: CloudHSMString;
-        ServerCertLastUpdated?: CloudHSMTimestamp;
-        Partitions?: CloudHSMPartitionList;
-    }
-
-    export interface CloudHSMDescribeLunaClientRequest {
-        ClientArn?: CloudHSMClientArn;
-        CertificateFingerprint?: CloudHSMCertificateFingerprint;
-    }
-
-    export interface CloudHSMDescribeLunaClientResponse {
-        ClientArn?: CloudHSMClientArn;
-        Certificate?: CloudHSMCertificate;
-        CertificateFingerprint?: CloudHSMCertificateFingerprint;
-        LastModifiedTimestamp?: CloudHSMTimestamp;
-        Label?: CloudHSMLabel;
-    }
-
-    export type CloudHSMEniId = string; // pattern: "eni-[0-9a-f]{8}"
-    export type CloudHSMExternalId = string; // pattern: "[\w :+=./-]*"
-    export interface CloudHSMGetConfigRequest {
-        ClientArn: CloudHSMClientArn;
-        ClientVersion: CloudHSMClientVersion;
-        HapgList: CloudHSMHapgList;
-    }
-
-    export interface CloudHSMGetConfigResponse {
-        ConfigType?: CloudHSMString;
-        ConfigFile?: CloudHSMString;
-        ConfigCred?: CloudHSMString;
-    }
-
-    export type CloudHSMHapgArn = string; // pattern: "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:hapg-[0-9a-f]{8}"
-    export type CloudHSMHapgList = Array<CloudHSMHapgArn>;
-    export type CloudHSMHsmArn = string; // pattern: "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:hsm-[0-9a-f]{8}"
-    export type CloudHSMHsmList = Array<CloudHSMHsmArn>;
-    export type CloudHSMHsmSerialNumber = string; // pattern: "\d{1,16}"
-    export type CloudHSMHsmStatus = string;
-    export type CloudHSMIamRoleArn = string; // pattern: "arn:aws(-iso)?:iam::[0-9]{12}:role/[a-zA-Z0-9_\+=,\.\-@]{1,64}"
-    export interface CloudHSMInvalidRequestException {
-    }
-
-    export type CloudHSMIpAddress = string; // pattern: "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
-    export type CloudHSMLabel = string; // pattern: "[a-zA-Z0-9_.-]{1,64}"
-    export interface CloudHSMListAvailableZonesRequest {
-    }
-
-    export interface CloudHSMListAvailableZonesResponse {
-        AZList?: CloudHSMAZList;
-    }
-
-    export interface CloudHSMListHapgsRequest {
-        NextToken?: CloudHSMPaginationToken;
-    }
-
-    export interface CloudHSMListHapgsResponse {
-        HapgList: CloudHSMHapgList;
-        NextToken?: CloudHSMPaginationToken;
-    }
-
-    export interface CloudHSMListHsmsRequest {
-        NextToken?: CloudHSMPaginationToken;
-    }
-
-    export interface CloudHSMListHsmsResponse {
-        HsmList?: CloudHSMHsmList;
-        NextToken?: CloudHSMPaginationToken;
-    }
-
-    export interface CloudHSMListLunaClientsRequest {
-        NextToken?: CloudHSMPaginationToken;
-    }
-
-    export interface CloudHSMListLunaClientsResponse {
-        ClientList: CloudHSMClientList;
-        NextToken?: CloudHSMPaginationToken;
-    }
-
-    export interface CloudHSMModifyHapgRequest {
-        HapgArn: CloudHSMHapgArn;
-        Label?: CloudHSMLabel;
-        PartitionSerialList?: CloudHSMPartitionSerialList;
-    }
-
-    export interface CloudHSMModifyHapgResponse {
-        HapgArn?: CloudHSMHapgArn;
-    }
-
-    export interface CloudHSMModifyHsmRequest {
-        HsmArn: CloudHSMHsmArn;
-        SubnetId?: CloudHSMSubnetId;
-        EniIp?: CloudHSMIpAddress;
-        IamRoleArn?: CloudHSMIamRoleArn;
-        ExternalId?: CloudHSMExternalId;
-        SyslogIp?: CloudHSMIpAddress;
-    }
-
-    export interface CloudHSMModifyHsmResponse {
-        HsmArn?: CloudHSMHsmArn;
-    }
-
-    export interface CloudHSMModifyLunaClientRequest {
-        ClientArn: CloudHSMClientArn;
-        Certificate: CloudHSMCertificate;
-    }
-
-    export interface CloudHSMModifyLunaClientResponse {
-        ClientArn?: CloudHSMClientArn;
-    }
-
-    export type CloudHSMPaginationToken = string; // pattern: "[a-zA-Z0-9+/]*"
-    export type CloudHSMPartitionArn = string; // pattern: "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\-]*:[0-9]{12}:hsm-[0-9a-f]{8}/partition-[0-9]{6,12}"
-    export type CloudHSMPartitionList = Array<CloudHSMPartitionArn>;
-    export type CloudHSMPartitionSerial = string; // pattern: "\d{9}"
-    export type CloudHSMPartitionSerialList = Array<CloudHSMPartitionSerial>;
-    export type CloudHSMSshKey = string; // pattern: "[a-zA-Z0-9+/= ._:\\@-]*"
-    export type CloudHSMString = string; // pattern: "[\w :+=./\\-]*"
-    export type CloudHSMSubnetId = string; // pattern: "subnet-[0-9a-f]{8}"
-    export type CloudHSMSubscriptionType = string;
-    export type CloudHSMTimestamp = string; // pattern: "\d*"
-    export type CloudHSMVpcId = string; // pattern: "vpc-[0-9a-f]{8}"
 }

--- a/output/aws-cloudsearch.d.ts
+++ b/output/aws-cloudsearch.d.ts
@@ -6,394 +6,328 @@ declare module "aws-sdk" {
 
     export class CloudSearch extends Service {
       constructor(options?: any);
-      createDomain(params: CloudSearchCreateDomainRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchLimitExceededException|any, data: CloudSearchCreateDomainResponse|any) => void): Request;
-      defineIndexField(params: CloudSearchDefineIndexFieldRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchLimitExceededException|CloudSearchInvalidTypeException|CloudSearchResourceNotFoundException|any, data: CloudSearchDefineIndexFieldResponse|any) => void): Request;
-      defineRankExpression(params: CloudSearchDefineRankExpressionRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchLimitExceededException|CloudSearchInvalidTypeException|CloudSearchResourceNotFoundException|any, data: CloudSearchDefineRankExpressionResponse|any) => void): Request;
-      deleteDomain(params: CloudSearchDeleteDomainRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|any, data: CloudSearchDeleteDomainResponse|any) => void): Request;
-      deleteIndexField(params: CloudSearchDeleteIndexFieldRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchResourceNotFoundException|any, data: CloudSearchDeleteIndexFieldResponse|any) => void): Request;
-      deleteRankExpression(params: CloudSearchDeleteRankExpressionRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchResourceNotFoundException|any, data: CloudSearchDeleteRankExpressionResponse|any) => void): Request;
-      describeAvailabilityOptions(params: CloudSearchDescribeAvailabilityOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchLimitExceededException|CloudSearchResourceNotFoundException|CloudSearchDisabledOperationException|any, data: CloudSearchDescribeAvailabilityOptionsResponse|any) => void): Request;
-      describeDefaultSearchField(params: CloudSearchDescribeDefaultSearchFieldRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeDefaultSearchFieldResponse|any) => void): Request;
-      describeDomains(params: CloudSearchDescribeDomainsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|any, data: CloudSearchDescribeDomainsResponse|any) => void): Request;
-      describeIndexFields(params: CloudSearchDescribeIndexFieldsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeIndexFieldsResponse|any) => void): Request;
-      describeRankExpressions(params: CloudSearchDescribeRankExpressionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeRankExpressionsResponse|any) => void): Request;
-      describeServiceAccessPolicies(params: CloudSearchDescribeServiceAccessPoliciesRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeServiceAccessPoliciesResponse|any) => void): Request;
-      describeStemmingOptions(params: CloudSearchDescribeStemmingOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeStemmingOptionsResponse|any) => void): Request;
-      describeStopwordOptions(params: CloudSearchDescribeStopwordOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeStopwordOptionsResponse|any) => void): Request;
-      describeSynonymOptions(params: CloudSearchDescribeSynonymOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchDescribeSynonymOptionsResponse|any) => void): Request;
-      indexDocuments(params: CloudSearchIndexDocumentsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchResourceNotFoundException|any, data: CloudSearchIndexDocumentsResponse|any) => void): Request;
-      updateAvailabilityOptions(params: CloudSearchUpdateAvailabilityOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchLimitExceededException|CloudSearchResourceNotFoundException|CloudSearchDisabledOperationException|any, data: CloudSearchUpdateAvailabilityOptionsResponse|any) => void): Request;
-      updateDefaultSearchField(params: CloudSearchUpdateDefaultSearchFieldRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchResourceNotFoundException|any, data: CloudSearchUpdateDefaultSearchFieldResponse|any) => void): Request;
-      updateServiceAccessPolicies(params: CloudSearchUpdateServiceAccessPoliciesRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchLimitExceededException|CloudSearchResourceNotFoundException|CloudSearchInvalidTypeException|any, data: CloudSearchUpdateServiceAccessPoliciesResponse|any) => void): Request;
-      updateStemmingOptions(params: CloudSearchUpdateStemmingOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchLimitExceededException|CloudSearchResourceNotFoundException|any, data: CloudSearchUpdateStemmingOptionsResponse|any) => void): Request;
-      updateStopwordOptions(params: CloudSearchUpdateStopwordOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchLimitExceededException|CloudSearchResourceNotFoundException|any, data: CloudSearchUpdateStopwordOptionsResponse|any) => void): Request;
-      updateSynonymOptions(params: CloudSearchUpdateSynonymOptionsRequest, callback?: (err: CloudSearchBaseException|CloudSearchInternalException|CloudSearchInvalidTypeException|CloudSearchLimitExceededException|CloudSearchResourceNotFoundException|any, data: CloudSearchUpdateSynonymOptionsResponse|any) => void): Request;
-    }
-
-    export interface CloudSearchAccessPoliciesStatus {
-        Options: CloudSearchPolicyDocument;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export type CloudSearchArn = string;
-    export interface CloudSearchAvailabilityOptionsStatus {
-        Options: CloudSearchMultiAZ;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export interface CloudSearchBaseException {
-        Code?: CloudSearchErrorCode;
-        Message?: CloudSearchErrorMessage;
-    }
-
-    export type CloudSearchBoolean = boolean;
-    export interface CloudSearchCreateDomainRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchCreateDomainResponse {
-        DomainStatus?: CloudSearchDomainStatus;
-    }
-
-    export interface CloudSearchDefaultSearchFieldStatus {
-        Options: CloudSearchFieldName;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export interface CloudSearchDefineIndexFieldRequest {
-        DomainName: CloudSearchDomainName;
-        IndexField: CloudSearchIndexField;
-    }
-
-    export interface CloudSearchDefineIndexFieldResponse {
-        IndexField: CloudSearchIndexFieldStatus;
-    }
-
-    export interface CloudSearchDefineRankExpressionRequest {
-        DomainName: CloudSearchDomainName;
-        RankExpression: CloudSearchNamedRankExpression;
-    }
-
-    export interface CloudSearchDefineRankExpressionResponse {
-        RankExpression: CloudSearchRankExpressionStatus;
-    }
-
-    export interface CloudSearchDeleteDomainRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDeleteDomainResponse {
-        DomainStatus?: CloudSearchDomainStatus;
-    }
-
-    export interface CloudSearchDeleteIndexFieldRequest {
-        DomainName: CloudSearchDomainName;
-        IndexFieldName: CloudSearchFieldName;
-    }
-
-    export interface CloudSearchDeleteIndexFieldResponse {
-        IndexField: CloudSearchIndexFieldStatus;
-    }
-
-    export interface CloudSearchDeleteRankExpressionRequest {
-        DomainName: CloudSearchDomainName;
-        RankName: CloudSearchFieldName;
-    }
-
-    export interface CloudSearchDeleteRankExpressionResponse {
-        RankExpression: CloudSearchRankExpressionStatus;
-    }
-
-    export interface CloudSearchDescribeAvailabilityOptionsRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDescribeAvailabilityOptionsResponse {
-        AvailabilityOptions?: CloudSearchAvailabilityOptionsStatus;
-    }
-
-    export interface CloudSearchDescribeDefaultSearchFieldRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDescribeDefaultSearchFieldResponse {
-        DefaultSearchField: CloudSearchDefaultSearchFieldStatus;
-    }
-
-    export interface CloudSearchDescribeDomainsRequest {
-        DomainNames?: CloudSearchDomainNameList;
-    }
-
-    export interface CloudSearchDescribeDomainsResponse {
-        DomainStatusList: CloudSearchDomainStatusList;
-    }
-
-    export interface CloudSearchDescribeIndexFieldsRequest {
-        DomainName: CloudSearchDomainName;
-        FieldNames?: CloudSearchFieldNameList;
-    }
-
-    export interface CloudSearchDescribeIndexFieldsResponse {
-        IndexFields: CloudSearchIndexFieldStatusList;
-    }
-
-    export interface CloudSearchDescribeRankExpressionsRequest {
-        DomainName: CloudSearchDomainName;
-        RankNames?: CloudSearchFieldNameList;
-    }
-
-    export interface CloudSearchDescribeRankExpressionsResponse {
-        RankExpressions: CloudSearchRankExpressionStatusList;
-    }
-
-    export interface CloudSearchDescribeServiceAccessPoliciesRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDescribeServiceAccessPoliciesResponse {
-        AccessPolicies: CloudSearchAccessPoliciesStatus;
-    }
-
-    export interface CloudSearchDescribeStemmingOptionsRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDescribeStemmingOptionsResponse {
-        Stems: CloudSearchStemmingOptionsStatus;
-    }
-
-    export interface CloudSearchDescribeStopwordOptionsRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDescribeStopwordOptionsResponse {
-        Stopwords: CloudSearchStopwordOptionsStatus;
-    }
-
-    export interface CloudSearchDescribeSynonymOptionsRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchDescribeSynonymOptionsResponse {
-        Synonyms: CloudSearchSynonymOptionsStatus;
-    }
-
-    export interface CloudSearchDisabledOperationException {
-    }
-
-    export type CloudSearchDocumentCount = number;
-    export type CloudSearchDomainId = string;
-    export type CloudSearchDomainName = string; // pattern: "[a-z][a-z0-9\-]+"
-    export type CloudSearchDomainNameList = Array<CloudSearchDomainName>;
-    export interface CloudSearchDomainStatus {
-        DomainId: CloudSearchDomainId;
-        DomainName: CloudSearchDomainName;
-        Created?: CloudSearchBoolean;
-        Deleted?: CloudSearchBoolean;
-        NumSearchableDocs?: CloudSearchDocumentCount;
-        DocService?: CloudSearchServiceEndpoint;
-        SearchService?: CloudSearchServiceEndpoint;
-        RequiresIndexDocuments: CloudSearchBoolean;
-        Processing?: CloudSearchBoolean;
-        SearchInstanceType?: CloudSearchSearchInstanceType;
-        SearchPartitionCount?: CloudSearchPartitionCount;
-        SearchInstanceCount?: CloudSearchInstanceCount;
-    }
-
-    export type CloudSearchDomainStatusList = Array<CloudSearchDomainStatus>;
-    export type CloudSearchErrorCode = string;
-    export type CloudSearchErrorMessage = string;
-    export type CloudSearchFieldName = string; // pattern: "[a-z][a-z0-9_]*"
-    export type CloudSearchFieldNameList = Array<CloudSearchFieldName>;
-    export type CloudSearchFieldValue = string;
-    export interface CloudSearchIndexDocumentsRequest {
-        DomainName: CloudSearchDomainName;
-    }
-
-    export interface CloudSearchIndexDocumentsResponse {
-        FieldNames?: CloudSearchFieldNameList;
-    }
-
-    export interface CloudSearchIndexField {
-        IndexFieldName: CloudSearchFieldName;
-        IndexFieldType: CloudSearchIndexFieldType;
-        UIntOptions?: CloudSearchUIntOptions;
-        LiteralOptions?: CloudSearchLiteralOptions;
-        TextOptions?: CloudSearchTextOptions;
-        SourceAttributes?: CloudSearchSourceAttributeList;
-    }
-
-    export interface CloudSearchIndexFieldStatus {
-        Options: CloudSearchIndexField;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export type CloudSearchIndexFieldStatusList = Array<CloudSearchIndexFieldStatus>;
-    export type CloudSearchIndexFieldType = string;
-    export type CloudSearchInstanceCount = number;
-    export interface CloudSearchInternalException {
-    }
-
-    export interface CloudSearchInvalidTypeException {
-    }
-
-    export type CloudSearchLanguage = string; // pattern: "[a-zA-Z]{2,8}(?:-[a-zA-Z]{2,8})*"
-    export interface CloudSearchLimitExceededException {
-    }
-
-    export interface CloudSearchLiteralOptions {
-        DefaultValue?: CloudSearchFieldValue;
-        SearchEnabled?: CloudSearchBoolean;
-        FacetEnabled?: CloudSearchBoolean;
-        ResultEnabled?: CloudSearchBoolean;
-    }
-
-    export type CloudSearchMultiAZ = boolean;
-    export interface CloudSearchNamedRankExpression {
-        RankName: CloudSearchFieldName;
-        RankExpression: CloudSearchRankExpression;
-    }
-
-    export type CloudSearchOptionState = string;
-    export interface CloudSearchOptionStatus {
-        CreationDate: CloudSearchUpdateTimestamp;
-        UpdateDate: CloudSearchUpdateTimestamp;
-        UpdateVersion?: CloudSearchUIntValue;
-        State: CloudSearchOptionState;
-        PendingDeletion?: CloudSearchBoolean;
-    }
-
-    export type CloudSearchPartitionCount = number;
-    export type CloudSearchPolicyDocument = string;
-    export type CloudSearchRankExpression = string;
-    export interface CloudSearchRankExpressionStatus {
-        Options: CloudSearchNamedRankExpression;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export type CloudSearchRankExpressionStatusList = Array<CloudSearchRankExpressionStatus>;
-    export interface CloudSearchResourceNotFoundException {
-    }
-
-    export type CloudSearchSearchInstanceType = string;
-    export interface CloudSearchServiceEndpoint {
-        Arn?: CloudSearchArn;
-        Endpoint?: CloudSearchServiceUrl;
-    }
-
-    export type CloudSearchServiceUrl = string;
-    export interface CloudSearchSourceAttribute {
-        SourceDataFunction: CloudSearchSourceDataFunction;
-        SourceDataCopy?: CloudSearchSourceData;
-        SourceDataTrimTitle?: CloudSearchSourceDataTrimTitle;
-        SourceDataMap?: CloudSearchSourceDataMap;
-    }
-
-    export type CloudSearchSourceAttributeList = Array<CloudSearchSourceAttribute>;
-    export interface CloudSearchSourceData {
-        SourceName: CloudSearchFieldName;
-        DefaultValue?: CloudSearchFieldValue;
-    }
-
-    export type CloudSearchSourceDataFunction = string;
-    export interface CloudSearchSourceDataMap {
-        SourceName: CloudSearchFieldName;
-        DefaultValue?: CloudSearchFieldValue;
-        Cases?: CloudSearchStringCaseMap;
-    }
+      createDomain(params: CloudSearch.CreateDomainRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.LimitExceededException|any, data: CloudSearch.CreateDomainResponse|any) => void): Request;
+      defineIndexField(params: CloudSearch.DefineIndexFieldRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.LimitExceededException|CloudSearch.InvalidTypeException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DefineIndexFieldResponse|any) => void): Request;
+      defineRankExpression(params: CloudSearch.DefineRankExpressionRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.LimitExceededException|CloudSearch.InvalidTypeException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DefineRankExpressionResponse|any) => void): Request;
+      deleteDomain(params: CloudSearch.DeleteDomainRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|any, data: CloudSearch.DeleteDomainResponse|any) => void): Request;
+      deleteIndexField(params: CloudSearch.DeleteIndexFieldRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DeleteIndexFieldResponse|any) => void): Request;
+      deleteRankExpression(params: CloudSearch.DeleteRankExpressionRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DeleteRankExpressionResponse|any) => void): Request;
+      describeAvailabilityOptions(params: CloudSearch.DescribeAvailabilityOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.LimitExceededException|CloudSearch.ResourceNotFoundException|CloudSearch.DisabledOperationException|any, data: CloudSearch.DescribeAvailabilityOptionsResponse|any) => void): Request;
+      describeDefaultSearchField(params: CloudSearch.DescribeDefaultSearchFieldRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeDefaultSearchFieldResponse|any) => void): Request;
+      describeDomains(params: CloudSearch.DescribeDomainsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|any, data: CloudSearch.DescribeDomainsResponse|any) => void): Request;
+      describeIndexFields(params: CloudSearch.DescribeIndexFieldsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeIndexFieldsResponse|any) => void): Request;
+      describeRankExpressions(params: CloudSearch.DescribeRankExpressionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeRankExpressionsResponse|any) => void): Request;
+      describeServiceAccessPolicies(params: CloudSearch.DescribeServiceAccessPoliciesRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeServiceAccessPoliciesResponse|any) => void): Request;
+      describeStemmingOptions(params: CloudSearch.DescribeStemmingOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeStemmingOptionsResponse|any) => void): Request;
+      describeStopwordOptions(params: CloudSearch.DescribeStopwordOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeStopwordOptionsResponse|any) => void): Request;
+      describeSynonymOptions(params: CloudSearch.DescribeSynonymOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.DescribeSynonymOptionsResponse|any) => void): Request;
+      indexDocuments(params: CloudSearch.IndexDocumentsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.IndexDocumentsResponse|any) => void): Request;
+      updateAvailabilityOptions(params: CloudSearch.UpdateAvailabilityOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.LimitExceededException|CloudSearch.ResourceNotFoundException|CloudSearch.DisabledOperationException|any, data: CloudSearch.UpdateAvailabilityOptionsResponse|any) => void): Request;
+      updateDefaultSearchField(params: CloudSearch.UpdateDefaultSearchFieldRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.UpdateDefaultSearchFieldResponse|any) => void): Request;
+      updateServiceAccessPolicies(params: CloudSearch.UpdateServiceAccessPoliciesRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.LimitExceededException|CloudSearch.ResourceNotFoundException|CloudSearch.InvalidTypeException|any, data: CloudSearch.UpdateServiceAccessPoliciesResponse|any) => void): Request;
+      updateStemmingOptions(params: CloudSearch.UpdateStemmingOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.LimitExceededException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.UpdateStemmingOptionsResponse|any) => void): Request;
+      updateStopwordOptions(params: CloudSearch.UpdateStopwordOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.LimitExceededException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.UpdateStopwordOptionsResponse|any) => void): Request;
+      updateSynonymOptions(params: CloudSearch.UpdateSynonymOptionsRequest, callback?: (err: CloudSearch.BaseException|CloudSearch.InternalException|CloudSearch.InvalidTypeException|CloudSearch.LimitExceededException|CloudSearch.ResourceNotFoundException|any, data: CloudSearch.UpdateSynonymOptionsResponse|any) => void): Request;
+    }
+    
+    export module CloudSearch {
+        export type Arn = string;
+        export type Boolean = boolean;
+        export type DocumentCount = number;
+        export type DomainId = string;    // max: 64, min: 1
+        export type DomainName = string;    // pattern: &quot;[a-z][a-z0-9\-]+&quot;, max: 28, min: 3
+        export type DomainNameList = DomainName[];
+        export type DomainStatusList = DomainStatus[];
+        export type ErrorCode = string;
+        export type ErrorMessage = string;
+        export type FieldName = string;    // pattern: &quot;[a-z][a-z0-9_]*&quot;, max: 64, min: 1
+        export type FieldNameList = FieldName[];
+        export type FieldValue = string;    // max: 1024
+        export type IndexFieldStatusList = IndexFieldStatus[];
+        export type IndexFieldType = string;
+        export type InstanceCount = number;    // min: 1
+        export type Language = string;    // pattern: &quot;[a-zA-Z]{2,8}(?:-[a-zA-Z]{2,8})*&quot;
+        export type MultiAZ = boolean;
+        export type OptionState = string;
+        export type PartitionCount = number;    // min: 1
+        export type PolicyDocument = string;
+        export type RankExpression = string;    // max: 10240, min: 1
+        export type RankExpressionStatusList = RankExpressionStatus[];
+        export type SearchInstanceType = string;
+        export type ServiceUrl = string;
+        export type SourceAttributeList = SourceAttribute[];
+        export type SourceDataFunction = string;
+        export type StemsDocument = string;
+        export type StopwordsDocument = string;
+        export type String = string;
+        export type StringCaseMap = {[key:string]: FieldValue};
+        export type SynonymsDocument = string;
+        export type UIntValue = number;
+        export type UpdateTimestamp = number;
+
+        export interface AccessPoliciesStatus {
+            Options: PolicyDocument;            
+            Status: OptionStatus;            
+        }
+        export interface AvailabilityOptionsStatus {
+            Options: MultiAZ;            
+            Status: OptionStatus;            
+        }
+        export interface BaseException {
+            Code?: ErrorCode;            
+            Message?: ErrorMessage;            
+        }
+        export interface CreateDomainRequest {
+            DomainName: DomainName;            
+        }
+        export interface CreateDomainResponse {
+            DomainStatus?: DomainStatus;            
+        }
+        export interface DefaultSearchFieldStatus {
+            Options: FieldName;            
+            Status: OptionStatus;            
+        }
+        export interface DefineIndexFieldRequest {
+            DomainName: DomainName;            
+            IndexField: IndexField;            
+        }
+        export interface DefineIndexFieldResponse {
+            IndexField: IndexFieldStatus;            
+        }
+        export interface DefineRankExpressionRequest {
+            DomainName: DomainName;            
+            RankExpression: NamedRankExpression;            
+        }
+        export interface DefineRankExpressionResponse {
+            RankExpression: RankExpressionStatus;            
+        }
+        export interface DeleteDomainRequest {
+            DomainName: DomainName;            
+        }
+        export interface DeleteDomainResponse {
+            DomainStatus?: DomainStatus;            
+        }
+        export interface DeleteIndexFieldRequest {
+            DomainName: DomainName;            
+            IndexFieldName: FieldName;            
+        }
+        export interface DeleteIndexFieldResponse {
+            IndexField: IndexFieldStatus;            
+        }
+        export interface DeleteRankExpressionRequest {
+            DomainName: DomainName;            
+            RankName: FieldName;            
+        }
+        export interface DeleteRankExpressionResponse {
+            RankExpression: RankExpressionStatus;            
+        }
+        export interface DescribeAvailabilityOptionsRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeAvailabilityOptionsResponse {
+            AvailabilityOptions?: AvailabilityOptionsStatus;            
+        }
+        export interface DescribeDefaultSearchFieldRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeDefaultSearchFieldResponse {
+            DefaultSearchField: DefaultSearchFieldStatus;            
+        }
+        export interface DescribeDomainsRequest {
+            DomainNames?: DomainNameList;            
+        }
+        export interface DescribeDomainsResponse {
+            DomainStatusList: DomainStatusList;            
+        }
+        export interface DescribeIndexFieldsRequest {
+            DomainName: DomainName;            
+            FieldNames?: FieldNameList;            
+        }
+        export interface DescribeIndexFieldsResponse {
+            IndexFields: IndexFieldStatusList;            
+        }
+        export interface DescribeRankExpressionsRequest {
+            DomainName: DomainName;            
+            RankNames?: FieldNameList;            
+        }
+        export interface DescribeRankExpressionsResponse {
+            RankExpressions: RankExpressionStatusList;            
+        }
+        export interface DescribeServiceAccessPoliciesRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeServiceAccessPoliciesResponse {
+            AccessPolicies: AccessPoliciesStatus;            
+        }
+        export interface DescribeStemmingOptionsRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeStemmingOptionsResponse {
+            Stems: StemmingOptionsStatus;            
+        }
+        export interface DescribeStopwordOptionsRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeStopwordOptionsResponse {
+            Stopwords: StopwordOptionsStatus;            
+        }
+        export interface DescribeSynonymOptionsRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeSynonymOptionsResponse {
+            Synonyms: SynonymOptionsStatus;            
+        }
+        export interface DisabledOperationException {
+        }
+        export interface DomainStatus {
+            DomainId: DomainId;            
+            DomainName: DomainName;            
+            Created?: Boolean;            
+            Deleted?: Boolean;            
+            NumSearchableDocs?: DocumentCount;            
+            DocService?: ServiceEndpoint;            
+            SearchService?: ServiceEndpoint;            
+            RequiresIndexDocuments: Boolean;            
+            Processing?: Boolean;            
+            SearchInstanceType?: SearchInstanceType;            
+            SearchPartitionCount?: PartitionCount;            
+            SearchInstanceCount?: InstanceCount;            
+        }
+        export interface IndexDocumentsRequest {
+            DomainName: DomainName;            
+        }
+        export interface IndexDocumentsResponse {
+            FieldNames?: FieldNameList;            
+        }
+        export interface IndexField {
+            IndexFieldName: FieldName;            
+            IndexFieldType: IndexFieldType;            
+            UIntOptions?: UIntOptions;            
+            LiteralOptions?: LiteralOptions;            
+            TextOptions?: TextOptions;            
+            SourceAttributes?: SourceAttributeList;            
+        }
+        export interface IndexFieldStatus {
+            Options: IndexField;            
+            Status: OptionStatus;            
+        }
+        export interface InternalException {
+        }
+        export interface InvalidTypeException {
+        }
+        export interface LimitExceededException {
+        }
+        export interface LiteralOptions {
+            DefaultValue?: FieldValue;            
+            SearchEnabled?: Boolean;            
+            FacetEnabled?: Boolean;            
+            ResultEnabled?: Boolean;            
+        }
+        export interface NamedRankExpression {
+            RankName: FieldName;            
+            RankExpression: RankExpression;            
+        }
+        export interface OptionStatus {
+            CreationDate: UpdateTimestamp;            
+            UpdateDate: UpdateTimestamp;            
+            UpdateVersion?: UIntValue;            
+            State: OptionState;            
+            PendingDeletion?: Boolean;            
+        }
+        export interface RankExpressionStatus {
+            Options: NamedRankExpression;            
+            Status: OptionStatus;            
+        }
+        export interface ResourceNotFoundException {
+        }
+        export interface ServiceEndpoint {
+            Arn?: Arn;            
+            Endpoint?: ServiceUrl;            
+        }
+        export interface SourceAttribute {
+            SourceDataFunction: SourceDataFunction;            
+            SourceDataCopy?: SourceData;            
+            SourceDataTrimTitle?: SourceDataTrimTitle;            
+            SourceDataMap?: SourceDataMap;            
+        }
+        export interface SourceData {
+            SourceName: FieldName;            
+            DefaultValue?: FieldValue;            
+        }
+        export interface SourceDataMap {
+            SourceName: FieldName;            
+            DefaultValue?: FieldValue;            
+            Cases?: StringCaseMap;            
+        }
+        export interface SourceDataTrimTitle {
+            SourceName: FieldName;            
+            DefaultValue?: FieldValue;            
+            Separator?: String;            
+            Language?: Language;            
+        }
+        export interface StemmingOptionsStatus {
+            Options: StemsDocument;            
+            Status: OptionStatus;            
+        }
+        export interface StopwordOptionsStatus {
+            Options: StopwordsDocument;            
+            Status: OptionStatus;            
+        }
+        export interface SynonymOptionsStatus {
+            Options: SynonymsDocument;            
+            Status: OptionStatus;            
+        }
+        export interface TextOptions {
+            DefaultValue?: FieldValue;            
+            FacetEnabled?: Boolean;            
+            ResultEnabled?: Boolean;            
+            TextProcessor?: FieldName;            
+        }
+        export interface UIntOptions {
+            DefaultValue?: UIntValue;            
+        }
+        export interface UpdateAvailabilityOptionsRequest {
+            DomainName: DomainName;            
+            MultiAZ: Boolean;            
+        }
+        export interface UpdateAvailabilityOptionsResponse {
+            AvailabilityOptions?: AvailabilityOptionsStatus;            
+        }
+        export interface UpdateDefaultSearchFieldRequest {
+            DomainName: DomainName;            
+            DefaultSearchField: String;            
+        }
+        export interface UpdateDefaultSearchFieldResponse {
+            DefaultSearchField: DefaultSearchFieldStatus;            
+        }
+        export interface UpdateServiceAccessPoliciesRequest {
+            DomainName: DomainName;            
+            AccessPolicies: PolicyDocument;            
+        }
+        export interface UpdateServiceAccessPoliciesResponse {
+            AccessPolicies: AccessPoliciesStatus;            
+        }
+        export interface UpdateStemmingOptionsRequest {
+            DomainName: DomainName;            
+            Stems: StemsDocument;            
+        }
+        export interface UpdateStemmingOptionsResponse {
+            Stems: StemmingOptionsStatus;            
+        }
+        export interface UpdateStopwordOptionsRequest {
+            DomainName: DomainName;            
+            Stopwords: StopwordsDocument;            
+        }
+        export interface UpdateStopwordOptionsResponse {
+            Stopwords: StopwordOptionsStatus;            
+        }
+        export interface UpdateSynonymOptionsRequest {
+            DomainName: DomainName;            
+            Synonyms: SynonymsDocument;            
+        }
+        export interface UpdateSynonymOptionsResponse {
+            Synonyms: SynonymOptionsStatus;            
+        }
 
-    export interface CloudSearchSourceDataTrimTitle {
-        SourceName: CloudSearchFieldName;
-        DefaultValue?: CloudSearchFieldValue;
-        Separator?: CloudSearchString;
-        Language?: CloudSearchLanguage;
     }
-
-    export interface CloudSearchStemmingOptionsStatus {
-        Options: CloudSearchStemsDocument;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export type CloudSearchStemsDocument = string;
-    export interface CloudSearchStopwordOptionsStatus {
-        Options: CloudSearchStopwordsDocument;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export type CloudSearchStopwordsDocument = string;
-    export type CloudSearchString = string;
-    export type CloudSearchStringCaseMap = any; // not really - it was 'map' instead - must fix this one
-    export interface CloudSearchSynonymOptionsStatus {
-        Options: CloudSearchSynonymsDocument;
-        Status: CloudSearchOptionStatus;
-    }
-
-    export type CloudSearchSynonymsDocument = string;
-    export interface CloudSearchTextOptions {
-        DefaultValue?: CloudSearchFieldValue;
-        FacetEnabled?: CloudSearchBoolean;
-        ResultEnabled?: CloudSearchBoolean;
-        TextProcessor?: CloudSearchFieldName;
-    }
-
-    export interface CloudSearchUIntOptions {
-        DefaultValue?: CloudSearchUIntValue;
-    }
-
-    export type CloudSearchUIntValue = number;
-    export interface CloudSearchUpdateAvailabilityOptionsRequest {
-        DomainName: CloudSearchDomainName;
-        MultiAZ: CloudSearchBoolean;
-    }
-
-    export interface CloudSearchUpdateAvailabilityOptionsResponse {
-        AvailabilityOptions?: CloudSearchAvailabilityOptionsStatus;
-    }
-
-    export interface CloudSearchUpdateDefaultSearchFieldRequest {
-        DomainName: CloudSearchDomainName;
-        DefaultSearchField: CloudSearchString;
-    }
-
-    export interface CloudSearchUpdateDefaultSearchFieldResponse {
-        DefaultSearchField: CloudSearchDefaultSearchFieldStatus;
-    }
-
-    export interface CloudSearchUpdateServiceAccessPoliciesRequest {
-        DomainName: CloudSearchDomainName;
-        AccessPolicies: CloudSearchPolicyDocument;
-    }
-
-    export interface CloudSearchUpdateServiceAccessPoliciesResponse {
-        AccessPolicies: CloudSearchAccessPoliciesStatus;
-    }
-
-    export interface CloudSearchUpdateStemmingOptionsRequest {
-        DomainName: CloudSearchDomainName;
-        Stems: CloudSearchStemsDocument;
-    }
-
-    export interface CloudSearchUpdateStemmingOptionsResponse {
-        Stems: CloudSearchStemmingOptionsStatus;
-    }
-
-    export interface CloudSearchUpdateStopwordOptionsRequest {
-        DomainName: CloudSearchDomainName;
-        Stopwords: CloudSearchStopwordsDocument;
-    }
-
-    export interface CloudSearchUpdateStopwordOptionsResponse {
-        Stopwords: CloudSearchStopwordOptionsStatus;
-    }
-
-    export interface CloudSearchUpdateSynonymOptionsRequest {
-        DomainName: CloudSearchDomainName;
-        Synonyms: CloudSearchSynonymsDocument;
-    }
-
-    export interface CloudSearchUpdateSynonymOptionsResponse {
-        Synonyms: CloudSearchSynonymOptionsStatus;
-    }
-
-    export type CloudSearchUpdateTimestamp = number;
 }

--- a/output/aws-cloudsearchdomain.d.ts
+++ b/output/aws-cloudsearchdomain.d.ts
@@ -6,142 +6,129 @@ declare module "aws-sdk" {
 
     export class CloudSearchDomain extends Service {
       constructor(options?: any);
-      search(params: CloudSearchDomainSearchRequest, callback?: (err: CloudSearchDomainSearchException|any, data: CloudSearchDomainSearchResponse|any) => void): Request;
-      suggest(params: CloudSearchDomainSuggestRequest, callback?: (err: CloudSearchDomainSearchException|any, data: CloudSearchDomainSuggestResponse|any) => void): Request;
-      uploadDocuments(params: CloudSearchDomainUploadDocumentsRequest, callback?: (err: CloudSearchDomainDocumentServiceException|any, data: CloudSearchDomainUploadDocumentsResponse|any) => void): Request;
+      search(params: CloudSearchDomain.SearchRequest, callback?: (err: CloudSearchDomain.SearchException|any, data: CloudSearchDomain.SearchResponse|any) => void): Request;
+      suggest(params: CloudSearchDomain.SuggestRequest, callback?: (err: CloudSearchDomain.SearchException|any, data: CloudSearchDomain.SuggestResponse|any) => void): Request;
+      uploadDocuments(params: CloudSearchDomain.UploadDocumentsRequest, callback?: (err: CloudSearchDomain.DocumentServiceException|any, data: CloudSearchDomain.UploadDocumentsResponse|any) => void): Request;
     }
+    
+    export module CloudSearchDomain {
+        export type Adds = number;
+        export type Blob = any;    // type: blob
+        export type BucketList = Bucket[];
+        export type ContentType = string;
+        export type Cursor = string;
+        export type Deletes = number;
+        export type DocumentServiceWarnings = DocumentServiceWarning[];
+        export type Expr = string;
+        export type Exprs = {[key:string]: String};
+        export type Facet = string;
+        export type Facets = {[key:string]: BucketInfo};
+        export type FieldValue = String[];
+        export type Fields = {[key:string]: FieldValue};
+        export type FilterQuery = string;
+        export type Highlight = string;
+        export type Highlights = {[key:string]: String};
+        export type HitList = Hit[];
+        export type Long = number;
+        export type Partial = boolean;
+        export type Query = string;
+        export type QueryOptions = string;
+        export type QueryParser = string;
+        export type Return = string;
+        export type Size = number;
+        export type Sort = string;
+        export type Start = number;
+        export type String = string;
+        export type Suggester = string;
+        export type Suggestions = SuggestionMatch[];
+        export type SuggestionsSize = number;
 
-    export type CloudSearchDomainAdds = number;
-    export type CloudSearchDomainBlob = any; // not really - it was 'blob' instead - must fix this one
-    export interface CloudSearchDomainBucket {
-        value?: CloudSearchDomainString;
-        count?: CloudSearchDomainLong;
+        export interface Bucket {
+            value?: String;            
+            count?: Long;            
+        }
+        export interface BucketInfo {
+            buckets?: BucketList;            
+        }
+        export interface DocumentServiceException {
+            status?: String;            
+            message?: String;            
+        }
+        export interface DocumentServiceWarning {
+            message?: String;            
+        }
+        export interface Hit {
+            id?: String;            
+            fields?: Fields;            
+            exprs?: Exprs;            
+            highlights?: Highlights;            
+        }
+        export interface Hits {
+            found?: Long;            
+            start?: Long;            
+            cursor?: String;            
+            hit?: HitList;            
+        }
+        export interface SearchException {
+            message?: String;            
+        }
+        export interface SearchRequest {
+            cursor?: Cursor;            
+            expr?: Expr;            
+            facet?: Facet;            
+            filterQuery?: FilterQuery;            
+            highlight?: Highlight;            
+            partial?: Partial;            
+            query: Query;            
+            queryOptions?: QueryOptions;            
+            queryParser?: QueryParser;            
+            return?: Return;            
+            size?: Size;            
+            sort?: Sort;            
+            start?: Start;            
+        }
+        export interface SearchResponse {
+            status?: SearchStatus;            
+            hits?: Hits;            
+            facets?: Facets;            
+        }
+        export interface SearchStatus {
+            timems?: Long;            
+            rid?: String;            
+        }
+        export interface SuggestModel {
+            query?: String;            
+            found?: Long;            
+            suggestions?: Suggestions;            
+        }
+        export interface SuggestRequest {
+            query: Query;            
+            suggester: Suggester;            
+            size?: SuggestionsSize;            
+        }
+        export interface SuggestResponse {
+            status?: SuggestStatus;            
+            suggest?: SuggestModel;            
+        }
+        export interface SuggestStatus {
+            timems?: Long;            
+            rid?: String;            
+        }
+        export interface SuggestionMatch {
+            suggestion?: String;            
+            score?: Long;            
+            id?: String;            
+        }
+        export interface UploadDocumentsRequest {
+            documents: Blob;            
+            contentType: ContentType;            
+        }
+        export interface UploadDocumentsResponse {
+            status?: String;            
+            adds?: Adds;            
+            deletes?: Deletes;            
+            warnings?: DocumentServiceWarnings;            
+        }
+
     }
-
-    export interface CloudSearchDomainBucketInfo {
-        buckets?: CloudSearchDomainBucketList;
-    }
-
-    export type CloudSearchDomainBucketList = Array<CloudSearchDomainBucket>;
-    export type CloudSearchDomainContentType = string;
-    export type CloudSearchDomainCursor = string;
-    export type CloudSearchDomainDeletes = number;
-    export interface CloudSearchDomainDocumentServiceException {
-        status?: CloudSearchDomainString;
-        message?: CloudSearchDomainString;
-    }
-
-    export interface CloudSearchDomainDocumentServiceWarning {
-        message?: CloudSearchDomainString;
-    }
-
-    export type CloudSearchDomainDocumentServiceWarnings = Array<CloudSearchDomainDocumentServiceWarning>;
-    export type CloudSearchDomainExpr = string;
-    export type CloudSearchDomainExprs = any; // not really - it was 'map' instead - must fix this one
-    export type CloudSearchDomainFacet = string;
-    export type CloudSearchDomainFacets = any; // not really - it was 'map' instead - must fix this one
-    export type CloudSearchDomainFieldValue = Array<CloudSearchDomainString>;
-    export type CloudSearchDomainFields = any; // not really - it was 'map' instead - must fix this one
-    export type CloudSearchDomainFilterQuery = string;
-    export type CloudSearchDomainHighlight = string;
-    export type CloudSearchDomainHighlights = any; // not really - it was 'map' instead - must fix this one
-    export interface CloudSearchDomainHit {
-        id?: CloudSearchDomainString;
-        fields?: CloudSearchDomainFields;
-        exprs?: CloudSearchDomainExprs;
-        highlights?: CloudSearchDomainHighlights;
-    }
-
-    export type CloudSearchDomainHitList = Array<CloudSearchDomainHit>;
-    export interface CloudSearchDomainHits {
-        found?: CloudSearchDomainLong;
-        start?: CloudSearchDomainLong;
-        cursor?: CloudSearchDomainString;
-        hit?: CloudSearchDomainHitList;
-    }
-
-    export type CloudSearchDomainLong = number;
-    export type CloudSearchDomainPartial = boolean;
-    export type CloudSearchDomainQuery = string;
-    export type CloudSearchDomainQueryOptions = string;
-    export type CloudSearchDomainQueryParser = string;
-    export type CloudSearchDomainReturn = string;
-    export interface CloudSearchDomainSearchException {
-        message?: CloudSearchDomainString;
-    }
-
-    export interface CloudSearchDomainSearchRequest {
-        cursor?: CloudSearchDomainCursor;
-        expr?: CloudSearchDomainExpr;
-        facet?: CloudSearchDomainFacet;
-        filterQuery?: CloudSearchDomainFilterQuery;
-        highlight?: CloudSearchDomainHighlight;
-        partial?: CloudSearchDomainPartial;
-        query: CloudSearchDomainQuery;
-        queryOptions?: CloudSearchDomainQueryOptions;
-        queryParser?: CloudSearchDomainQueryParser;
-        return?: CloudSearchDomainReturn;
-        size?: CloudSearchDomainSize;
-        sort?: CloudSearchDomainSort;
-        start?: CloudSearchDomainStart;
-    }
-
-    export interface CloudSearchDomainSearchResponse {
-        status?: CloudSearchDomainSearchStatus;
-        hits?: CloudSearchDomainHits;
-        facets?: CloudSearchDomainFacets;
-    }
-
-    export interface CloudSearchDomainSearchStatus {
-        timems?: CloudSearchDomainLong;
-        rid?: CloudSearchDomainString;
-    }
-
-    export type CloudSearchDomainSize = number;
-    export type CloudSearchDomainSort = string;
-    export type CloudSearchDomainStart = number;
-    export type CloudSearchDomainString = string;
-    export interface CloudSearchDomainSuggestModel {
-        query?: CloudSearchDomainString;
-        found?: CloudSearchDomainLong;
-        suggestions?: CloudSearchDomainSuggestions;
-    }
-
-    export interface CloudSearchDomainSuggestRequest {
-        query: CloudSearchDomainQuery;
-        suggester: CloudSearchDomainSuggester;
-        size?: CloudSearchDomainSuggestionsSize;
-    }
-
-    export interface CloudSearchDomainSuggestResponse {
-        status?: CloudSearchDomainSuggestStatus;
-        suggest?: CloudSearchDomainSuggestModel;
-    }
-
-    export interface CloudSearchDomainSuggestStatus {
-        timems?: CloudSearchDomainLong;
-        rid?: CloudSearchDomainString;
-    }
-
-    export type CloudSearchDomainSuggester = string;
-    export interface CloudSearchDomainSuggestionMatch {
-        suggestion?: CloudSearchDomainString;
-        score?: CloudSearchDomainLong;
-        id?: CloudSearchDomainString;
-    }
-
-    export type CloudSearchDomainSuggestions = Array<CloudSearchDomainSuggestionMatch>;
-    export type CloudSearchDomainSuggestionsSize = number;
-    export interface CloudSearchDomainUploadDocumentsRequest {
-        documents: CloudSearchDomainBlob;
-        contentType: CloudSearchDomainContentType;
-    }
-
-    export interface CloudSearchDomainUploadDocumentsResponse {
-        status?: CloudSearchDomainString;
-        adds?: CloudSearchDomainAdds;
-        deletes?: CloudSearchDomainDeletes;
-        warnings?: CloudSearchDomainDocumentServiceWarnings;
-    }
-
 }

--- a/output/aws-cloudtrail.d.ts
+++ b/output/aws-cloudtrail.d.ts
@@ -6,326 +6,269 @@ declare module "aws-sdk" {
 
     export class CloudTrail extends Service {
       constructor(options?: any);
-      addTags(params: CloudTrailAddTagsRequest, callback?: (err: CloudTrailResourceNotFoundException|CloudTrailCloudTrailARNInvalidException|CloudTrailResourceTypeNotSupportedException|CloudTrailTagsLimitExceededException|CloudTrailInvalidTrailNameException|CloudTrailInvalidTagParameterException|CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|any, data: CloudTrailAddTagsResponse|any) => void): Request;
-      createTrail(params: CloudTrailCreateTrailRequest, callback?: (err: CloudTrailMaximumNumberOfTrailsExceededException|CloudTrailTrailAlreadyExistsException|CloudTrailS3BucketDoesNotExistException|CloudTrailInsufficientS3BucketPolicyException|CloudTrailInsufficientSnsTopicPolicyException|CloudTrailInsufficientEncryptionPolicyException|CloudTrailInvalidS3BucketNameException|CloudTrailInvalidS3PrefixException|CloudTrailInvalidSnsTopicNameException|CloudTrailInvalidKmsKeyIdException|CloudTrailInvalidTrailNameException|CloudTrailTrailNotProvidedException|CloudTrailKmsKeyNotFoundException|CloudTrailKmsKeyDisabledException|CloudTrailInvalidCloudWatchLogsLogGroupArnException|CloudTrailInvalidCloudWatchLogsRoleArnException|CloudTrailCloudWatchLogsDeliveryUnavailableException|CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|any, data: CloudTrailCreateTrailResponse|any) => void): Request;
-      deleteTrail(params: CloudTrailDeleteTrailRequest, callback?: (err: CloudTrailTrailNotFoundException|CloudTrailInvalidTrailNameException|any, data: CloudTrailDeleteTrailResponse|any) => void): Request;
-      describeTrails(params: CloudTrailDescribeTrailsRequest, callback?: (err: CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|any, data: CloudTrailDescribeTrailsResponse|any) => void): Request;
-      getTrailStatus(params: CloudTrailGetTrailStatusRequest, callback?: (err: CloudTrailTrailNotFoundException|CloudTrailInvalidTrailNameException|any, data: CloudTrailGetTrailStatusResponse|any) => void): Request;
-      listPublicKeys(params: CloudTrailListPublicKeysRequest, callback?: (err: CloudTrailInvalidTimeRangeException|CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|CloudTrailInvalidTokenException|any, data: CloudTrailListPublicKeysResponse|any) => void): Request;
-      listTags(params: CloudTrailListTagsRequest, callback?: (err: CloudTrailResourceNotFoundException|CloudTrailCloudTrailARNInvalidException|CloudTrailResourceTypeNotSupportedException|CloudTrailInvalidTrailNameException|CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|CloudTrailInvalidTokenException|any, data: CloudTrailListTagsResponse|any) => void): Request;
-      lookupEvents(params: CloudTrailLookupEventsRequest, callback?: (err: CloudTrailInvalidLookupAttributesException|CloudTrailInvalidTimeRangeException|CloudTrailInvalidMaxResultsException|CloudTrailInvalidNextTokenException|any, data: CloudTrailLookupEventsResponse|any) => void): Request;
-      removeTags(params: CloudTrailRemoveTagsRequest, callback?: (err: CloudTrailResourceNotFoundException|CloudTrailCloudTrailARNInvalidException|CloudTrailResourceTypeNotSupportedException|CloudTrailInvalidTrailNameException|CloudTrailInvalidTagParameterException|CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|any, data: CloudTrailRemoveTagsResponse|any) => void): Request;
-      startLogging(params: CloudTrailStartLoggingRequest, callback?: (err: CloudTrailTrailNotFoundException|CloudTrailInvalidTrailNameException|any, data: CloudTrailStartLoggingResponse|any) => void): Request;
-      stopLogging(params: CloudTrailStopLoggingRequest, callback?: (err: CloudTrailTrailNotFoundException|CloudTrailInvalidTrailNameException|any, data: CloudTrailStopLoggingResponse|any) => void): Request;
-      updateTrail(params: CloudTrailUpdateTrailRequest, callback?: (err: CloudTrailS3BucketDoesNotExistException|CloudTrailInsufficientS3BucketPolicyException|CloudTrailInsufficientSnsTopicPolicyException|CloudTrailInsufficientEncryptionPolicyException|CloudTrailTrailNotFoundException|CloudTrailInvalidS3BucketNameException|CloudTrailInvalidS3PrefixException|CloudTrailInvalidSnsTopicNameException|CloudTrailInvalidKmsKeyIdException|CloudTrailInvalidTrailNameException|CloudTrailTrailNotProvidedException|CloudTrailKmsKeyNotFoundException|CloudTrailKmsKeyDisabledException|CloudTrailInvalidCloudWatchLogsLogGroupArnException|CloudTrailInvalidCloudWatchLogsRoleArnException|CloudTrailCloudWatchLogsDeliveryUnavailableException|CloudTrailUnsupportedOperationException|CloudTrailOperationNotPermittedException|any, data: CloudTrailUpdateTrailResponse|any) => void): Request;
+      addTags(params: CloudTrail.AddTagsRequest, callback?: (err: CloudTrail.ResourceNotFoundException|CloudTrail.CloudTrailARNInvalidException|CloudTrail.ResourceTypeNotSupportedException|CloudTrail.TagsLimitExceededException|CloudTrail.InvalidTrailNameException|CloudTrail.InvalidTagParameterException|CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|any, data: CloudTrail.AddTagsResponse|any) => void): Request;
+      createTrail(params: CloudTrail.CreateTrailRequest, callback?: (err: CloudTrail.MaximumNumberOfTrailsExceededException|CloudTrail.TrailAlreadyExistsException|CloudTrail.S3BucketDoesNotExistException|CloudTrail.InsufficientS3BucketPolicyException|CloudTrail.InsufficientSnsTopicPolicyException|CloudTrail.InsufficientEncryptionPolicyException|CloudTrail.InvalidS3BucketNameException|CloudTrail.InvalidS3PrefixException|CloudTrail.InvalidSnsTopicNameException|CloudTrail.InvalidKmsKeyIdException|CloudTrail.InvalidTrailNameException|CloudTrail.TrailNotProvidedException|CloudTrail.KmsKeyNotFoundException|CloudTrail.KmsKeyDisabledException|CloudTrail.InvalidCloudWatchLogsLogGroupArnException|CloudTrail.InvalidCloudWatchLogsRoleArnException|CloudTrail.CloudWatchLogsDeliveryUnavailableException|CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|any, data: CloudTrail.CreateTrailResponse|any) => void): Request;
+      deleteTrail(params: CloudTrail.DeleteTrailRequest, callback?: (err: CloudTrail.TrailNotFoundException|CloudTrail.InvalidTrailNameException|any, data: CloudTrail.DeleteTrailResponse|any) => void): Request;
+      describeTrails(params: CloudTrail.DescribeTrailsRequest, callback?: (err: CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|any, data: CloudTrail.DescribeTrailsResponse|any) => void): Request;
+      getTrailStatus(params: CloudTrail.GetTrailStatusRequest, callback?: (err: CloudTrail.TrailNotFoundException|CloudTrail.InvalidTrailNameException|any, data: CloudTrail.GetTrailStatusResponse|any) => void): Request;
+      listPublicKeys(params: CloudTrail.ListPublicKeysRequest, callback?: (err: CloudTrail.InvalidTimeRangeException|CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|CloudTrail.InvalidTokenException|any, data: CloudTrail.ListPublicKeysResponse|any) => void): Request;
+      listTags(params: CloudTrail.ListTagsRequest, callback?: (err: CloudTrail.ResourceNotFoundException|CloudTrail.CloudTrailARNInvalidException|CloudTrail.ResourceTypeNotSupportedException|CloudTrail.InvalidTrailNameException|CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|CloudTrail.InvalidTokenException|any, data: CloudTrail.ListTagsResponse|any) => void): Request;
+      lookupEvents(params: CloudTrail.LookupEventsRequest, callback?: (err: CloudTrail.InvalidLookupAttributesException|CloudTrail.InvalidTimeRangeException|CloudTrail.InvalidMaxResultsException|CloudTrail.InvalidNextTokenException|any, data: CloudTrail.LookupEventsResponse|any) => void): Request;
+      removeTags(params: CloudTrail.RemoveTagsRequest, callback?: (err: CloudTrail.ResourceNotFoundException|CloudTrail.CloudTrailARNInvalidException|CloudTrail.ResourceTypeNotSupportedException|CloudTrail.InvalidTrailNameException|CloudTrail.InvalidTagParameterException|CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|any, data: CloudTrail.RemoveTagsResponse|any) => void): Request;
+      startLogging(params: CloudTrail.StartLoggingRequest, callback?: (err: CloudTrail.TrailNotFoundException|CloudTrail.InvalidTrailNameException|any, data: CloudTrail.StartLoggingResponse|any) => void): Request;
+      stopLogging(params: CloudTrail.StopLoggingRequest, callback?: (err: CloudTrail.TrailNotFoundException|CloudTrail.InvalidTrailNameException|any, data: CloudTrail.StopLoggingResponse|any) => void): Request;
+      updateTrail(params: CloudTrail.UpdateTrailRequest, callback?: (err: CloudTrail.S3BucketDoesNotExistException|CloudTrail.InsufficientS3BucketPolicyException|CloudTrail.InsufficientSnsTopicPolicyException|CloudTrail.InsufficientEncryptionPolicyException|CloudTrail.TrailNotFoundException|CloudTrail.InvalidS3BucketNameException|CloudTrail.InvalidS3PrefixException|CloudTrail.InvalidSnsTopicNameException|CloudTrail.InvalidKmsKeyIdException|CloudTrail.InvalidTrailNameException|CloudTrail.TrailNotProvidedException|CloudTrail.KmsKeyNotFoundException|CloudTrail.KmsKeyDisabledException|CloudTrail.InvalidCloudWatchLogsLogGroupArnException|CloudTrail.InvalidCloudWatchLogsRoleArnException|CloudTrail.CloudWatchLogsDeliveryUnavailableException|CloudTrail.UnsupportedOperationException|CloudTrail.OperationNotPermittedException|any, data: CloudTrail.UpdateTrailResponse|any) => void): Request;
     }
+    
+    export module CloudTrail {
+        export type Boolean = boolean;
+        export type ByteBuffer = any;    // type: blob
+        export type Date = number;
+        export type EventsList = Event[];
+        export type LookupAttributeKey = string;
+        export type LookupAttributesList = LookupAttribute[];
+        export type MaxResults = number;    // max: 50, min: 1
+        export type NextToken = string;
+        export type PublicKeyList = PublicKey[];
+        export type ResourceIdList = String[];
+        export type ResourceList = Resource[];
+        export type ResourceTagList = ResourceTag[];
+        export type String = string;
+        export type TagsList = Tag[];
+        export type TrailList = Trail[];
+        export type TrailNameList = String[];
 
-    export interface CloudTrailAddTagsRequest {
-        ResourceId: CloudTrailString;
-        TagsList?: CloudTrailTagsList;
+        export interface AddTagsRequest {
+            ResourceId: String;            
+            TagsList?: TagsList;            
+        }
+        export interface AddTagsResponse {
+        }
+        export interface CloudTrailARNInvalidException {
+        }
+        export interface CloudWatchLogsDeliveryUnavailableException {
+        }
+        export interface CreateTrailRequest {
+            Name: String;            
+            S3BucketName: String;            
+            S3KeyPrefix?: String;            
+            SnsTopicName?: String;            
+            IncludeGlobalServiceEvents?: Boolean;            
+            EnableLogFileValidation?: Boolean;            
+            CloudWatchLogsLogGroupArn?: String;            
+            CloudWatchLogsRoleArn?: String;            
+            KmsKeyId?: String;            
+        }
+        export interface CreateTrailResponse {
+            Name?: String;            
+            S3BucketName?: String;            
+            S3KeyPrefix?: String;            
+            SnsTopicName?: String;            
+            IncludeGlobalServiceEvents?: Boolean;            
+            TrailARN?: String;            
+            LogFileValidationEnabled?: Boolean;            
+            CloudWatchLogsLogGroupArn?: String;            
+            CloudWatchLogsRoleArn?: String;            
+            KmsKeyId?: String;            
+        }
+        export interface DeleteTrailRequest {
+            Name: String;            
+        }
+        export interface DeleteTrailResponse {
+        }
+        export interface DescribeTrailsRequest {
+            trailNameList?: TrailNameList;            
+        }
+        export interface DescribeTrailsResponse {
+            trailList?: TrailList;            
+        }
+        export interface Event {
+            EventId?: String;            
+            EventName?: String;            
+            EventTime?: Date;            
+            Username?: String;            
+            Resources?: ResourceList;            
+            CloudTrailEvent?: String;            
+        }
+        export interface GetTrailStatusRequest {
+            Name: String;            
+        }
+        export interface GetTrailStatusResponse {
+            IsLogging?: Boolean;            
+            LatestDeliveryError?: String;            
+            LatestNotificationError?: String;            
+            LatestDeliveryTime?: Date;            
+            LatestNotificationTime?: Date;            
+            StartLoggingTime?: Date;            
+            StopLoggingTime?: Date;            
+            LatestCloudWatchLogsDeliveryError?: String;            
+            LatestCloudWatchLogsDeliveryTime?: Date;            
+            LatestDigestDeliveryTime?: Date;            
+            LatestDigestDeliveryError?: String;            
+            LatestDeliveryAttemptTime?: String;            
+            LatestNotificationAttemptTime?: String;            
+            LatestNotificationAttemptSucceeded?: String;            
+            LatestDeliveryAttemptSucceeded?: String;            
+            TimeLoggingStarted?: String;            
+            TimeLoggingStopped?: String;            
+        }
+        export interface InsufficientEncryptionPolicyException {
+        }
+        export interface InsufficientS3BucketPolicyException {
+        }
+        export interface InsufficientSnsTopicPolicyException {
+        }
+        export interface InvalidCloudWatchLogsLogGroupArnException {
+        }
+        export interface InvalidCloudWatchLogsRoleArnException {
+        }
+        export interface InvalidKmsKeyIdException {
+        }
+        export interface InvalidLookupAttributesException {
+        }
+        export interface InvalidMaxResultsException {
+        }
+        export interface InvalidNextTokenException {
+        }
+        export interface InvalidS3BucketNameException {
+        }
+        export interface InvalidS3PrefixException {
+        }
+        export interface InvalidSnsTopicNameException {
+        }
+        export interface InvalidTagParameterException {
+        }
+        export interface InvalidTimeRangeException {
+        }
+        export interface InvalidTokenException {
+        }
+        export interface InvalidTrailNameException {
+        }
+        export interface KmsKeyDisabledException {
+        }
+        export interface KmsKeyNotFoundException {
+        }
+        export interface ListPublicKeysRequest {
+            StartTime?: Date;            
+            EndTime?: Date;            
+            NextToken?: String;            
+        }
+        export interface ListPublicKeysResponse {
+            PublicKeyList?: PublicKeyList;            
+            NextToken?: String;            
+        }
+        export interface ListTagsRequest {
+            ResourceIdList: ResourceIdList;            
+            NextToken?: String;            
+        }
+        export interface ListTagsResponse {
+            ResourceTagList?: ResourceTagList;            
+            NextToken?: String;            
+        }
+        export interface LookupAttribute {
+            AttributeKey: LookupAttributeKey;            
+            AttributeValue: String;            
+        }
+        export interface LookupEventsRequest {
+            LookupAttributes?: LookupAttributesList;            
+            StartTime?: Date;            
+            EndTime?: Date;            
+            MaxResults?: MaxResults;            
+            NextToken?: NextToken;            
+        }
+        export interface LookupEventsResponse {
+            Events?: EventsList;            
+            NextToken?: NextToken;            
+        }
+        export interface MaximumNumberOfTrailsExceededException {
+        }
+        export interface OperationNotPermittedException {
+        }
+        export interface PublicKey {
+            Value?: ByteBuffer;            
+            ValidityStartTime?: Date;            
+            ValidityEndTime?: Date;            
+            Fingerprint?: String;            
+        }
+        export interface RemoveTagsRequest {
+            ResourceId: String;            
+            TagsList?: TagsList;            
+        }
+        export interface RemoveTagsResponse {
+        }
+        export interface Resource {
+            ResourceType?: String;            
+            ResourceName?: String;            
+        }
+        export interface ResourceNotFoundException {
+        }
+        export interface ResourceTag {
+            ResourceId?: String;            
+            TagsList?: TagsList;            
+        }
+        export interface ResourceTypeNotSupportedException {
+        }
+        export interface S3BucketDoesNotExistException {
+        }
+        export interface StartLoggingRequest {
+            Name: String;            
+        }
+        export interface StartLoggingResponse {
+        }
+        export interface StopLoggingRequest {
+            Name: String;            
+        }
+        export interface StopLoggingResponse {
+        }
+        export interface Tag {
+            Key: String;            
+            Value?: String;            
+        }
+        export interface TagsLimitExceededException {
+        }
+        export interface Trail {
+            Name?: String;            
+            S3BucketName?: String;            
+            S3KeyPrefix?: String;            
+            SnsTopicName?: String;            
+            IncludeGlobalServiceEvents?: Boolean;            
+            TrailARN?: String;            
+            LogFileValidationEnabled?: Boolean;            
+            CloudWatchLogsLogGroupArn?: String;            
+            CloudWatchLogsRoleArn?: String;            
+            KmsKeyId?: String;            
+        }
+        export interface TrailAlreadyExistsException {
+        }
+        export interface TrailNotFoundException {
+        }
+        export interface TrailNotProvidedException {
+        }
+        export interface UnsupportedOperationException {
+        }
+        export interface UpdateTrailRequest {
+            Name: String;            
+            S3BucketName?: String;            
+            S3KeyPrefix?: String;            
+            SnsTopicName?: String;            
+            IncludeGlobalServiceEvents?: Boolean;            
+            EnableLogFileValidation?: Boolean;            
+            CloudWatchLogsLogGroupArn?: String;            
+            CloudWatchLogsRoleArn?: String;            
+            KmsKeyId?: String;            
+        }
+        export interface UpdateTrailResponse {
+            Name?: String;            
+            S3BucketName?: String;            
+            S3KeyPrefix?: String;            
+            SnsTopicName?: String;            
+            IncludeGlobalServiceEvents?: Boolean;            
+            TrailARN?: String;            
+            LogFileValidationEnabled?: Boolean;            
+            CloudWatchLogsLogGroupArn?: String;            
+            CloudWatchLogsRoleArn?: String;            
+            KmsKeyId?: String;            
+        }
+
     }
-
-    export interface CloudTrailAddTagsResponse {
-    }
-
-    export type CloudTrailBoolean = boolean;
-    export type CloudTrailByteBuffer = any; // not really - it was 'blob' instead - must fix this one
-    export interface CloudTrailCloudTrailARNInvalidException {
-    }
-
-    export interface CloudTrailCloudWatchLogsDeliveryUnavailableException {
-    }
-
-    export interface CloudTrailCreateTrailRequest {
-        Name: CloudTrailString;
-        S3BucketName: CloudTrailString;
-        S3KeyPrefix?: CloudTrailString;
-        SnsTopicName?: CloudTrailString;
-        IncludeGlobalServiceEvents?: CloudTrailBoolean;
-        EnableLogFileValidation?: CloudTrailBoolean;
-        CloudWatchLogsLogGroupArn?: CloudTrailString;
-        CloudWatchLogsRoleArn?: CloudTrailString;
-        KmsKeyId?: CloudTrailString;
-    }
-
-    export interface CloudTrailCreateTrailResponse {
-        Name?: CloudTrailString;
-        S3BucketName?: CloudTrailString;
-        S3KeyPrefix?: CloudTrailString;
-        SnsTopicName?: CloudTrailString;
-        IncludeGlobalServiceEvents?: CloudTrailBoolean;
-        TrailARN?: CloudTrailString;
-        LogFileValidationEnabled?: CloudTrailBoolean;
-        CloudWatchLogsLogGroupArn?: CloudTrailString;
-        CloudWatchLogsRoleArn?: CloudTrailString;
-        KmsKeyId?: CloudTrailString;
-    }
-
-    export type CloudTrailDate = number;
-    export interface CloudTrailDeleteTrailRequest {
-        Name: CloudTrailString;
-    }
-
-    export interface CloudTrailDeleteTrailResponse {
-    }
-
-    export interface CloudTrailDescribeTrailsRequest {
-        trailNameList?: CloudTrailTrailNameList;
-    }
-
-    export interface CloudTrailDescribeTrailsResponse {
-        trailList?: CloudTrailTrailList;
-    }
-
-    export interface CloudTrailEvent {
-        EventId?: CloudTrailString;
-        EventName?: CloudTrailString;
-        EventTime?: CloudTrailDate;
-        Username?: CloudTrailString;
-        Resources?: CloudTrailResourceList;
-        CloudTrailEvent?: CloudTrailString;
-    }
-
-    export type CloudTrailEventsList = Array<CloudTrailEvent>;
-    export interface CloudTrailGetTrailStatusRequest {
-        Name: CloudTrailString;
-    }
-
-    export interface CloudTrailGetTrailStatusResponse {
-        IsLogging?: CloudTrailBoolean;
-        LatestDeliveryError?: CloudTrailString;
-        LatestNotificationError?: CloudTrailString;
-        LatestDeliveryTime?: CloudTrailDate;
-        LatestNotificationTime?: CloudTrailDate;
-        StartLoggingTime?: CloudTrailDate;
-        StopLoggingTime?: CloudTrailDate;
-        LatestCloudWatchLogsDeliveryError?: CloudTrailString;
-        LatestCloudWatchLogsDeliveryTime?: CloudTrailDate;
-        LatestDigestDeliveryTime?: CloudTrailDate;
-        LatestDigestDeliveryError?: CloudTrailString;
-        LatestDeliveryAttemptTime?: CloudTrailString;
-        LatestNotificationAttemptTime?: CloudTrailString;
-        LatestNotificationAttemptSucceeded?: CloudTrailString;
-        LatestDeliveryAttemptSucceeded?: CloudTrailString;
-        TimeLoggingStarted?: CloudTrailString;
-        TimeLoggingStopped?: CloudTrailString;
-    }
-
-    export interface CloudTrailInsufficientEncryptionPolicyException {
-    }
-
-    export interface CloudTrailInsufficientS3BucketPolicyException {
-    }
-
-    export interface CloudTrailInsufficientSnsTopicPolicyException {
-    }
-
-    export interface CloudTrailInvalidCloudWatchLogsLogGroupArnException {
-    }
-
-    export interface CloudTrailInvalidCloudWatchLogsRoleArnException {
-    }
-
-    export interface CloudTrailInvalidKmsKeyIdException {
-    }
-
-    export interface CloudTrailInvalidLookupAttributesException {
-    }
-
-    export interface CloudTrailInvalidMaxResultsException {
-    }
-
-    export interface CloudTrailInvalidNextTokenException {
-    }
-
-    export interface CloudTrailInvalidS3BucketNameException {
-    }
-
-    export interface CloudTrailInvalidS3PrefixException {
-    }
-
-    export interface CloudTrailInvalidSnsTopicNameException {
-    }
-
-    export interface CloudTrailInvalidTagParameterException {
-    }
-
-    export interface CloudTrailInvalidTimeRangeException {
-    }
-
-    export interface CloudTrailInvalidTokenException {
-    }
-
-    export interface CloudTrailInvalidTrailNameException {
-    }
-
-    export interface CloudTrailKmsKeyDisabledException {
-    }
-
-    export interface CloudTrailKmsKeyNotFoundException {
-    }
-
-    export interface CloudTrailListPublicKeysRequest {
-        StartTime?: CloudTrailDate;
-        EndTime?: CloudTrailDate;
-        NextToken?: CloudTrailString;
-    }
-
-    export interface CloudTrailListPublicKeysResponse {
-        PublicKeyList?: CloudTrailPublicKeyList;
-        NextToken?: CloudTrailString;
-    }
-
-    export interface CloudTrailListTagsRequest {
-        ResourceIdList: CloudTrailResourceIdList;
-        NextToken?: CloudTrailString;
-    }
-
-    export interface CloudTrailListTagsResponse {
-        ResourceTagList?: CloudTrailResourceTagList;
-        NextToken?: CloudTrailString;
-    }
-
-    export interface CloudTrailLookupAttribute {
-        AttributeKey: CloudTrailLookupAttributeKey;
-        AttributeValue: CloudTrailString;
-    }
-
-    export type CloudTrailLookupAttributeKey = string;
-    export type CloudTrailLookupAttributesList = Array<CloudTrailLookupAttribute>;
-    export interface CloudTrailLookupEventsRequest {
-        LookupAttributes?: CloudTrailLookupAttributesList;
-        StartTime?: CloudTrailDate;
-        EndTime?: CloudTrailDate;
-        MaxResults?: CloudTrailMaxResults;
-        NextToken?: CloudTrailNextToken;
-    }
-
-    export interface CloudTrailLookupEventsResponse {
-        Events?: CloudTrailEventsList;
-        NextToken?: CloudTrailNextToken;
-    }
-
-    export type CloudTrailMaxResults = number;
-    export interface CloudTrailMaximumNumberOfTrailsExceededException {
-    }
-
-    export type CloudTrailNextToken = string;
-    export interface CloudTrailOperationNotPermittedException {
-    }
-
-    export interface CloudTrailPublicKey {
-        Value?: CloudTrailByteBuffer;
-        ValidityStartTime?: CloudTrailDate;
-        ValidityEndTime?: CloudTrailDate;
-        Fingerprint?: CloudTrailString;
-    }
-
-    export type CloudTrailPublicKeyList = Array<CloudTrailPublicKey>;
-    export interface CloudTrailRemoveTagsRequest {
-        ResourceId: CloudTrailString;
-        TagsList?: CloudTrailTagsList;
-    }
-
-    export interface CloudTrailRemoveTagsResponse {
-    }
-
-    export interface CloudTrailResource {
-        ResourceType?: CloudTrailString;
-        ResourceName?: CloudTrailString;
-    }
-
-    export type CloudTrailResourceIdList = Array<CloudTrailString>;
-    export type CloudTrailResourceList = Array<CloudTrailResource>;
-    export interface CloudTrailResourceNotFoundException {
-    }
-
-    export interface CloudTrailResourceTag {
-        ResourceId?: CloudTrailString;
-        TagsList?: CloudTrailTagsList;
-    }
-
-    export type CloudTrailResourceTagList = Array<CloudTrailResourceTag>;
-    export interface CloudTrailResourceTypeNotSupportedException {
-    }
-
-    export interface CloudTrailS3BucketDoesNotExistException {
-    }
-
-    export interface CloudTrailStartLoggingRequest {
-        Name: CloudTrailString;
-    }
-
-    export interface CloudTrailStartLoggingResponse {
-    }
-
-    export interface CloudTrailStopLoggingRequest {
-        Name: CloudTrailString;
-    }
-
-    export interface CloudTrailStopLoggingResponse {
-    }
-
-    export type CloudTrailString = string;
-    export interface CloudTrailTag {
-        Key: CloudTrailString;
-        Value?: CloudTrailString;
-    }
-
-    export interface CloudTrailTagsLimitExceededException {
-    }
-
-    export type CloudTrailTagsList = Array<CloudTrailTag>;
-    export interface CloudTrailTrail {
-        Name?: CloudTrailString;
-        S3BucketName?: CloudTrailString;
-        S3KeyPrefix?: CloudTrailString;
-        SnsTopicName?: CloudTrailString;
-        IncludeGlobalServiceEvents?: CloudTrailBoolean;
-        TrailARN?: CloudTrailString;
-        LogFileValidationEnabled?: CloudTrailBoolean;
-        CloudWatchLogsLogGroupArn?: CloudTrailString;
-        CloudWatchLogsRoleArn?: CloudTrailString;
-        KmsKeyId?: CloudTrailString;
-    }
-
-    export interface CloudTrailTrailAlreadyExistsException {
-    }
-
-    export type CloudTrailTrailList = Array<CloudTrailTrail>;
-    export type CloudTrailTrailNameList = Array<CloudTrailString>;
-    export interface CloudTrailTrailNotFoundException {
-    }
-
-    export interface CloudTrailTrailNotProvidedException {
-    }
-
-    export interface CloudTrailUnsupportedOperationException {
-    }
-
-    export interface CloudTrailUpdateTrailRequest {
-        Name: CloudTrailString;
-        S3BucketName?: CloudTrailString;
-        S3KeyPrefix?: CloudTrailString;
-        SnsTopicName?: CloudTrailString;
-        IncludeGlobalServiceEvents?: CloudTrailBoolean;
-        EnableLogFileValidation?: CloudTrailBoolean;
-        CloudWatchLogsLogGroupArn?: CloudTrailString;
-        CloudWatchLogsRoleArn?: CloudTrailString;
-        KmsKeyId?: CloudTrailString;
-    }
-
-    export interface CloudTrailUpdateTrailResponse {
-        Name?: CloudTrailString;
-        S3BucketName?: CloudTrailString;
-        S3KeyPrefix?: CloudTrailString;
-        SnsTopicName?: CloudTrailString;
-        IncludeGlobalServiceEvents?: CloudTrailBoolean;
-        TrailARN?: CloudTrailString;
-        LogFileValidationEnabled?: CloudTrailBoolean;
-        CloudWatchLogsLogGroupArn?: CloudTrailString;
-        CloudWatchLogsRoleArn?: CloudTrailString;
-        KmsKeyId?: CloudTrailString;
-    }
-
 }

--- a/output/aws-codecommit.d.ts
+++ b/output/aws-codecommit.d.ts
@@ -6,213 +6,173 @@ declare module "aws-sdk" {
 
     export class CodeCommit extends Service {
       constructor(options?: any);
-      batchGetRepositories(params: CodeCommitBatchGetRepositoriesInput, callback?: (err: CodeCommitRepositoryNamesRequiredException|CodeCommitMaximumRepositoryNamesExceededException|CodeCommitInvalidRepositoryNameException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: CodeCommitBatchGetRepositoriesOutput|any) => void): Request;
-      createBranch(params: CodeCommitCreateBranchInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitInvalidRepositoryNameException|CodeCommitRepositoryDoesNotExistException|CodeCommitBranchNameRequiredException|CodeCommitBranchNameExistsException|CodeCommitInvalidBranchNameException|CodeCommitCommitIdRequiredException|CodeCommitCommitDoesNotExistException|CodeCommitInvalidCommitIdException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: any) => void): Request;
-      createRepository(params: CodeCommitCreateRepositoryInput, callback?: (err: CodeCommitRepositoryNameExistsException|CodeCommitRepositoryNameRequiredException|CodeCommitInvalidRepositoryNameException|CodeCommitInvalidRepositoryDescriptionException|CodeCommitRepositoryLimitExceededException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: CodeCommitCreateRepositoryOutput|any) => void): Request;
-      deleteRepository(params: CodeCommitDeleteRepositoryInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitInvalidRepositoryNameException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: CodeCommitDeleteRepositoryOutput|any) => void): Request;
-      getBranch(params: CodeCommitGetBranchInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitRepositoryDoesNotExistException|CodeCommitInvalidRepositoryNameException|CodeCommitBranchNameRequiredException|CodeCommitInvalidBranchNameException|CodeCommitBranchDoesNotExistException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: CodeCommitGetBranchOutput|any) => void): Request;
-      getRepository(params: CodeCommitGetRepositoryInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitRepositoryDoesNotExistException|CodeCommitInvalidRepositoryNameException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: CodeCommitGetRepositoryOutput|any) => void): Request;
-      listBranches(params: CodeCommitListBranchesInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitRepositoryDoesNotExistException|CodeCommitInvalidRepositoryNameException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|CodeCommitInvalidContinuationTokenException|any, data: CodeCommitListBranchesOutput|any) => void): Request;
-      listRepositories(params: CodeCommitListRepositoriesInput, callback?: (err: CodeCommitInvalidSortByException|CodeCommitInvalidOrderException|CodeCommitInvalidContinuationTokenException|any, data: CodeCommitListRepositoriesOutput|any) => void): Request;
-      updateDefaultBranch(params: CodeCommitUpdateDefaultBranchInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitRepositoryDoesNotExistException|CodeCommitInvalidRepositoryNameException|CodeCommitBranchNameRequiredException|CodeCommitInvalidBranchNameException|CodeCommitBranchDoesNotExistException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: any) => void): Request;
-      updateRepositoryDescription(params: CodeCommitUpdateRepositoryDescriptionInput, callback?: (err: CodeCommitRepositoryNameRequiredException|CodeCommitRepositoryDoesNotExistException|CodeCommitInvalidRepositoryNameException|CodeCommitInvalidRepositoryDescriptionException|CodeCommitEncryptionIntegrityChecksFailedException|CodeCommitEncryptionKeyAccessDeniedException|CodeCommitEncryptionKeyDisabledException|CodeCommitEncryptionKeyNotFoundException|CodeCommitEncryptionKeyUnavailableException|any, data: any) => void): Request;
-      updateRepositoryName(params: CodeCommitUpdateRepositoryNameInput, callback?: (err: CodeCommitRepositoryDoesNotExistException|CodeCommitRepositoryNameExistsException|CodeCommitRepositoryNameRequiredException|CodeCommitInvalidRepositoryNameException|any, data: any) => void): Request;
+      batchGetRepositories(params: CodeCommit.BatchGetRepositoriesInput, callback?: (err: CodeCommit.RepositoryNamesRequiredException|CodeCommit.MaximumRepositoryNamesExceededException|CodeCommit.InvalidRepositoryNameException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: CodeCommit.BatchGetRepositoriesOutput|any) => void): Request;
+      createBranch(params: CodeCommit.CreateBranchInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.InvalidRepositoryNameException|CodeCommit.RepositoryDoesNotExistException|CodeCommit.BranchNameRequiredException|CodeCommit.BranchNameExistsException|CodeCommit.InvalidBranchNameException|CodeCommit.CommitIdRequiredException|CodeCommit.CommitDoesNotExistException|CodeCommit.InvalidCommitIdException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: any) => void): Request;
+      createRepository(params: CodeCommit.CreateRepositoryInput, callback?: (err: CodeCommit.RepositoryNameExistsException|CodeCommit.RepositoryNameRequiredException|CodeCommit.InvalidRepositoryNameException|CodeCommit.InvalidRepositoryDescriptionException|CodeCommit.RepositoryLimitExceededException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: CodeCommit.CreateRepositoryOutput|any) => void): Request;
+      deleteRepository(params: CodeCommit.DeleteRepositoryInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.InvalidRepositoryNameException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: CodeCommit.DeleteRepositoryOutput|any) => void): Request;
+      getBranch(params: CodeCommit.GetBranchInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.RepositoryDoesNotExistException|CodeCommit.InvalidRepositoryNameException|CodeCommit.BranchNameRequiredException|CodeCommit.InvalidBranchNameException|CodeCommit.BranchDoesNotExistException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: CodeCommit.GetBranchOutput|any) => void): Request;
+      getRepository(params: CodeCommit.GetRepositoryInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.RepositoryDoesNotExistException|CodeCommit.InvalidRepositoryNameException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: CodeCommit.GetRepositoryOutput|any) => void): Request;
+      listBranches(params: CodeCommit.ListBranchesInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.RepositoryDoesNotExistException|CodeCommit.InvalidRepositoryNameException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|CodeCommit.InvalidContinuationTokenException|any, data: CodeCommit.ListBranchesOutput|any) => void): Request;
+      listRepositories(params: CodeCommit.ListRepositoriesInput, callback?: (err: CodeCommit.InvalidSortByException|CodeCommit.InvalidOrderException|CodeCommit.InvalidContinuationTokenException|any, data: CodeCommit.ListRepositoriesOutput|any) => void): Request;
+      updateDefaultBranch(params: CodeCommit.UpdateDefaultBranchInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.RepositoryDoesNotExistException|CodeCommit.InvalidRepositoryNameException|CodeCommit.BranchNameRequiredException|CodeCommit.InvalidBranchNameException|CodeCommit.BranchDoesNotExistException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: any) => void): Request;
+      updateRepositoryDescription(params: CodeCommit.UpdateRepositoryDescriptionInput, callback?: (err: CodeCommit.RepositoryNameRequiredException|CodeCommit.RepositoryDoesNotExistException|CodeCommit.InvalidRepositoryNameException|CodeCommit.InvalidRepositoryDescriptionException|CodeCommit.EncryptionIntegrityChecksFailedException|CodeCommit.EncryptionKeyAccessDeniedException|CodeCommit.EncryptionKeyDisabledException|CodeCommit.EncryptionKeyNotFoundException|CodeCommit.EncryptionKeyUnavailableException|any, data: any) => void): Request;
+      updateRepositoryName(params: CodeCommit.UpdateRepositoryNameInput, callback?: (err: CodeCommit.RepositoryDoesNotExistException|CodeCommit.RepositoryNameExistsException|CodeCommit.RepositoryNameRequiredException|CodeCommit.InvalidRepositoryNameException|any, data: any) => void): Request;
     }
+    
+    export module CodeCommit {
+        export type AccountId = string;
+        export type Arn = string;
+        export type BranchName = string;    // max: 100, min: 1
+        export type BranchNameList = BranchName[];
+        export type CloneUrlHttp = string;
+        export type CloneUrlSsh = string;
+        export type CommitId = string;
+        export type CreationDate = number;
+        export type LastModifiedDate = number;
+        export type NextToken = string;
+        export type OrderEnum = string;
+        export type RepositoryDescription = string;    // max: 1000
+        export type RepositoryId = string;
+        export type RepositoryMetadataList = RepositoryMetadata[];
+        export type RepositoryName = string;    // pattern: &quot;[\\w\\.-]+&quot;, max: 100, min: 1
+        export type RepositoryNameIdPairList = RepositoryNameIdPair[];
+        export type RepositoryNameList = RepositoryName[];
+        export type RepositoryNotFoundList = RepositoryName[];
+        export type SortByEnum = string;
 
-    export type CodeCommitAccountId = string;
-    export type CodeCommitArn = string;
-    export interface CodeCommitBatchGetRepositoriesInput {
-        repositoryNames: CodeCommitRepositoryNameList;
+        export interface BatchGetRepositoriesInput {
+            repositoryNames: RepositoryNameList;            
+        }
+        export interface BatchGetRepositoriesOutput {
+            repositories?: RepositoryMetadataList;            
+            repositoriesNotFound?: RepositoryNotFoundList;            
+        }
+        export interface BranchDoesNotExistException {
+        }
+        export interface BranchInfo {
+            branchName?: BranchName;            
+            commitId?: CommitId;            
+        }
+        export interface BranchNameExistsException {
+        }
+        export interface BranchNameRequiredException {
+        }
+        export interface CommitDoesNotExistException {
+        }
+        export interface CommitIdRequiredException {
+        }
+        export interface CreateBranchInput {
+            repositoryName: RepositoryName;            
+            branchName: BranchName;            
+            commitId: CommitId;            
+        }
+        export interface CreateRepositoryInput {
+            repositoryName: RepositoryName;            
+            repositoryDescription?: RepositoryDescription;            
+        }
+        export interface CreateRepositoryOutput {
+            repositoryMetadata?: RepositoryMetadata;            
+        }
+        export interface DeleteRepositoryInput {
+            repositoryName: RepositoryName;            
+        }
+        export interface DeleteRepositoryOutput {
+            repositoryId?: RepositoryId;            
+        }
+        export interface EncryptionIntegrityChecksFailedException {
+        }
+        export interface EncryptionKeyAccessDeniedException {
+        }
+        export interface EncryptionKeyDisabledException {
+        }
+        export interface EncryptionKeyNotFoundException {
+        }
+        export interface EncryptionKeyUnavailableException {
+        }
+        export interface GetBranchInput {
+            repositoryName?: RepositoryName;            
+            branchName?: BranchName;            
+        }
+        export interface GetBranchOutput {
+            branch?: BranchInfo;            
+        }
+        export interface GetRepositoryInput {
+            repositoryName: RepositoryName;            
+        }
+        export interface GetRepositoryOutput {
+            repositoryMetadata?: RepositoryMetadata;            
+        }
+        export interface InvalidBranchNameException {
+        }
+        export interface InvalidCommitIdException {
+        }
+        export interface InvalidContinuationTokenException {
+        }
+        export interface InvalidOrderException {
+        }
+        export interface InvalidRepositoryDescriptionException {
+        }
+        export interface InvalidRepositoryNameException {
+        }
+        export interface InvalidSortByException {
+        }
+        export interface ListBranchesInput {
+            repositoryName: RepositoryName;            
+            nextToken?: NextToken;            
+        }
+        export interface ListBranchesOutput {
+            branches?: BranchNameList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListRepositoriesInput {
+            nextToken?: NextToken;            
+            sortBy?: SortByEnum;            
+            order?: OrderEnum;            
+        }
+        export interface ListRepositoriesOutput {
+            repositories?: RepositoryNameIdPairList;            
+            nextToken?: NextToken;            
+        }
+        export interface MaximumRepositoryNamesExceededException {
+        }
+        export interface RepositoryDoesNotExistException {
+        }
+        export interface RepositoryLimitExceededException {
+        }
+        export interface RepositoryMetadata {
+            accountId?: AccountId;            
+            repositoryId?: RepositoryId;            
+            repositoryName?: RepositoryName;            
+            repositoryDescription?: RepositoryDescription;            
+            defaultBranch?: BranchName;            
+            lastModifiedDate?: LastModifiedDate;            
+            creationDate?: CreationDate;            
+            cloneUrlHttp?: CloneUrlHttp;            
+            cloneUrlSsh?: CloneUrlSsh;            
+            Arn?: Arn;            
+        }
+        export interface RepositoryNameExistsException {
+        }
+        export interface RepositoryNameIdPair {
+            repositoryName?: RepositoryName;            
+            repositoryId?: RepositoryId;            
+        }
+        export interface RepositoryNameRequiredException {
+        }
+        export interface RepositoryNamesRequiredException {
+        }
+        export interface UpdateDefaultBranchInput {
+            repositoryName: RepositoryName;            
+            defaultBranchName: BranchName;            
+        }
+        export interface UpdateRepositoryDescriptionInput {
+            repositoryName: RepositoryName;            
+            repositoryDescription?: RepositoryDescription;            
+        }
+        export interface UpdateRepositoryNameInput {
+            oldName: RepositoryName;            
+            newName: RepositoryName;            
+        }
+
     }
-
-    export interface CodeCommitBatchGetRepositoriesOutput {
-        repositories?: CodeCommitRepositoryMetadataList;
-        repositoriesNotFound?: CodeCommitRepositoryNotFoundList;
-    }
-
-    export interface CodeCommitBranchDoesNotExistException {
-    }
-
-    export interface CodeCommitBranchInfo {
-        branchName?: CodeCommitBranchName;
-        commitId?: CodeCommitCommitId;
-    }
-
-    export type CodeCommitBranchName = string;
-    export interface CodeCommitBranchNameExistsException {
-    }
-
-    export type CodeCommitBranchNameList = Array<CodeCommitBranchName>;
-    export interface CodeCommitBranchNameRequiredException {
-    }
-
-    export type CodeCommitCloneUrlHttp = string;
-    export type CodeCommitCloneUrlSsh = string;
-    export interface CodeCommitCommitDoesNotExistException {
-    }
-
-    export type CodeCommitCommitId = string;
-    export interface CodeCommitCommitIdRequiredException {
-    }
-
-    export interface CodeCommitCreateBranchInput {
-        repositoryName: CodeCommitRepositoryName;
-        branchName: CodeCommitBranchName;
-        commitId: CodeCommitCommitId;
-    }
-
-    export interface CodeCommitCreateRepositoryInput {
-        repositoryName: CodeCommitRepositoryName;
-        repositoryDescription?: CodeCommitRepositoryDescription;
-    }
-
-    export interface CodeCommitCreateRepositoryOutput {
-        repositoryMetadata?: CodeCommitRepositoryMetadata;
-    }
-
-    export type CodeCommitCreationDate = number;
-    export interface CodeCommitDeleteRepositoryInput {
-        repositoryName: CodeCommitRepositoryName;
-    }
-
-    export interface CodeCommitDeleteRepositoryOutput {
-        repositoryId?: CodeCommitRepositoryId;
-    }
-
-    export interface CodeCommitEncryptionIntegrityChecksFailedException {
-    }
-
-    export interface CodeCommitEncryptionKeyAccessDeniedException {
-    }
-
-    export interface CodeCommitEncryptionKeyDisabledException {
-    }
-
-    export interface CodeCommitEncryptionKeyNotFoundException {
-    }
-
-    export interface CodeCommitEncryptionKeyUnavailableException {
-    }
-
-    export interface CodeCommitGetBranchInput {
-        repositoryName?: CodeCommitRepositoryName;
-        branchName?: CodeCommitBranchName;
-    }
-
-    export interface CodeCommitGetBranchOutput {
-        branch?: CodeCommitBranchInfo;
-    }
-
-    export interface CodeCommitGetRepositoryInput {
-        repositoryName: CodeCommitRepositoryName;
-    }
-
-    export interface CodeCommitGetRepositoryOutput {
-        repositoryMetadata?: CodeCommitRepositoryMetadata;
-    }
-
-    export interface CodeCommitInvalidBranchNameException {
-    }
-
-    export interface CodeCommitInvalidCommitIdException {
-    }
-
-    export interface CodeCommitInvalidContinuationTokenException {
-    }
-
-    export interface CodeCommitInvalidOrderException {
-    }
-
-    export interface CodeCommitInvalidRepositoryDescriptionException {
-    }
-
-    export interface CodeCommitInvalidRepositoryNameException {
-    }
-
-    export interface CodeCommitInvalidSortByException {
-    }
-
-    export type CodeCommitLastModifiedDate = number;
-    export interface CodeCommitListBranchesInput {
-        repositoryName: CodeCommitRepositoryName;
-        nextToken?: CodeCommitNextToken;
-    }
-
-    export interface CodeCommitListBranchesOutput {
-        branches?: CodeCommitBranchNameList;
-        nextToken?: CodeCommitNextToken;
-    }
-
-    export interface CodeCommitListRepositoriesInput {
-        nextToken?: CodeCommitNextToken;
-        sortBy?: CodeCommitSortByEnum;
-        order?: CodeCommitOrderEnum;
-    }
-
-    export interface CodeCommitListRepositoriesOutput {
-        repositories?: CodeCommitRepositoryNameIdPairList;
-        nextToken?: CodeCommitNextToken;
-    }
-
-    export interface CodeCommitMaximumRepositoryNamesExceededException {
-    }
-
-    export type CodeCommitNextToken = string;
-    export type CodeCommitOrderEnum = string;
-    export type CodeCommitRepositoryDescription = string;
-    export interface CodeCommitRepositoryDoesNotExistException {
-    }
-
-    export type CodeCommitRepositoryId = string;
-    export interface CodeCommitRepositoryLimitExceededException {
-    }
-
-    export interface CodeCommitRepositoryMetadata {
-        accountId?: CodeCommitAccountId;
-        repositoryId?: CodeCommitRepositoryId;
-        repositoryName?: CodeCommitRepositoryName;
-        repositoryDescription?: CodeCommitRepositoryDescription;
-        defaultBranch?: CodeCommitBranchName;
-        lastModifiedDate?: CodeCommitLastModifiedDate;
-        creationDate?: CodeCommitCreationDate;
-        cloneUrlHttp?: CodeCommitCloneUrlHttp;
-        cloneUrlSsh?: CodeCommitCloneUrlSsh;
-        Arn?: CodeCommitArn;
-    }
-
-    export type CodeCommitRepositoryMetadataList = Array<CodeCommitRepositoryMetadata>;
-    export type CodeCommitRepositoryName = string; // pattern: "[\\w\\.-]+"
-    export interface CodeCommitRepositoryNameExistsException {
-    }
-
-    export interface CodeCommitRepositoryNameIdPair {
-        repositoryName?: CodeCommitRepositoryName;
-        repositoryId?: CodeCommitRepositoryId;
-    }
-
-    export type CodeCommitRepositoryNameIdPairList = Array<CodeCommitRepositoryNameIdPair>;
-    export type CodeCommitRepositoryNameList = Array<CodeCommitRepositoryName>;
-    export interface CodeCommitRepositoryNameRequiredException {
-    }
-
-    export interface CodeCommitRepositoryNamesRequiredException {
-    }
-
-    export type CodeCommitRepositoryNotFoundList = Array<CodeCommitRepositoryName>;
-    export type CodeCommitSortByEnum = string;
-    export interface CodeCommitUpdateDefaultBranchInput {
-        repositoryName: CodeCommitRepositoryName;
-        defaultBranchName: CodeCommitBranchName;
-    }
-
-    export interface CodeCommitUpdateRepositoryDescriptionInput {
-        repositoryName: CodeCommitRepositoryName;
-        repositoryDescription?: CodeCommitRepositoryDescription;
-    }
-
-    export interface CodeCommitUpdateRepositoryNameInput {
-        oldName: CodeCommitRepositoryName;
-        newName: CodeCommitRepositoryName;
-    }
-
 }

--- a/output/aws-codedeploy.d.ts
+++ b/output/aws-codedeploy.d.ts
@@ -6,703 +6,574 @@ declare module "aws-sdk" {
 
     export class CodeDeploy extends Service {
       constructor(options?: any);
-      addTagsToOnPremisesInstances(params: CodeDeployAddTagsToOnPremisesInstancesInput, callback?: (err: CodeDeployInstanceNameRequiredException|CodeDeployTagRequiredException|CodeDeployInvalidTagException|CodeDeployTagLimitExceededException|CodeDeployInstanceLimitExceededException|CodeDeployInstanceNotRegisteredException|any, data: any) => void): Request;
-      batchGetApplications(params: CodeDeployBatchGetApplicationsInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|any, data: CodeDeployBatchGetApplicationsOutput|any) => void): Request;
-      batchGetDeployments(params: CodeDeployBatchGetDeploymentsInput, callback?: (err: CodeDeployDeploymentIdRequiredException|CodeDeployInvalidDeploymentIdException|any, data: CodeDeployBatchGetDeploymentsOutput|any) => void): Request;
-      batchGetOnPremisesInstances(params: CodeDeployBatchGetOnPremisesInstancesInput, callback?: (err: CodeDeployInstanceNameRequiredException|CodeDeployInvalidInstanceNameException|any, data: CodeDeployBatchGetOnPremisesInstancesOutput|any) => void): Request;
-      createApplication(params: CodeDeployCreateApplicationInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationAlreadyExistsException|CodeDeployApplicationLimitExceededException|any, data: CodeDeployCreateApplicationOutput|any) => void): Request;
-      createDeployment(params: CodeDeployCreateDeploymentInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|CodeDeployDeploymentGroupNameRequiredException|CodeDeployInvalidDeploymentGroupNameException|CodeDeployDeploymentGroupDoesNotExistException|CodeDeployRevisionRequiredException|CodeDeployInvalidRevisionException|CodeDeployInvalidDeploymentConfigNameException|CodeDeployDeploymentConfigDoesNotExistException|CodeDeployDescriptionTooLongException|CodeDeployDeploymentLimitExceededException|any, data: CodeDeployCreateDeploymentOutput|any) => void): Request;
-      createDeploymentConfig(params: CodeDeployCreateDeploymentConfigInput, callback?: (err: CodeDeployInvalidDeploymentConfigNameException|CodeDeployDeploymentConfigNameRequiredException|CodeDeployDeploymentConfigAlreadyExistsException|CodeDeployInvalidMinimumHealthyHostValueException|CodeDeployDeploymentConfigLimitExceededException|any, data: CodeDeployCreateDeploymentConfigOutput|any) => void): Request;
-      createDeploymentGroup(params: CodeDeployCreateDeploymentGroupInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|CodeDeployDeploymentGroupNameRequiredException|CodeDeployInvalidDeploymentGroupNameException|CodeDeployDeploymentGroupAlreadyExistsException|CodeDeployInvalidEC2TagException|CodeDeployInvalidTagException|CodeDeployInvalidAutoScalingGroupException|CodeDeployInvalidDeploymentConfigNameException|CodeDeployDeploymentConfigDoesNotExistException|CodeDeployRoleRequiredException|CodeDeployInvalidRoleException|CodeDeployDeploymentGroupLimitExceededException|any, data: CodeDeployCreateDeploymentGroupOutput|any) => void): Request;
-      deleteApplication(params: CodeDeployDeleteApplicationInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|any, data: any) => void): Request;
-      deleteDeploymentConfig(params: CodeDeployDeleteDeploymentConfigInput, callback?: (err: CodeDeployInvalidDeploymentConfigNameException|CodeDeployDeploymentConfigNameRequiredException|CodeDeployDeploymentConfigInUseException|CodeDeployInvalidOperationException|any, data: any) => void): Request;
-      deleteDeploymentGroup(params: CodeDeployDeleteDeploymentGroupInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployDeploymentGroupNameRequiredException|CodeDeployInvalidDeploymentGroupNameException|CodeDeployInvalidRoleException|any, data: CodeDeployDeleteDeploymentGroupOutput|any) => void): Request;
-      deregisterOnPremisesInstance(params: CodeDeployDeregisterOnPremisesInstanceInput, callback?: (err: CodeDeployInstanceNameRequiredException|CodeDeployInvalidInstanceNameException|any, data: any) => void): Request;
-      getApplication(params: CodeDeployGetApplicationInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|any, data: CodeDeployGetApplicationOutput|any) => void): Request;
-      getApplicationRevision(params: CodeDeployGetApplicationRevisionInput, callback?: (err: CodeDeployApplicationDoesNotExistException|CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployRevisionDoesNotExistException|CodeDeployRevisionRequiredException|CodeDeployInvalidRevisionException|any, data: CodeDeployGetApplicationRevisionOutput|any) => void): Request;
-      getDeployment(params: CodeDeployGetDeploymentInput, callback?: (err: CodeDeployDeploymentIdRequiredException|CodeDeployInvalidDeploymentIdException|CodeDeployDeploymentDoesNotExistException|any, data: CodeDeployGetDeploymentOutput|any) => void): Request;
-      getDeploymentConfig(params: CodeDeployGetDeploymentConfigInput, callback?: (err: CodeDeployInvalidDeploymentConfigNameException|CodeDeployDeploymentConfigNameRequiredException|CodeDeployDeploymentConfigDoesNotExistException|any, data: CodeDeployGetDeploymentConfigOutput|any) => void): Request;
-      getDeploymentGroup(params: CodeDeployGetDeploymentGroupInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|CodeDeployDeploymentGroupNameRequiredException|CodeDeployInvalidDeploymentGroupNameException|CodeDeployDeploymentGroupDoesNotExistException|any, data: CodeDeployGetDeploymentGroupOutput|any) => void): Request;
-      getDeploymentInstance(params: CodeDeployGetDeploymentInstanceInput, callback?: (err: CodeDeployDeploymentIdRequiredException|CodeDeployDeploymentDoesNotExistException|CodeDeployInstanceIdRequiredException|CodeDeployInvalidDeploymentIdException|CodeDeployInstanceDoesNotExistException|any, data: CodeDeployGetDeploymentInstanceOutput|any) => void): Request;
-      getOnPremisesInstance(params: CodeDeployGetOnPremisesInstanceInput, callback?: (err: CodeDeployInstanceNameRequiredException|CodeDeployInstanceNotRegisteredException|CodeDeployInvalidInstanceNameException|any, data: CodeDeployGetOnPremisesInstanceOutput|any) => void): Request;
-      listApplicationRevisions(params: CodeDeployListApplicationRevisionsInput, callback?: (err: CodeDeployApplicationDoesNotExistException|CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployInvalidSortByException|CodeDeployInvalidSortOrderException|CodeDeployInvalidBucketNameFilterException|CodeDeployInvalidKeyPrefixFilterException|CodeDeployBucketNameFilterRequiredException|CodeDeployInvalidDeployedStateFilterException|CodeDeployInvalidNextTokenException|any, data: CodeDeployListApplicationRevisionsOutput|any) => void): Request;
-      listApplications(params: CodeDeployListApplicationsInput, callback?: (err: CodeDeployInvalidNextTokenException|any, data: CodeDeployListApplicationsOutput|any) => void): Request;
-      listDeploymentConfigs(params: CodeDeployListDeploymentConfigsInput, callback?: (err: CodeDeployInvalidNextTokenException|any, data: CodeDeployListDeploymentConfigsOutput|any) => void): Request;
-      listDeploymentGroups(params: CodeDeployListDeploymentGroupsInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|CodeDeployInvalidNextTokenException|any, data: CodeDeployListDeploymentGroupsOutput|any) => void): Request;
-      listDeploymentInstances(params: CodeDeployListDeploymentInstancesInput, callback?: (err: CodeDeployDeploymentIdRequiredException|CodeDeployDeploymentDoesNotExistException|CodeDeployDeploymentNotStartedException|CodeDeployInvalidNextTokenException|CodeDeployInvalidDeploymentIdException|CodeDeployInvalidInstanceStatusException|any, data: CodeDeployListDeploymentInstancesOutput|any) => void): Request;
-      listDeployments(params: CodeDeployListDeploymentsInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|CodeDeployInvalidDeploymentGroupNameException|CodeDeployDeploymentGroupDoesNotExistException|CodeDeployDeploymentGroupNameRequiredException|CodeDeployInvalidTimeRangeException|CodeDeployInvalidDeploymentStatusException|CodeDeployInvalidNextTokenException|any, data: CodeDeployListDeploymentsOutput|any) => void): Request;
-      listOnPremisesInstances(params: CodeDeployListOnPremisesInstancesInput, callback?: (err: CodeDeployInvalidRegistrationStatusException|CodeDeployInvalidTagFilterException|CodeDeployInvalidNextTokenException|any, data: CodeDeployListOnPremisesInstancesOutput|any) => void): Request;
-      registerApplicationRevision(params: CodeDeployRegisterApplicationRevisionInput, callback?: (err: CodeDeployApplicationDoesNotExistException|CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployDescriptionTooLongException|CodeDeployRevisionRequiredException|CodeDeployInvalidRevisionException|any, data: any) => void): Request;
-      registerOnPremisesInstance(params: CodeDeployRegisterOnPremisesInstanceInput, callback?: (err: CodeDeployInstanceNameAlreadyRegisteredException|CodeDeployIamUserArnAlreadyRegisteredException|CodeDeployInstanceNameRequiredException|CodeDeployIamUserArnRequiredException|CodeDeployInvalidInstanceNameException|CodeDeployInvalidIamUserArnException|any, data: any) => void): Request;
-      removeTagsFromOnPremisesInstances(params: CodeDeployRemoveTagsFromOnPremisesInstancesInput, callback?: (err: CodeDeployInstanceNameRequiredException|CodeDeployTagRequiredException|CodeDeployInvalidTagException|CodeDeployTagLimitExceededException|CodeDeployInstanceLimitExceededException|CodeDeployInstanceNotRegisteredException|any, data: any) => void): Request;
-      stopDeployment(params: CodeDeployStopDeploymentInput, callback?: (err: CodeDeployDeploymentIdRequiredException|CodeDeployDeploymentDoesNotExistException|CodeDeployDeploymentAlreadyCompletedException|CodeDeployInvalidDeploymentIdException|any, data: CodeDeployStopDeploymentOutput|any) => void): Request;
-      updateApplication(params: CodeDeployUpdateApplicationInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationAlreadyExistsException|CodeDeployApplicationDoesNotExistException|any, data: any) => void): Request;
-      updateDeploymentGroup(params: CodeDeployUpdateDeploymentGroupInput, callback?: (err: CodeDeployApplicationNameRequiredException|CodeDeployInvalidApplicationNameException|CodeDeployApplicationDoesNotExistException|CodeDeployInvalidDeploymentGroupNameException|CodeDeployDeploymentGroupAlreadyExistsException|CodeDeployDeploymentGroupNameRequiredException|CodeDeployDeploymentGroupDoesNotExistException|CodeDeployInvalidEC2TagException|CodeDeployInvalidTagException|CodeDeployInvalidAutoScalingGroupException|CodeDeployInvalidDeploymentConfigNameException|CodeDeployDeploymentConfigDoesNotExistException|CodeDeployInvalidRoleException|any, data: CodeDeployUpdateDeploymentGroupOutput|any) => void): Request;
-    }
-
-    export interface CodeDeployAddTagsToOnPremisesInstancesInput {
-        tags: CodeDeployTagList;
-        instanceNames: CodeDeployInstanceNameList;
-    }
-
-    export interface CodeDeployApplicationAlreadyExistsException {
-    }
-
-    export interface CodeDeployApplicationDoesNotExistException {
-    }
-
-    export type CodeDeployApplicationId = string;
-    export interface CodeDeployApplicationInfo {
-        applicationId?: CodeDeployApplicationId;
-        applicationName?: CodeDeployApplicationName;
-        createTime?: CodeDeployTimestamp;
-        linkedToGitHub?: CodeDeployBoolean;
-    }
-
-    export interface CodeDeployApplicationLimitExceededException {
-    }
-
-    export type CodeDeployApplicationName = string;
-    export interface CodeDeployApplicationNameRequiredException {
-    }
-
-    export type CodeDeployApplicationRevisionSortBy = string;
-    export type CodeDeployApplicationsInfoList = Array<CodeDeployApplicationInfo>;
-    export type CodeDeployApplicationsList = Array<CodeDeployApplicationName>;
-    export interface CodeDeployAutoScalingGroup {
-        name?: CodeDeployAutoScalingGroupName;
-        hook?: CodeDeployAutoScalingGroupHook;
-    }
-
-    export type CodeDeployAutoScalingGroupHook = string;
-    export type CodeDeployAutoScalingGroupList = Array<CodeDeployAutoScalingGroup>;
-    export type CodeDeployAutoScalingGroupName = string;
-    export type CodeDeployAutoScalingGroupNameList = Array<CodeDeployAutoScalingGroupName>;
-    export interface CodeDeployBatchGetApplicationsInput {
-        applicationNames?: CodeDeployApplicationsList;
-    }
-
-    export interface CodeDeployBatchGetApplicationsOutput {
-        applicationsInfo?: CodeDeployApplicationsInfoList;
-    }
-
-    export interface CodeDeployBatchGetDeploymentsInput {
-        deploymentIds?: CodeDeployDeploymentsList;
-    }
-
-    export interface CodeDeployBatchGetDeploymentsOutput {
-        deploymentsInfo?: CodeDeployDeploymentsInfoList;
-    }
-
-    export interface CodeDeployBatchGetOnPremisesInstancesInput {
-        instanceNames?: CodeDeployInstanceNameList;
-    }
-
-    export interface CodeDeployBatchGetOnPremisesInstancesOutput {
-        instanceInfos?: CodeDeployInstanceInfoList;
-    }
-
-    export type CodeDeployBoolean = boolean;
-    export interface CodeDeployBucketNameFilterRequiredException {
-    }
-
-    export type CodeDeployBundleType = string;
-    export type CodeDeployCommitId = string;
-    export interface CodeDeployCreateApplicationInput {
-        applicationName: CodeDeployApplicationName;
-    }
-
-    export interface CodeDeployCreateApplicationOutput {
-        applicationId?: CodeDeployApplicationId;
-    }
-
-    export interface CodeDeployCreateDeploymentConfigInput {
-        deploymentConfigName: CodeDeployDeploymentConfigName;
-        minimumHealthyHosts?: CodeDeployMinimumHealthyHosts;
-    }
-
-    export interface CodeDeployCreateDeploymentConfigOutput {
-        deploymentConfigId?: CodeDeployDeploymentConfigId;
-    }
-
-    export interface CodeDeployCreateDeploymentGroupInput {
-        applicationName: CodeDeployApplicationName;
-        deploymentGroupName: CodeDeployDeploymentGroupName;
-        deploymentConfigName?: CodeDeployDeploymentConfigName;
-        ec2TagFilters?: CodeDeployEC2TagFilterList;
-        onPremisesInstanceTagFilters?: CodeDeployTagFilterList;
-        autoScalingGroups?: CodeDeployAutoScalingGroupNameList;
-        serviceRoleArn: CodeDeployRole;
-    }
-
-    export interface CodeDeployCreateDeploymentGroupOutput {
-        deploymentGroupId?: CodeDeployDeploymentGroupId;
-    }
-
-    export interface CodeDeployCreateDeploymentInput {
-        applicationName: CodeDeployApplicationName;
-        deploymentGroupName?: CodeDeployDeploymentGroupName;
-        revision?: CodeDeployRevisionLocation;
-        deploymentConfigName?: CodeDeployDeploymentConfigName;
-        description?: CodeDeployDescription;
-        ignoreApplicationStopFailures?: CodeDeployBoolean;
-    }
-
-    export interface CodeDeployCreateDeploymentOutput {
-        deploymentId?: CodeDeployDeploymentId;
-    }
-
-    export interface CodeDeployDeleteApplicationInput {
-        applicationName: CodeDeployApplicationName;
-    }
-
-    export interface CodeDeployDeleteDeploymentConfigInput {
-        deploymentConfigName: CodeDeployDeploymentConfigName;
-    }
-
-    export interface CodeDeployDeleteDeploymentGroupInput {
-        applicationName: CodeDeployApplicationName;
-        deploymentGroupName: CodeDeployDeploymentGroupName;
-    }
-
-    export interface CodeDeployDeleteDeploymentGroupOutput {
-        hooksNotCleanedUp?: CodeDeployAutoScalingGroupList;
-    }
-
-    export interface CodeDeployDeploymentAlreadyCompletedException {
-    }
-
-    export interface CodeDeployDeploymentConfigAlreadyExistsException {
-    }
-
-    export interface CodeDeployDeploymentConfigDoesNotExistException {
-    }
-
-    export type CodeDeployDeploymentConfigId = string;
-    export interface CodeDeployDeploymentConfigInUseException {
-    }
-
-    export interface CodeDeployDeploymentConfigInfo {
-        deploymentConfigId?: CodeDeployDeploymentConfigId;
-        deploymentConfigName?: CodeDeployDeploymentConfigName;
-        minimumHealthyHosts?: CodeDeployMinimumHealthyHosts;
-        createTime?: CodeDeployTimestamp;
-    }
-
-    export interface CodeDeployDeploymentConfigLimitExceededException {
-    }
-
-    export type CodeDeployDeploymentConfigName = string;
-    export interface CodeDeployDeploymentConfigNameRequiredException {
-    }
-
-    export type CodeDeployDeploymentConfigsList = Array<CodeDeployDeploymentConfigName>;
-    export type CodeDeployDeploymentCreator = string;
-    export interface CodeDeployDeploymentDoesNotExistException {
-    }
-
-    export interface CodeDeployDeploymentGroupAlreadyExistsException {
-    }
-
-    export interface CodeDeployDeploymentGroupDoesNotExistException {
-    }
-
-    export type CodeDeployDeploymentGroupId = string;
-    export interface CodeDeployDeploymentGroupInfo {
-        applicationName?: CodeDeployApplicationName;
-        deploymentGroupId?: CodeDeployDeploymentGroupId;
-        deploymentGroupName?: CodeDeployDeploymentGroupName;
-        deploymentConfigName?: CodeDeployDeploymentConfigName;
-        ec2TagFilters?: CodeDeployEC2TagFilterList;
-        onPremisesInstanceTagFilters?: CodeDeployTagFilterList;
-        autoScalingGroups?: CodeDeployAutoScalingGroupList;
-        serviceRoleArn?: CodeDeployRole;
-        targetRevision?: CodeDeployRevisionLocation;
-    }
-
-    export interface CodeDeployDeploymentGroupLimitExceededException {
-    }
-
-    export type CodeDeployDeploymentGroupName = string;
-    export interface CodeDeployDeploymentGroupNameRequiredException {
-    }
-
-    export type CodeDeployDeploymentGroupsList = Array<CodeDeployDeploymentGroupName>;
-    export type CodeDeployDeploymentId = string;
-    export interface CodeDeployDeploymentIdRequiredException {
-    }
-
-    export interface CodeDeployDeploymentInfo {
-        applicationName?: CodeDeployApplicationName;
-        deploymentGroupName?: CodeDeployDeploymentGroupName;
-        deploymentConfigName?: CodeDeployDeploymentConfigName;
-        deploymentId?: CodeDeployDeploymentId;
-        revision?: CodeDeployRevisionLocation;
-        status?: CodeDeployDeploymentStatus;
-        errorInformation?: CodeDeployErrorInformation;
-        createTime?: CodeDeployTimestamp;
-        startTime?: CodeDeployTimestamp;
-        completeTime?: CodeDeployTimestamp;
-        deploymentOverview?: CodeDeployDeploymentOverview;
-        description?: CodeDeployDescription;
-        creator?: CodeDeployDeploymentCreator;
-        ignoreApplicationStopFailures?: CodeDeployBoolean;
-    }
-
-    export interface CodeDeployDeploymentLimitExceededException {
-    }
-
-    export interface CodeDeployDeploymentNotStartedException {
-    }
-
-    export interface CodeDeployDeploymentOverview {
-        Pending?: CodeDeployInstanceCount;
-        InProgress?: CodeDeployInstanceCount;
-        Succeeded?: CodeDeployInstanceCount;
-        Failed?: CodeDeployInstanceCount;
-        Skipped?: CodeDeployInstanceCount;
-    }
-
-    export type CodeDeployDeploymentStatus = string;
-    export type CodeDeployDeploymentStatusList = Array<CodeDeployDeploymentStatus>;
-    export type CodeDeployDeploymentsInfoList = Array<CodeDeployDeploymentInfo>;
-    export type CodeDeployDeploymentsList = Array<CodeDeployDeploymentId>;
-    export interface CodeDeployDeregisterOnPremisesInstanceInput {
-        instanceName: CodeDeployInstanceName;
-    }
-
-    export type CodeDeployDescription = string;
-    export interface CodeDeployDescriptionTooLongException {
-    }
-
-    export interface CodeDeployDiagnostics {
-        errorCode?: CodeDeployLifecycleErrorCode;
-        scriptName?: CodeDeployScriptName;
-        message?: CodeDeployLifecycleMessage;
-        logTail?: CodeDeployLogTail;
-    }
-
-    export interface CodeDeployEC2TagFilter {
-        Key?: CodeDeployKey;
-        Value?: CodeDeployValue;
-        Type?: CodeDeployEC2TagFilterType;
-    }
-
-    export type CodeDeployEC2TagFilterList = Array<CodeDeployEC2TagFilter>;
-    export type CodeDeployEC2TagFilterType = string;
-    export type CodeDeployETag = string;
-    export type CodeDeployErrorCode = string;
-    export interface CodeDeployErrorInformation {
-        code?: CodeDeployErrorCode;
-        message?: CodeDeployErrorMessage;
-    }
-
-    export type CodeDeployErrorMessage = string;
-    export interface CodeDeployGenericRevisionInfo {
-        description?: CodeDeployDescription;
-        deploymentGroups?: CodeDeployDeploymentGroupsList;
-        firstUsedTime?: CodeDeployTimestamp;
-        lastUsedTime?: CodeDeployTimestamp;
-        registerTime?: CodeDeployTimestamp;
-    }
-
-    export interface CodeDeployGetApplicationInput {
-        applicationName: CodeDeployApplicationName;
-    }
-
-    export interface CodeDeployGetApplicationOutput {
-        application?: CodeDeployApplicationInfo;
-    }
-
-    export interface CodeDeployGetApplicationRevisionInput {
-        applicationName: CodeDeployApplicationName;
-        revision: CodeDeployRevisionLocation;
-    }
-
-    export interface CodeDeployGetApplicationRevisionOutput {
-        applicationName?: CodeDeployApplicationName;
-        revision?: CodeDeployRevisionLocation;
-        revisionInfo?: CodeDeployGenericRevisionInfo;
-    }
-
-    export interface CodeDeployGetDeploymentConfigInput {
-        deploymentConfigName: CodeDeployDeploymentConfigName;
-    }
-
-    export interface CodeDeployGetDeploymentConfigOutput {
-        deploymentConfigInfo?: CodeDeployDeploymentConfigInfo;
-    }
-
-    export interface CodeDeployGetDeploymentGroupInput {
-        applicationName: CodeDeployApplicationName;
-        deploymentGroupName: CodeDeployDeploymentGroupName;
-    }
-
-    export interface CodeDeployGetDeploymentGroupOutput {
-        deploymentGroupInfo?: CodeDeployDeploymentGroupInfo;
-    }
-
-    export interface CodeDeployGetDeploymentInput {
-        deploymentId: CodeDeployDeploymentId;
-    }
-
-    export interface CodeDeployGetDeploymentInstanceInput {
-        deploymentId: CodeDeployDeploymentId;
-        instanceId: CodeDeployInstanceId;
-    }
-
-    export interface CodeDeployGetDeploymentInstanceOutput {
-        instanceSummary?: CodeDeployInstanceSummary;
-    }
-
-    export interface CodeDeployGetDeploymentOutput {
-        deploymentInfo?: CodeDeployDeploymentInfo;
-    }
-
-    export interface CodeDeployGetOnPremisesInstanceInput {
-        instanceName: CodeDeployInstanceName;
-    }
-
-    export interface CodeDeployGetOnPremisesInstanceOutput {
-        instanceInfo?: CodeDeployInstanceInfo;
-    }
-
-    export interface CodeDeployGitHubLocation {
-        repository?: CodeDeployRepository;
-        commitId?: CodeDeployCommitId;
-    }
-
-    export type CodeDeployIamUserArn = string;
-    export interface CodeDeployIamUserArnAlreadyRegisteredException {
-    }
+      addTagsToOnPremisesInstances(params: CodeDeploy.AddTagsToOnPremisesInstancesInput, callback?: (err: CodeDeploy.InstanceNameRequiredException|CodeDeploy.TagRequiredException|CodeDeploy.InvalidTagException|CodeDeploy.TagLimitExceededException|CodeDeploy.InstanceLimitExceededException|CodeDeploy.InstanceNotRegisteredException|any, data: any) => void): Request;
+      batchGetApplications(params: CodeDeploy.BatchGetApplicationsInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|any, data: CodeDeploy.BatchGetApplicationsOutput|any) => void): Request;
+      batchGetDeployments(params: CodeDeploy.BatchGetDeploymentsInput, callback?: (err: CodeDeploy.DeploymentIdRequiredException|CodeDeploy.InvalidDeploymentIdException|any, data: CodeDeploy.BatchGetDeploymentsOutput|any) => void): Request;
+      batchGetOnPremisesInstances(params: CodeDeploy.BatchGetOnPremisesInstancesInput, callback?: (err: CodeDeploy.InstanceNameRequiredException|CodeDeploy.InvalidInstanceNameException|any, data: CodeDeploy.BatchGetOnPremisesInstancesOutput|any) => void): Request;
+      createApplication(params: CodeDeploy.CreateApplicationInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationAlreadyExistsException|CodeDeploy.ApplicationLimitExceededException|any, data: CodeDeploy.CreateApplicationOutput|any) => void): Request;
+      createDeployment(params: CodeDeploy.CreateDeploymentInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.DeploymentGroupNameRequiredException|CodeDeploy.InvalidDeploymentGroupNameException|CodeDeploy.DeploymentGroupDoesNotExistException|CodeDeploy.RevisionRequiredException|CodeDeploy.InvalidRevisionException|CodeDeploy.InvalidDeploymentConfigNameException|CodeDeploy.DeploymentConfigDoesNotExistException|CodeDeploy.DescriptionTooLongException|CodeDeploy.DeploymentLimitExceededException|any, data: CodeDeploy.CreateDeploymentOutput|any) => void): Request;
+      createDeploymentConfig(params: CodeDeploy.CreateDeploymentConfigInput, callback?: (err: CodeDeploy.InvalidDeploymentConfigNameException|CodeDeploy.DeploymentConfigNameRequiredException|CodeDeploy.DeploymentConfigAlreadyExistsException|CodeDeploy.InvalidMinimumHealthyHostValueException|CodeDeploy.DeploymentConfigLimitExceededException|any, data: CodeDeploy.CreateDeploymentConfigOutput|any) => void): Request;
+      createDeploymentGroup(params: CodeDeploy.CreateDeploymentGroupInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.DeploymentGroupNameRequiredException|CodeDeploy.InvalidDeploymentGroupNameException|CodeDeploy.DeploymentGroupAlreadyExistsException|CodeDeploy.InvalidEC2TagException|CodeDeploy.InvalidTagException|CodeDeploy.InvalidAutoScalingGroupException|CodeDeploy.InvalidDeploymentConfigNameException|CodeDeploy.DeploymentConfigDoesNotExistException|CodeDeploy.RoleRequiredException|CodeDeploy.InvalidRoleException|CodeDeploy.DeploymentGroupLimitExceededException|any, data: CodeDeploy.CreateDeploymentGroupOutput|any) => void): Request;
+      deleteApplication(params: CodeDeploy.DeleteApplicationInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|any, data: any) => void): Request;
+      deleteDeploymentConfig(params: CodeDeploy.DeleteDeploymentConfigInput, callback?: (err: CodeDeploy.InvalidDeploymentConfigNameException|CodeDeploy.DeploymentConfigNameRequiredException|CodeDeploy.DeploymentConfigInUseException|CodeDeploy.InvalidOperationException|any, data: any) => void): Request;
+      deleteDeploymentGroup(params: CodeDeploy.DeleteDeploymentGroupInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.DeploymentGroupNameRequiredException|CodeDeploy.InvalidDeploymentGroupNameException|CodeDeploy.InvalidRoleException|any, data: CodeDeploy.DeleteDeploymentGroupOutput|any) => void): Request;
+      deregisterOnPremisesInstance(params: CodeDeploy.DeregisterOnPremisesInstanceInput, callback?: (err: CodeDeploy.InstanceNameRequiredException|CodeDeploy.InvalidInstanceNameException|any, data: any) => void): Request;
+      getApplication(params: CodeDeploy.GetApplicationInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|any, data: CodeDeploy.GetApplicationOutput|any) => void): Request;
+      getApplicationRevision(params: CodeDeploy.GetApplicationRevisionInput, callback?: (err: CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.RevisionDoesNotExistException|CodeDeploy.RevisionRequiredException|CodeDeploy.InvalidRevisionException|any, data: CodeDeploy.GetApplicationRevisionOutput|any) => void): Request;
+      getDeployment(params: CodeDeploy.GetDeploymentInput, callback?: (err: CodeDeploy.DeploymentIdRequiredException|CodeDeploy.InvalidDeploymentIdException|CodeDeploy.DeploymentDoesNotExistException|any, data: CodeDeploy.GetDeploymentOutput|any) => void): Request;
+      getDeploymentConfig(params: CodeDeploy.GetDeploymentConfigInput, callback?: (err: CodeDeploy.InvalidDeploymentConfigNameException|CodeDeploy.DeploymentConfigNameRequiredException|CodeDeploy.DeploymentConfigDoesNotExistException|any, data: CodeDeploy.GetDeploymentConfigOutput|any) => void): Request;
+      getDeploymentGroup(params: CodeDeploy.GetDeploymentGroupInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.DeploymentGroupNameRequiredException|CodeDeploy.InvalidDeploymentGroupNameException|CodeDeploy.DeploymentGroupDoesNotExistException|any, data: CodeDeploy.GetDeploymentGroupOutput|any) => void): Request;
+      getDeploymentInstance(params: CodeDeploy.GetDeploymentInstanceInput, callback?: (err: CodeDeploy.DeploymentIdRequiredException|CodeDeploy.DeploymentDoesNotExistException|CodeDeploy.InstanceIdRequiredException|CodeDeploy.InvalidDeploymentIdException|CodeDeploy.InstanceDoesNotExistException|any, data: CodeDeploy.GetDeploymentInstanceOutput|any) => void): Request;
+      getOnPremisesInstance(params: CodeDeploy.GetOnPremisesInstanceInput, callback?: (err: CodeDeploy.InstanceNameRequiredException|CodeDeploy.InstanceNotRegisteredException|CodeDeploy.InvalidInstanceNameException|any, data: CodeDeploy.GetOnPremisesInstanceOutput|any) => void): Request;
+      listApplicationRevisions(params: CodeDeploy.ListApplicationRevisionsInput, callback?: (err: CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.InvalidSortByException|CodeDeploy.InvalidSortOrderException|CodeDeploy.InvalidBucketNameFilterException|CodeDeploy.InvalidKeyPrefixFilterException|CodeDeploy.BucketNameFilterRequiredException|CodeDeploy.InvalidDeployedStateFilterException|CodeDeploy.InvalidNextTokenException|any, data: CodeDeploy.ListApplicationRevisionsOutput|any) => void): Request;
+      listApplications(params: CodeDeploy.ListApplicationsInput, callback?: (err: CodeDeploy.InvalidNextTokenException|any, data: CodeDeploy.ListApplicationsOutput|any) => void): Request;
+      listDeploymentConfigs(params: CodeDeploy.ListDeploymentConfigsInput, callback?: (err: CodeDeploy.InvalidNextTokenException|any, data: CodeDeploy.ListDeploymentConfigsOutput|any) => void): Request;
+      listDeploymentGroups(params: CodeDeploy.ListDeploymentGroupsInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.InvalidNextTokenException|any, data: CodeDeploy.ListDeploymentGroupsOutput|any) => void): Request;
+      listDeploymentInstances(params: CodeDeploy.ListDeploymentInstancesInput, callback?: (err: CodeDeploy.DeploymentIdRequiredException|CodeDeploy.DeploymentDoesNotExistException|CodeDeploy.DeploymentNotStartedException|CodeDeploy.InvalidNextTokenException|CodeDeploy.InvalidDeploymentIdException|CodeDeploy.InvalidInstanceStatusException|any, data: CodeDeploy.ListDeploymentInstancesOutput|any) => void): Request;
+      listDeployments(params: CodeDeploy.ListDeploymentsInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.InvalidDeploymentGroupNameException|CodeDeploy.DeploymentGroupDoesNotExistException|CodeDeploy.DeploymentGroupNameRequiredException|CodeDeploy.InvalidTimeRangeException|CodeDeploy.InvalidDeploymentStatusException|CodeDeploy.InvalidNextTokenException|any, data: CodeDeploy.ListDeploymentsOutput|any) => void): Request;
+      listOnPremisesInstances(params: CodeDeploy.ListOnPremisesInstancesInput, callback?: (err: CodeDeploy.InvalidRegistrationStatusException|CodeDeploy.InvalidTagFilterException|CodeDeploy.InvalidNextTokenException|any, data: CodeDeploy.ListOnPremisesInstancesOutput|any) => void): Request;
+      registerApplicationRevision(params: CodeDeploy.RegisterApplicationRevisionInput, callback?: (err: CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.DescriptionTooLongException|CodeDeploy.RevisionRequiredException|CodeDeploy.InvalidRevisionException|any, data: any) => void): Request;
+      registerOnPremisesInstance(params: CodeDeploy.RegisterOnPremisesInstanceInput, callback?: (err: CodeDeploy.InstanceNameAlreadyRegisteredException|CodeDeploy.IamUserArnAlreadyRegisteredException|CodeDeploy.InstanceNameRequiredException|CodeDeploy.IamUserArnRequiredException|CodeDeploy.InvalidInstanceNameException|CodeDeploy.InvalidIamUserArnException|any, data: any) => void): Request;
+      removeTagsFromOnPremisesInstances(params: CodeDeploy.RemoveTagsFromOnPremisesInstancesInput, callback?: (err: CodeDeploy.InstanceNameRequiredException|CodeDeploy.TagRequiredException|CodeDeploy.InvalidTagException|CodeDeploy.TagLimitExceededException|CodeDeploy.InstanceLimitExceededException|CodeDeploy.InstanceNotRegisteredException|any, data: any) => void): Request;
+      stopDeployment(params: CodeDeploy.StopDeploymentInput, callback?: (err: CodeDeploy.DeploymentIdRequiredException|CodeDeploy.DeploymentDoesNotExistException|CodeDeploy.DeploymentAlreadyCompletedException|CodeDeploy.InvalidDeploymentIdException|any, data: CodeDeploy.StopDeploymentOutput|any) => void): Request;
+      updateApplication(params: CodeDeploy.UpdateApplicationInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationAlreadyExistsException|CodeDeploy.ApplicationDoesNotExistException|any, data: any) => void): Request;
+      updateDeploymentGroup(params: CodeDeploy.UpdateDeploymentGroupInput, callback?: (err: CodeDeploy.ApplicationNameRequiredException|CodeDeploy.InvalidApplicationNameException|CodeDeploy.ApplicationDoesNotExistException|CodeDeploy.InvalidDeploymentGroupNameException|CodeDeploy.DeploymentGroupAlreadyExistsException|CodeDeploy.DeploymentGroupNameRequiredException|CodeDeploy.DeploymentGroupDoesNotExistException|CodeDeploy.InvalidEC2TagException|CodeDeploy.InvalidTagException|CodeDeploy.InvalidAutoScalingGroupException|CodeDeploy.InvalidDeploymentConfigNameException|CodeDeploy.DeploymentConfigDoesNotExistException|CodeDeploy.InvalidRoleException|any, data: CodeDeploy.UpdateDeploymentGroupOutput|any) => void): Request;
+    }
+    
+    export module CodeDeploy {
+        export type ApplicationId = string;
+        export type ApplicationName = string;    // max: 100, min: 1
+        export type ApplicationRevisionSortBy = string;
+        export type ApplicationsInfoList = ApplicationInfo[];
+        export type ApplicationsList = ApplicationName[];
+        export type AutoScalingGroupHook = string;
+        export type AutoScalingGroupList = AutoScalingGroup[];
+        export type AutoScalingGroupName = string;
+        export type AutoScalingGroupNameList = AutoScalingGroupName[];
+        export type Boolean = boolean;
+        export type BundleType = string;
+        export type CommitId = string;
+        export type DeploymentConfigId = string;
+        export type DeploymentConfigName = string;    // max: 100, min: 1
+        export type DeploymentConfigsList = DeploymentConfigName[];
+        export type DeploymentCreator = string;
+        export type DeploymentGroupId = string;
+        export type DeploymentGroupName = string;    // max: 100, min: 1
+        export type DeploymentGroupsList = DeploymentGroupName[];
+        export type DeploymentId = string;
+        export type DeploymentStatus = string;
+        export type DeploymentStatusList = DeploymentStatus[];
+        export type DeploymentsInfoList = DeploymentInfo[];
+        export type DeploymentsList = DeploymentId[];
+        export type Description = string;
+        export type EC2TagFilterList = EC2TagFilter[];
+        export type EC2TagFilterType = string;
+        export type ETag = string;
+        export type ErrorCode = string;
+        export type ErrorMessage = string;
+        export type IamUserArn = string;
+        export type InstanceArn = string;
+        export type InstanceCount = number;
+        export type InstanceId = string;
+        export type InstanceInfoList = InstanceInfo[];
+        export type InstanceName = string;
+        export type InstanceNameList = InstanceName[];
+        export type InstanceStatus = string;
+        export type InstanceStatusList = InstanceStatus[];
+        export type InstancesList = InstanceId[];
+        export type Key = string;
+        export type LifecycleErrorCode = string;
+        export type LifecycleEventList = LifecycleEvent[];
+        export type LifecycleEventName = string;
+        export type LifecycleEventStatus = string;
+        export type LifecycleMessage = string;
+        export type ListStateFilterAction = string;
+        export type LogTail = string;
+        export type Message = string;
+        export type MinimumHealthyHostsType = string;
+        export type MinimumHealthyHostsValue = number;
+        export type NextToken = string;
+        export type RegistrationStatus = string;
+        export type Repository = string;
+        export type RevisionLocationList = RevisionLocation[];
+        export type RevisionLocationType = string;
+        export type Role = string;
+        export type S3Bucket = string;
+        export type S3Key = string;
+        export type ScriptName = string;
+        export type SortOrder = string;
+        export type StopStatus = string;
+        export type TagFilterList = TagFilter[];
+        export type TagFilterType = string;
+        export type TagList = Tag[];
+        export type Timestamp = number;
+        export type Value = string;
+        export type VersionId = string;
+
+        export interface AddTagsToOnPremisesInstancesInput {
+            tags: TagList;            
+            instanceNames: InstanceNameList;            
+        }
+        export interface ApplicationAlreadyExistsException {
+        }
+        export interface ApplicationDoesNotExistException {
+        }
+        export interface ApplicationInfo {
+            applicationId?: ApplicationId;            
+            applicationName?: ApplicationName;            
+            createTime?: Timestamp;            
+            linkedToGitHub?: Boolean;            
+        }
+        export interface ApplicationLimitExceededException {
+        }
+        export interface ApplicationNameRequiredException {
+        }
+        export interface AutoScalingGroup {
+            name?: AutoScalingGroupName;            
+            hook?: AutoScalingGroupHook;            
+        }
+        export interface BatchGetApplicationsInput {
+            applicationNames?: ApplicationsList;            
+        }
+        export interface BatchGetApplicationsOutput {
+            applicationsInfo?: ApplicationsInfoList;            
+        }
+        export interface BatchGetDeploymentsInput {
+            deploymentIds?: DeploymentsList;            
+        }
+        export interface BatchGetDeploymentsOutput {
+            deploymentsInfo?: DeploymentsInfoList;            
+        }
+        export interface BatchGetOnPremisesInstancesInput {
+            instanceNames?: InstanceNameList;            
+        }
+        export interface BatchGetOnPremisesInstancesOutput {
+            instanceInfos?: InstanceInfoList;            
+        }
+        export interface BucketNameFilterRequiredException {
+        }
+        export interface CreateApplicationInput {
+            applicationName: ApplicationName;            
+        }
+        export interface CreateApplicationOutput {
+            applicationId?: ApplicationId;            
+        }
+        export interface CreateDeploymentConfigInput {
+            deploymentConfigName: DeploymentConfigName;            
+            minimumHealthyHosts?: MinimumHealthyHosts;            
+        }
+        export interface CreateDeploymentConfigOutput {
+            deploymentConfigId?: DeploymentConfigId;            
+        }
+        export interface CreateDeploymentGroupInput {
+            applicationName: ApplicationName;            
+            deploymentGroupName: DeploymentGroupName;            
+            deploymentConfigName?: DeploymentConfigName;            
+            ec2TagFilters?: EC2TagFilterList;            
+            onPremisesInstanceTagFilters?: TagFilterList;            
+            autoScalingGroups?: AutoScalingGroupNameList;            
+            serviceRoleArn: Role;            
+        }
+        export interface CreateDeploymentGroupOutput {
+            deploymentGroupId?: DeploymentGroupId;            
+        }
+        export interface CreateDeploymentInput {
+            applicationName: ApplicationName;            
+            deploymentGroupName?: DeploymentGroupName;            
+            revision?: RevisionLocation;            
+            deploymentConfigName?: DeploymentConfigName;            
+            description?: Description;            
+            ignoreApplicationStopFailures?: Boolean;            
+        }
+        export interface CreateDeploymentOutput {
+            deploymentId?: DeploymentId;            
+        }
+        export interface DeleteApplicationInput {
+            applicationName: ApplicationName;            
+        }
+        export interface DeleteDeploymentConfigInput {
+            deploymentConfigName: DeploymentConfigName;            
+        }
+        export interface DeleteDeploymentGroupInput {
+            applicationName: ApplicationName;            
+            deploymentGroupName: DeploymentGroupName;            
+        }
+        export interface DeleteDeploymentGroupOutput {
+            hooksNotCleanedUp?: AutoScalingGroupList;            
+        }
+        export interface DeploymentAlreadyCompletedException {
+        }
+        export interface DeploymentConfigAlreadyExistsException {
+        }
+        export interface DeploymentConfigDoesNotExistException {
+        }
+        export interface DeploymentConfigInUseException {
+        }
+        export interface DeploymentConfigInfo {
+            deploymentConfigId?: DeploymentConfigId;            
+            deploymentConfigName?: DeploymentConfigName;            
+            minimumHealthyHosts?: MinimumHealthyHosts;            
+            createTime?: Timestamp;            
+        }
+        export interface DeploymentConfigLimitExceededException {
+        }
+        export interface DeploymentConfigNameRequiredException {
+        }
+        export interface DeploymentDoesNotExistException {
+        }
+        export interface DeploymentGroupAlreadyExistsException {
+        }
+        export interface DeploymentGroupDoesNotExistException {
+        }
+        export interface DeploymentGroupInfo {
+            applicationName?: ApplicationName;            
+            deploymentGroupId?: DeploymentGroupId;            
+            deploymentGroupName?: DeploymentGroupName;            
+            deploymentConfigName?: DeploymentConfigName;            
+            ec2TagFilters?: EC2TagFilterList;            
+            onPremisesInstanceTagFilters?: TagFilterList;            
+            autoScalingGroups?: AutoScalingGroupList;            
+            serviceRoleArn?: Role;            
+            targetRevision?: RevisionLocation;            
+        }
+        export interface DeploymentGroupLimitExceededException {
+        }
+        export interface DeploymentGroupNameRequiredException {
+        }
+        export interface DeploymentIdRequiredException {
+        }
+        export interface DeploymentInfo {
+            applicationName?: ApplicationName;            
+            deploymentGroupName?: DeploymentGroupName;            
+            deploymentConfigName?: DeploymentConfigName;            
+            deploymentId?: DeploymentId;            
+            revision?: RevisionLocation;            
+            status?: DeploymentStatus;            
+            errorInformation?: ErrorInformation;            
+            createTime?: Timestamp;            
+            startTime?: Timestamp;            
+            completeTime?: Timestamp;            
+            deploymentOverview?: DeploymentOverview;            
+            description?: Description;            
+            creator?: DeploymentCreator;            
+            ignoreApplicationStopFailures?: Boolean;            
+        }
+        export interface DeploymentLimitExceededException {
+        }
+        export interface DeploymentNotStartedException {
+        }
+        export interface DeploymentOverview {
+            Pending?: InstanceCount;            
+            InProgress?: InstanceCount;            
+            Succeeded?: InstanceCount;            
+            Failed?: InstanceCount;            
+            Skipped?: InstanceCount;            
+        }
+        export interface DeregisterOnPremisesInstanceInput {
+            instanceName: InstanceName;            
+        }
+        export interface DescriptionTooLongException {
+        }
+        export interface Diagnostics {
+            errorCode?: LifecycleErrorCode;            
+            scriptName?: ScriptName;            
+            message?: LifecycleMessage;            
+            logTail?: LogTail;            
+        }
+        export interface EC2TagFilter {
+            Key?: Key;            
+            Value?: Value;            
+            Type?: EC2TagFilterType;            
+        }
+        export interface ErrorInformation {
+            code?: ErrorCode;            
+            message?: ErrorMessage;            
+        }
+        export interface GenericRevisionInfo {
+            description?: Description;            
+            deploymentGroups?: DeploymentGroupsList;            
+            firstUsedTime?: Timestamp;            
+            lastUsedTime?: Timestamp;            
+            registerTime?: Timestamp;            
+        }
+        export interface GetApplicationInput {
+            applicationName: ApplicationName;            
+        }
+        export interface GetApplicationOutput {
+            application?: ApplicationInfo;            
+        }
+        export interface GetApplicationRevisionInput {
+            applicationName: ApplicationName;            
+            revision: RevisionLocation;            
+        }
+        export interface GetApplicationRevisionOutput {
+            applicationName?: ApplicationName;            
+            revision?: RevisionLocation;            
+            revisionInfo?: GenericRevisionInfo;            
+        }
+        export interface GetDeploymentConfigInput {
+            deploymentConfigName: DeploymentConfigName;            
+        }
+        export interface GetDeploymentConfigOutput {
+            deploymentConfigInfo?: DeploymentConfigInfo;            
+        }
+        export interface GetDeploymentGroupInput {
+            applicationName: ApplicationName;            
+            deploymentGroupName: DeploymentGroupName;            
+        }
+        export interface GetDeploymentGroupOutput {
+            deploymentGroupInfo?: DeploymentGroupInfo;            
+        }
+        export interface GetDeploymentInput {
+            deploymentId: DeploymentId;            
+        }
+        export interface GetDeploymentInstanceInput {
+            deploymentId: DeploymentId;            
+            instanceId: InstanceId;            
+        }
+        export interface GetDeploymentInstanceOutput {
+            instanceSummary?: InstanceSummary;            
+        }
+        export interface GetDeploymentOutput {
+            deploymentInfo?: DeploymentInfo;            
+        }
+        export interface GetOnPremisesInstanceInput {
+            instanceName: InstanceName;            
+        }
+        export interface GetOnPremisesInstanceOutput {
+            instanceInfo?: InstanceInfo;            
+        }
+        export interface GitHubLocation {
+            repository?: Repository;            
+            commitId?: CommitId;            
+        }
+        export interface IamUserArnAlreadyRegisteredException {
+        }
+        export interface IamUserArnRequiredException {
+        }
+        export interface InstanceDoesNotExistException {
+        }
+        export interface InstanceIdRequiredException {
+        }
+        export interface InstanceInfo {
+            instanceName?: InstanceName;            
+            iamUserArn?: IamUserArn;            
+            instanceArn?: InstanceArn;            
+            registerTime?: Timestamp;            
+            deregisterTime?: Timestamp;            
+            tags?: TagList;            
+        }
+        export interface InstanceLimitExceededException {
+        }
+        export interface InstanceNameAlreadyRegisteredException {
+        }
+        export interface InstanceNameRequiredException {
+        }
+        export interface InstanceNotRegisteredException {
+        }
+        export interface InstanceSummary {
+            deploymentId?: DeploymentId;            
+            instanceId?: InstanceId;            
+            status?: InstanceStatus;            
+            lastUpdatedAt?: Timestamp;            
+            lifecycleEvents?: LifecycleEventList;            
+        }
+        export interface InvalidApplicationNameException {
+        }
+        export interface InvalidAutoScalingGroupException {
+        }
+        export interface InvalidBucketNameFilterException {
+        }
+        export interface InvalidDeployedStateFilterException {
+        }
+        export interface InvalidDeploymentConfigNameException {
+        }
+        export interface InvalidDeploymentGroupNameException {
+        }
+        export interface InvalidDeploymentIdException {
+        }
+        export interface InvalidDeploymentStatusException {
+        }
+        export interface InvalidEC2TagException {
+        }
+        export interface InvalidIamUserArnException {
+        }
+        export interface InvalidInstanceNameException {
+        }
+        export interface InvalidInstanceStatusException {
+        }
+        export interface InvalidKeyPrefixFilterException {
+        }
+        export interface InvalidMinimumHealthyHostValueException {
+        }
+        export interface InvalidNextTokenException {
+        }
+        export interface InvalidOperationException {
+        }
+        export interface InvalidRegistrationStatusException {
+        }
+        export interface InvalidRevisionException {
+        }
+        export interface InvalidRoleException {
+        }
+        export interface InvalidSortByException {
+        }
+        export interface InvalidSortOrderException {
+        }
+        export interface InvalidTagException {
+        }
+        export interface InvalidTagFilterException {
+        }
+        export interface InvalidTimeRangeException {
+        }
+        export interface LifecycleEvent {
+            lifecycleEventName?: LifecycleEventName;            
+            diagnostics?: Diagnostics;            
+            startTime?: Timestamp;            
+            endTime?: Timestamp;            
+            status?: LifecycleEventStatus;            
+        }
+        export interface ListApplicationRevisionsInput {
+            applicationName: ApplicationName;            
+            sortBy?: ApplicationRevisionSortBy;            
+            sortOrder?: SortOrder;            
+            s3Bucket?: S3Bucket;            
+            s3KeyPrefix?: S3Key;            
+            deployed?: ListStateFilterAction;            
+            nextToken?: NextToken;            
+        }
+        export interface ListApplicationRevisionsOutput {
+            revisions?: RevisionLocationList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListApplicationsInput {
+            nextToken?: NextToken;            
+        }
+        export interface ListApplicationsOutput {
+            applications?: ApplicationsList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentConfigsInput {
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentConfigsOutput {
+            deploymentConfigsList?: DeploymentConfigsList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentGroupsInput {
+            applicationName: ApplicationName;            
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentGroupsOutput {
+            applicationName?: ApplicationName;            
+            deploymentGroups?: DeploymentGroupsList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentInstancesInput {
+            deploymentId: DeploymentId;            
+            nextToken?: NextToken;            
+            instanceStatusFilter?: InstanceStatusList;            
+        }
+        export interface ListDeploymentInstancesOutput {
+            instancesList?: InstancesList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentsInput {
+            applicationName?: ApplicationName;            
+            deploymentGroupName?: DeploymentGroupName;            
+            includeOnlyStatuses?: DeploymentStatusList;            
+            createTimeRange?: TimeRange;            
+            nextToken?: NextToken;            
+        }
+        export interface ListDeploymentsOutput {
+            deployments?: DeploymentsList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListOnPremisesInstancesInput {
+            registrationStatus?: RegistrationStatus;            
+            tagFilters?: TagFilterList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListOnPremisesInstancesOutput {
+            instanceNames?: InstanceNameList;            
+            nextToken?: NextToken;            
+        }
+        export interface MinimumHealthyHosts {
+            value?: MinimumHealthyHostsValue;            
+            type?: MinimumHealthyHostsType;            
+        }
+        export interface RegisterApplicationRevisionInput {
+            applicationName: ApplicationName;            
+            description?: Description;            
+            revision: RevisionLocation;            
+        }
+        export interface RegisterOnPremisesInstanceInput {
+            instanceName: InstanceName;            
+            iamUserArn: IamUserArn;            
+        }
+        export interface RemoveTagsFromOnPremisesInstancesInput {
+            tags: TagList;            
+            instanceNames: InstanceNameList;            
+        }
+        export interface RevisionDoesNotExistException {
+        }
+        export interface RevisionLocation {
+            revisionType?: RevisionLocationType;            
+            s3Location?: S3Location;            
+            gitHubLocation?: GitHubLocation;            
+        }
+        export interface RevisionRequiredException {
+        }
+        export interface RoleRequiredException {
+        }
+        export interface S3Location {
+            bucket?: S3Bucket;            
+            key?: S3Key;            
+            bundleType?: BundleType;            
+            version?: VersionId;            
+            eTag?: ETag;            
+        }
+        export interface StopDeploymentInput {
+            deploymentId: DeploymentId;            
+        }
+        export interface StopDeploymentOutput {
+            status?: StopStatus;            
+            statusMessage?: Message;            
+        }
+        export interface Tag {
+            Key?: Key;            
+            Value?: Value;            
+        }
+        export interface TagFilter {
+            Key?: Key;            
+            Value?: Value;            
+            Type?: TagFilterType;            
+        }
+        export interface TagLimitExceededException {
+        }
+        export interface TagRequiredException {
+        }
+        export interface TimeRange {
+            start?: Timestamp;            
+            end?: Timestamp;            
+        }
+        export interface UpdateApplicationInput {
+            applicationName?: ApplicationName;            
+            newApplicationName?: ApplicationName;            
+        }
+        export interface UpdateDeploymentGroupInput {
+            applicationName: ApplicationName;            
+            currentDeploymentGroupName: DeploymentGroupName;            
+            newDeploymentGroupName?: DeploymentGroupName;            
+            deploymentConfigName?: DeploymentConfigName;            
+            ec2TagFilters?: EC2TagFilterList;            
+            onPremisesInstanceTagFilters?: TagFilterList;            
+            autoScalingGroups?: AutoScalingGroupNameList;            
+            serviceRoleArn?: Role;            
+        }
+        export interface UpdateDeploymentGroupOutput {
+            hooksNotCleanedUp?: AutoScalingGroupList;            
+        }
 
-    export interface CodeDeployIamUserArnRequiredException {
     }
-
-    export type CodeDeployInstanceArn = string;
-    export type CodeDeployInstanceCount = number;
-    export interface CodeDeployInstanceDoesNotExistException {
-    }
-
-    export type CodeDeployInstanceId = string;
-    export interface CodeDeployInstanceIdRequiredException {
-    }
-
-    export interface CodeDeployInstanceInfo {
-        instanceName?: CodeDeployInstanceName;
-        iamUserArn?: CodeDeployIamUserArn;
-        instanceArn?: CodeDeployInstanceArn;
-        registerTime?: CodeDeployTimestamp;
-        deregisterTime?: CodeDeployTimestamp;
-        tags?: CodeDeployTagList;
-    }
-
-    export type CodeDeployInstanceInfoList = Array<CodeDeployInstanceInfo>;
-    export interface CodeDeployInstanceLimitExceededException {
-    }
-
-    export type CodeDeployInstanceName = string;
-    export interface CodeDeployInstanceNameAlreadyRegisteredException {
-    }
-
-    export type CodeDeployInstanceNameList = Array<CodeDeployInstanceName>;
-    export interface CodeDeployInstanceNameRequiredException {
-    }
-
-    export interface CodeDeployInstanceNotRegisteredException {
-    }
-
-    export type CodeDeployInstanceStatus = string;
-    export type CodeDeployInstanceStatusList = Array<CodeDeployInstanceStatus>;
-    export interface CodeDeployInstanceSummary {
-        deploymentId?: CodeDeployDeploymentId;
-        instanceId?: CodeDeployInstanceId;
-        status?: CodeDeployInstanceStatus;
-        lastUpdatedAt?: CodeDeployTimestamp;
-        lifecycleEvents?: CodeDeployLifecycleEventList;
-    }
-
-    export type CodeDeployInstancesList = Array<CodeDeployInstanceId>;
-    export interface CodeDeployInvalidApplicationNameException {
-    }
-
-    export interface CodeDeployInvalidAutoScalingGroupException {
-    }
-
-    export interface CodeDeployInvalidBucketNameFilterException {
-    }
-
-    export interface CodeDeployInvalidDeployedStateFilterException {
-    }
-
-    export interface CodeDeployInvalidDeploymentConfigNameException {
-    }
-
-    export interface CodeDeployInvalidDeploymentGroupNameException {
-    }
-
-    export interface CodeDeployInvalidDeploymentIdException {
-    }
-
-    export interface CodeDeployInvalidDeploymentStatusException {
-    }
-
-    export interface CodeDeployInvalidEC2TagException {
-    }
-
-    export interface CodeDeployInvalidIamUserArnException {
-    }
-
-    export interface CodeDeployInvalidInstanceNameException {
-    }
-
-    export interface CodeDeployInvalidInstanceStatusException {
-    }
-
-    export interface CodeDeployInvalidKeyPrefixFilterException {
-    }
-
-    export interface CodeDeployInvalidMinimumHealthyHostValueException {
-    }
-
-    export interface CodeDeployInvalidNextTokenException {
-    }
-
-    export interface CodeDeployInvalidOperationException {
-    }
-
-    export interface CodeDeployInvalidRegistrationStatusException {
-    }
-
-    export interface CodeDeployInvalidRevisionException {
-    }
-
-    export interface CodeDeployInvalidRoleException {
-    }
-
-    export interface CodeDeployInvalidSortByException {
-    }
-
-    export interface CodeDeployInvalidSortOrderException {
-    }
-
-    export interface CodeDeployInvalidTagException {
-    }
-
-    export interface CodeDeployInvalidTagFilterException {
-    }
-
-    export interface CodeDeployInvalidTimeRangeException {
-    }
-
-    export type CodeDeployKey = string;
-    export type CodeDeployLifecycleErrorCode = string;
-    export interface CodeDeployLifecycleEvent {
-        lifecycleEventName?: CodeDeployLifecycleEventName;
-        diagnostics?: CodeDeployDiagnostics;
-        startTime?: CodeDeployTimestamp;
-        endTime?: CodeDeployTimestamp;
-        status?: CodeDeployLifecycleEventStatus;
-    }
-
-    export type CodeDeployLifecycleEventList = Array<CodeDeployLifecycleEvent>;
-    export type CodeDeployLifecycleEventName = string;
-    export type CodeDeployLifecycleEventStatus = string;
-    export type CodeDeployLifecycleMessage = string;
-    export interface CodeDeployListApplicationRevisionsInput {
-        applicationName: CodeDeployApplicationName;
-        sortBy?: CodeDeployApplicationRevisionSortBy;
-        sortOrder?: CodeDeploySortOrder;
-        s3Bucket?: CodeDeployS3Bucket;
-        s3KeyPrefix?: CodeDeployS3Key;
-        deployed?: CodeDeployListStateFilterAction;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListApplicationRevisionsOutput {
-        revisions?: CodeDeployRevisionLocationList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListApplicationsInput {
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListApplicationsOutput {
-        applications?: CodeDeployApplicationsList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentConfigsInput {
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentConfigsOutput {
-        deploymentConfigsList?: CodeDeployDeploymentConfigsList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentGroupsInput {
-        applicationName: CodeDeployApplicationName;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentGroupsOutput {
-        applicationName?: CodeDeployApplicationName;
-        deploymentGroups?: CodeDeployDeploymentGroupsList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentInstancesInput {
-        deploymentId: CodeDeployDeploymentId;
-        nextToken?: CodeDeployNextToken;
-        instanceStatusFilter?: CodeDeployInstanceStatusList;
-    }
-
-    export interface CodeDeployListDeploymentInstancesOutput {
-        instancesList?: CodeDeployInstancesList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentsInput {
-        applicationName?: CodeDeployApplicationName;
-        deploymentGroupName?: CodeDeployDeploymentGroupName;
-        includeOnlyStatuses?: CodeDeployDeploymentStatusList;
-        createTimeRange?: CodeDeployTimeRange;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListDeploymentsOutput {
-        deployments?: CodeDeployDeploymentsList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListOnPremisesInstancesInput {
-        registrationStatus?: CodeDeployRegistrationStatus;
-        tagFilters?: CodeDeployTagFilterList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export interface CodeDeployListOnPremisesInstancesOutput {
-        instanceNames?: CodeDeployInstanceNameList;
-        nextToken?: CodeDeployNextToken;
-    }
-
-    export type CodeDeployListStateFilterAction = string;
-    export type CodeDeployLogTail = string;
-    export type CodeDeployMessage = string;
-    export interface CodeDeployMinimumHealthyHosts {
-        value?: CodeDeployMinimumHealthyHostsValue;
-        type?: CodeDeployMinimumHealthyHostsType;
-    }
-
-    export type CodeDeployMinimumHealthyHostsType = string;
-    export type CodeDeployMinimumHealthyHostsValue = number;
-    export type CodeDeployNextToken = string;
-    export interface CodeDeployRegisterApplicationRevisionInput {
-        applicationName: CodeDeployApplicationName;
-        description?: CodeDeployDescription;
-        revision: CodeDeployRevisionLocation;
-    }
-
-    export interface CodeDeployRegisterOnPremisesInstanceInput {
-        instanceName: CodeDeployInstanceName;
-        iamUserArn: CodeDeployIamUserArn;
-    }
-
-    export type CodeDeployRegistrationStatus = string;
-    export interface CodeDeployRemoveTagsFromOnPremisesInstancesInput {
-        tags: CodeDeployTagList;
-        instanceNames: CodeDeployInstanceNameList;
-    }
-
-    export type CodeDeployRepository = string;
-    export interface CodeDeployRevisionDoesNotExistException {
-    }
-
-    export interface CodeDeployRevisionLocation {
-        revisionType?: CodeDeployRevisionLocationType;
-        s3Location?: CodeDeployS3Location;
-        gitHubLocation?: CodeDeployGitHubLocation;
-    }
-
-    export type CodeDeployRevisionLocationList = Array<CodeDeployRevisionLocation>;
-    export type CodeDeployRevisionLocationType = string;
-    export interface CodeDeployRevisionRequiredException {
-    }
-
-    export type CodeDeployRole = string;
-    export interface CodeDeployRoleRequiredException {
-    }
-
-    export type CodeDeployS3Bucket = string;
-    export type CodeDeployS3Key = string;
-    export interface CodeDeployS3Location {
-        bucket?: CodeDeployS3Bucket;
-        key?: CodeDeployS3Key;
-        bundleType?: CodeDeployBundleType;
-        version?: CodeDeployVersionId;
-        eTag?: CodeDeployETag;
-    }
-
-    export type CodeDeployScriptName = string;
-    export type CodeDeploySortOrder = string;
-    export interface CodeDeployStopDeploymentInput {
-        deploymentId: CodeDeployDeploymentId;
-    }
-
-    export interface CodeDeployStopDeploymentOutput {
-        status?: CodeDeployStopStatus;
-        statusMessage?: CodeDeployMessage;
-    }
-
-    export type CodeDeployStopStatus = string;
-    export interface CodeDeployTag {
-        Key?: CodeDeployKey;
-        Value?: CodeDeployValue;
-    }
-
-    export interface CodeDeployTagFilter {
-        Key?: CodeDeployKey;
-        Value?: CodeDeployValue;
-        Type?: CodeDeployTagFilterType;
-    }
-
-    export type CodeDeployTagFilterList = Array<CodeDeployTagFilter>;
-    export type CodeDeployTagFilterType = string;
-    export interface CodeDeployTagLimitExceededException {
-    }
-
-    export type CodeDeployTagList = Array<CodeDeployTag>;
-    export interface CodeDeployTagRequiredException {
-    }
-
-    export interface CodeDeployTimeRange {
-        start?: CodeDeployTimestamp;
-        end?: CodeDeployTimestamp;
-    }
-
-    export type CodeDeployTimestamp = number;
-    export interface CodeDeployUpdateApplicationInput {
-        applicationName?: CodeDeployApplicationName;
-        newApplicationName?: CodeDeployApplicationName;
-    }
-
-    export interface CodeDeployUpdateDeploymentGroupInput {
-        applicationName: CodeDeployApplicationName;
-        currentDeploymentGroupName: CodeDeployDeploymentGroupName;
-        newDeploymentGroupName?: CodeDeployDeploymentGroupName;
-        deploymentConfigName?: CodeDeployDeploymentConfigName;
-        ec2TagFilters?: CodeDeployEC2TagFilterList;
-        onPremisesInstanceTagFilters?: CodeDeployTagFilterList;
-        autoScalingGroups?: CodeDeployAutoScalingGroupNameList;
-        serviceRoleArn?: CodeDeployRole;
-    }
-
-    export interface CodeDeployUpdateDeploymentGroupOutput {
-        hooksNotCleanedUp?: CodeDeployAutoScalingGroupList;
-    }
-
-    export type CodeDeployValue = string;
-    export type CodeDeployVersionId = string;
 }

--- a/output/aws-codepipeline.d.ts
+++ b/output/aws-codepipeline.d.ts
@@ -6,590 +6,501 @@ declare module "aws-sdk" {
 
     export class CodePipeline extends Service {
       constructor(options?: any);
-      acknowledgeJob(params: CodePipelineAcknowledgeJobInput, callback?: (err: CodePipelineValidationException|CodePipelineInvalidNonceException|CodePipelineJobNotFoundException|any, data: CodePipelineAcknowledgeJobOutput|any) => void): Request;
-      acknowledgeThirdPartyJob(params: CodePipelineAcknowledgeThirdPartyJobInput, callback?: (err: CodePipelineValidationException|CodePipelineInvalidNonceException|CodePipelineJobNotFoundException|CodePipelineInvalidClientTokenException|any, data: CodePipelineAcknowledgeThirdPartyJobOutput|any) => void): Request;
-      createCustomActionType(params: CodePipelineCreateCustomActionTypeInput, callback?: (err: CodePipelineValidationException|CodePipelineLimitExceededException|any, data: CodePipelineCreateCustomActionTypeOutput|any) => void): Request;
-      createPipeline(params: CodePipelineCreatePipelineInput, callback?: (err: CodePipelineValidationException|CodePipelinePipelineNameInUseException|CodePipelineInvalidStageDeclarationException|CodePipelineInvalidActionDeclarationException|CodePipelineInvalidBlockerDeclarationException|CodePipelineInvalidStructureException|CodePipelineLimitExceededException|any, data: CodePipelineCreatePipelineOutput|any) => void): Request;
-      deleteCustomActionType(params: CodePipelineDeleteCustomActionTypeInput, callback?: (err: CodePipelineValidationException|any, data: any) => void): Request;
-      deletePipeline(params: CodePipelineDeletePipelineInput, callback?: (err: CodePipelineValidationException|any, data: any) => void): Request;
-      disableStageTransition(params: CodePipelineDisableStageTransitionInput, callback?: (err: CodePipelineValidationException|CodePipelinePipelineNotFoundException|CodePipelineStageNotFoundException|any, data: any) => void): Request;
-      enableStageTransition(params: CodePipelineEnableStageTransitionInput, callback?: (err: CodePipelineValidationException|CodePipelinePipelineNotFoundException|CodePipelineStageNotFoundException|any, data: any) => void): Request;
-      getJobDetails(params: CodePipelineGetJobDetailsInput, callback?: (err: CodePipelineValidationException|CodePipelineJobNotFoundException|any, data: CodePipelineGetJobDetailsOutput|any) => void): Request;
-      getPipeline(params: CodePipelineGetPipelineInput, callback?: (err: CodePipelineValidationException|CodePipelinePipelineNotFoundException|CodePipelinePipelineVersionNotFoundException|any, data: CodePipelineGetPipelineOutput|any) => void): Request;
-      getPipelineState(params: CodePipelineGetPipelineStateInput, callback?: (err: CodePipelineValidationException|CodePipelinePipelineNotFoundException|any, data: CodePipelineGetPipelineStateOutput|any) => void): Request;
-      getThirdPartyJobDetails(params: CodePipelineGetThirdPartyJobDetailsInput, callback?: (err: CodePipelineJobNotFoundException|CodePipelineValidationException|CodePipelineInvalidClientTokenException|CodePipelineInvalidJobException|any, data: CodePipelineGetThirdPartyJobDetailsOutput|any) => void): Request;
-      listActionTypes(params: CodePipelineListActionTypesInput, callback?: (err: CodePipelineValidationException|CodePipelineInvalidNextTokenException|any, data: CodePipelineListActionTypesOutput|any) => void): Request;
-      listPipelines(params: CodePipelineListPipelinesInput, callback?: (err: CodePipelineInvalidNextTokenException|any, data: CodePipelineListPipelinesOutput|any) => void): Request;
-      pollForJobs(params: CodePipelinePollForJobsInput, callback?: (err: CodePipelineValidationException|CodePipelineActionTypeNotFoundException|any, data: CodePipelinePollForJobsOutput|any) => void): Request;
-      pollForThirdPartyJobs(params: CodePipelinePollForThirdPartyJobsInput, callback?: (err: CodePipelineActionTypeNotFoundException|CodePipelineValidationException|any, data: CodePipelinePollForThirdPartyJobsOutput|any) => void): Request;
-      putActionRevision(params: CodePipelinePutActionRevisionInput, callback?: (err: CodePipelinePipelineNotFoundException|CodePipelineStageNotFoundException|CodePipelineActionNotFoundException|CodePipelineValidationException|any, data: CodePipelinePutActionRevisionOutput|any) => void): Request;
-      putJobFailureResult(params: CodePipelinePutJobFailureResultInput, callback?: (err: CodePipelineValidationException|CodePipelineJobNotFoundException|CodePipelineInvalidJobStateException|any, data: any) => void): Request;
-      putJobSuccessResult(params: CodePipelinePutJobSuccessResultInput, callback?: (err: CodePipelineValidationException|CodePipelineJobNotFoundException|CodePipelineInvalidJobStateException|any, data: any) => void): Request;
-      putThirdPartyJobFailureResult(params: CodePipelinePutThirdPartyJobFailureResultInput, callback?: (err: CodePipelineValidationException|CodePipelineJobNotFoundException|CodePipelineInvalidJobStateException|CodePipelineInvalidClientTokenException|any, data: any) => void): Request;
-      putThirdPartyJobSuccessResult(params: CodePipelinePutThirdPartyJobSuccessResultInput, callback?: (err: CodePipelineValidationException|CodePipelineJobNotFoundException|CodePipelineInvalidJobStateException|CodePipelineInvalidClientTokenException|any, data: any) => void): Request;
-      startPipelineExecution(params: CodePipelineStartPipelineExecutionInput, callback?: (err: CodePipelineValidationException|CodePipelinePipelineNotFoundException|any, data: CodePipelineStartPipelineExecutionOutput|any) => void): Request;
-      updatePipeline(params: CodePipelineUpdatePipelineInput, callback?: (err: CodePipelineValidationException|CodePipelineInvalidStageDeclarationException|CodePipelineInvalidActionDeclarationException|CodePipelineInvalidBlockerDeclarationException|CodePipelineInvalidStructureException|any, data: CodePipelineUpdatePipelineOutput|any) => void): Request;
-    }
-
-    export interface CodePipelineAWSSessionCredentials {
-        accessKeyId: CodePipelineAccessKeyId;
-        secretAccessKey: CodePipelineSecretAccessKey;
-        sessionToken: CodePipelineSessionToken;
-    }
-
-    export type CodePipelineAccessKeyId = string;
-    export type CodePipelineAccountId = string; // pattern: "[0-9]{12}"
-    export interface CodePipelineAcknowledgeJobInput {
-        jobId: CodePipelineJobId;
-        nonce: CodePipelineNonce;
-    }
-
-    export interface CodePipelineAcknowledgeJobOutput {
-        status?: CodePipelineJobStatus;
-    }
-
-    export interface CodePipelineAcknowledgeThirdPartyJobInput {
-        jobId: CodePipelineThirdPartyJobId;
-        nonce: CodePipelineNonce;
-        clientToken: CodePipelineClientToken;
-    }
-
-    export interface CodePipelineAcknowledgeThirdPartyJobOutput {
-        status?: CodePipelineJobStatus;
-    }
-
-    export type CodePipelineActionCategory = string;
-    export interface CodePipelineActionConfiguration {
-        configuration?: CodePipelineActionConfigurationMap;
-    }
-
-    export type CodePipelineActionConfigurationKey = string;
-    export type CodePipelineActionConfigurationMap = any; // not really - it was 'map' instead - must fix this one
-    export interface CodePipelineActionConfigurationProperty {
-        name: CodePipelineActionConfigurationKey;
-        required: CodePipelineBoolean;
-        key: CodePipelineBoolean;
-        secret: CodePipelineBoolean;
-        queryable?: CodePipelineBoolean;
-        description?: CodePipelineDescription;
-        type?: CodePipelineActionConfigurationPropertyType;
-    }
-
-    export type CodePipelineActionConfigurationPropertyList = Array<CodePipelineActionConfigurationProperty>; // max: 10
-    export type CodePipelineActionConfigurationPropertyType = string;
-    export type CodePipelineActionConfigurationQueryableValue = string; // pattern: "[a-zA-Z0-9_-]+"
-    export type CodePipelineActionConfigurationValue = string;
-    export interface CodePipelineActionContext {
-        name?: CodePipelineActionName;
-    }
-
-    export interface CodePipelineActionDeclaration {
-        name: CodePipelineActionName;
-        actionTypeId: CodePipelineActionTypeId;
-        runOrder?: CodePipelineActionRunOrder;
-        configuration?: CodePipelineActionConfigurationMap;
-        outputArtifacts?: CodePipelineOutputArtifactList;
-        inputArtifacts?: CodePipelineInputArtifactList;
-        roleArn?: CodePipelineRoleArn;
-    }
-
-    export interface CodePipelineActionExecution {
-        status?: CodePipelineActionExecutionStatus;
-        summary?: CodePipelineExecutionSummary;
-        lastStatusChange?: CodePipelineTimestamp;
-        externalExecutionId?: CodePipelineExecutionId;
-        externalExecutionUrl?: CodePipelineUrl;
-        percentComplete?: CodePipelinePercentage;
-        errorDetails?: CodePipelineErrorDetails;
-    }
-
-    export type CodePipelineActionExecutionStatus = string;
-    export type CodePipelineActionName = string; // pattern: "[A-Za-z0-9.@\-_]+"
-    export interface CodePipelineActionNotFoundException {
-    }
-
-    export type CodePipelineActionOwner = string;
-    export type CodePipelineActionProvider = string; // pattern: "[0-9A-Za-z_-]+"
-    export interface CodePipelineActionRevision {
-        revisionId: CodePipelineRevisionId;
-        revisionChangeId?: CodePipelineRevisionChangeId;
-        created: CodePipelineTimestamp;
-    }
-
-    export type CodePipelineActionRunOrder = number;
-    export interface CodePipelineActionState {
-        actionName?: CodePipelineActionName;
-        currentRevision?: CodePipelineActionRevision;
-        latestExecution?: CodePipelineActionExecution;
-        entityUrl?: CodePipelineUrl;
-        revisionUrl?: CodePipelineUrl;
-    }
-
-    export type CodePipelineActionStateList = Array<CodePipelineActionState>;
-    export interface CodePipelineActionType {
-        id: CodePipelineActionTypeId;
-        settings?: CodePipelineActionTypeSettings;
-        actionConfigurationProperties?: CodePipelineActionConfigurationPropertyList;
-        inputArtifactDetails: CodePipelineArtifactDetails;
-        outputArtifactDetails: CodePipelineArtifactDetails;
-    }
-
-    export interface CodePipelineActionTypeId {
-        category: CodePipelineActionCategory;
-        owner: CodePipelineActionOwner;
-        provider: CodePipelineActionProvider;
-        version: CodePipelineVersion;
-    }
-
-    export type CodePipelineActionTypeList = Array<CodePipelineActionType>;
-    export interface CodePipelineActionTypeNotFoundException {
-    }
-
-    export interface CodePipelineActionTypeSettings {
-        thirdPartyConfigurationUrl?: CodePipelineUrl;
-        entityUrlTemplate?: CodePipelineUrlTemplate;
-        executionUrlTemplate?: CodePipelineUrlTemplate;
-        revisionUrlTemplate?: CodePipelineUrlTemplate;
-    }
-
-    export interface CodePipelineArtifact {
-        name?: CodePipelineArtifactName;
-        revision?: CodePipelineRevision;
-        location?: CodePipelineArtifactLocation;
-    }
-
-    export interface CodePipelineArtifactDetails {
-        minimumCount: CodePipelineMinimumArtifactCount;
-        maximumCount: CodePipelineMaximumArtifactCount;
-    }
-
-    export type CodePipelineArtifactList = Array<CodePipelineArtifact>;
-    export interface CodePipelineArtifactLocation {
-        type?: CodePipelineArtifactLocationType;
-        s3Location?: CodePipelineS3ArtifactLocation;
-    }
-
-    export type CodePipelineArtifactLocationType = string;
-    export type CodePipelineArtifactName = string; // pattern: "[a-zA-Z0-9_\-]+"
-    export interface CodePipelineArtifactStore {
-        type: CodePipelineArtifactStoreType;
-        location: CodePipelineArtifactStoreLocation;
-        encryptionKey?: CodePipelineEncryptionKey;
-    }
-
-    export type CodePipelineArtifactStoreLocation = string; // pattern: "[a-zA-Z0-9\-\.]+"
-    export type CodePipelineArtifactStoreType = string;
-    export interface CodePipelineBlockerDeclaration {
-        name: CodePipelineBlockerName;
-        type: CodePipelineBlockerType;
-    }
-
-    export type CodePipelineBlockerName = string;
-    export type CodePipelineBlockerType = string;
-    export type CodePipelineBoolean = boolean;
-    export type CodePipelineClientId = string; // pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    export type CodePipelineClientToken = string;
-    export type CodePipelineCode = string;
-    export type CodePipelineContinuationToken = string;
-    export interface CodePipelineCreateCustomActionTypeInput {
-        category: CodePipelineActionCategory;
-        provider: CodePipelineActionProvider;
-        version: CodePipelineVersion;
-        settings?: CodePipelineActionTypeSettings;
-        configurationProperties?: CodePipelineActionConfigurationPropertyList;
-        inputArtifactDetails: CodePipelineArtifactDetails;
-        outputArtifactDetails: CodePipelineArtifactDetails;
-    }
-
-    export interface CodePipelineCreateCustomActionTypeOutput {
-        actionType: CodePipelineActionType;
-    }
-
-    export interface CodePipelineCreatePipelineInput {
-        pipeline: CodePipelinePipelineDeclaration;
-    }
-
-    export interface CodePipelineCreatePipelineOutput {
-        pipeline?: CodePipelinePipelineDeclaration;
-    }
-
-    export interface CodePipelineCurrentRevision {
-        revision: CodePipelineRevision;
-        changeIdentifier: CodePipelineRevisionChangeIdentifier;
-    }
-
-    export interface CodePipelineDeleteCustomActionTypeInput {
-        category: CodePipelineActionCategory;
-        provider: CodePipelineActionProvider;
-        version: CodePipelineVersion;
-    }
-
-    export interface CodePipelineDeletePipelineInput {
-        name: CodePipelinePipelineName;
-    }
-
-    export type CodePipelineDescription = string;
-    export interface CodePipelineDisableStageTransitionInput {
-        pipelineName: CodePipelinePipelineName;
-        stageName: CodePipelineStageName;
-        transitionType: CodePipelineStageTransitionType;
-        reason: CodePipelineDisabledReason;
-    }
-
-    export type CodePipelineDisabledReason = string; // pattern: "[a-zA-Z0-9!@ \(\)\.\*\?\-]+"
-    export interface CodePipelineEnableStageTransitionInput {
-        pipelineName: CodePipelinePipelineName;
-        stageName: CodePipelineStageName;
-        transitionType: CodePipelineStageTransitionType;
-    }
-
-    export type CodePipelineEnabled = boolean;
-    export interface CodePipelineEncryptionKey {
-        id: CodePipelineEncryptionKeyId;
-        type: CodePipelineEncryptionKeyType;
-    }
-
-    export type CodePipelineEncryptionKeyId = string;
-    export type CodePipelineEncryptionKeyType = string;
-    export interface CodePipelineErrorDetails {
-        code?: CodePipelineCode;
-        message?: CodePipelineMessage;
-    }
-
-    export interface CodePipelineExecutionDetails {
-        summary?: CodePipelineExecutionSummary;
-        externalExecutionId?: CodePipelineExecutionId;
-        percentComplete?: CodePipelinePercentage;
-    }
-
-    export type CodePipelineExecutionId = string;
-    export type CodePipelineExecutionSummary = string;
-    export interface CodePipelineFailureDetails {
-        type: CodePipelineFailureType;
-        message: CodePipelineMessage;
-        externalExecutionId?: CodePipelineExecutionId;
-    }
-
-    export type CodePipelineFailureType = string;
-    export interface CodePipelineGetJobDetailsInput {
-        jobId: CodePipelineJobId;
-    }
-
-    export interface CodePipelineGetJobDetailsOutput {
-        jobDetails?: CodePipelineJobDetails;
-    }
-
-    export interface CodePipelineGetPipelineInput {
-        name: CodePipelinePipelineName;
-        version?: CodePipelinePipelineVersion;
-    }
-
-    export interface CodePipelineGetPipelineOutput {
-        pipeline?: CodePipelinePipelineDeclaration;
-    }
-
-    export interface CodePipelineGetPipelineStateInput {
-        name: CodePipelinePipelineName;
-    }
-
-    export interface CodePipelineGetPipelineStateOutput {
-        pipelineName?: CodePipelinePipelineName;
-        pipelineVersion?: CodePipelinePipelineVersion;
-        stageStates?: CodePipelineStageStateList;
-        created?: CodePipelineTimestamp;
-        updated?: CodePipelineTimestamp;
-    }
-
-    export interface CodePipelineGetThirdPartyJobDetailsInput {
-        jobId: CodePipelineThirdPartyJobId;
-        clientToken: CodePipelineClientToken;
-    }
-
-    export interface CodePipelineGetThirdPartyJobDetailsOutput {
-        jobDetails?: CodePipelineThirdPartyJobDetails;
-    }
-
-    export interface CodePipelineInputArtifact {
-        name: CodePipelineArtifactName;
-    }
-
-    export type CodePipelineInputArtifactList = Array<CodePipelineInputArtifact>;
-    export interface CodePipelineInvalidActionDeclarationException {
-    }
-
-    export interface CodePipelineInvalidBlockerDeclarationException {
-    }
+      acknowledgeJob(params: CodePipeline.AcknowledgeJobInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.InvalidNonceException|CodePipeline.JobNotFoundException|any, data: CodePipeline.AcknowledgeJobOutput|any) => void): Request;
+      acknowledgeThirdPartyJob(params: CodePipeline.AcknowledgeThirdPartyJobInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.InvalidNonceException|CodePipeline.JobNotFoundException|CodePipeline.InvalidClientTokenException|any, data: CodePipeline.AcknowledgeThirdPartyJobOutput|any) => void): Request;
+      createCustomActionType(params: CodePipeline.CreateCustomActionTypeInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.LimitExceededException|any, data: CodePipeline.CreateCustomActionTypeOutput|any) => void): Request;
+      createPipeline(params: CodePipeline.CreatePipelineInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.PipelineNameInUseException|CodePipeline.InvalidStageDeclarationException|CodePipeline.InvalidActionDeclarationException|CodePipeline.InvalidBlockerDeclarationException|CodePipeline.InvalidStructureException|CodePipeline.LimitExceededException|any, data: CodePipeline.CreatePipelineOutput|any) => void): Request;
+      deleteCustomActionType(params: CodePipeline.DeleteCustomActionTypeInput, callback?: (err: CodePipeline.ValidationException|any, data: any) => void): Request;
+      deletePipeline(params: CodePipeline.DeletePipelineInput, callback?: (err: CodePipeline.ValidationException|any, data: any) => void): Request;
+      disableStageTransition(params: CodePipeline.DisableStageTransitionInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.PipelineNotFoundException|CodePipeline.StageNotFoundException|any, data: any) => void): Request;
+      enableStageTransition(params: CodePipeline.EnableStageTransitionInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.PipelineNotFoundException|CodePipeline.StageNotFoundException|any, data: any) => void): Request;
+      getJobDetails(params: CodePipeline.GetJobDetailsInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.JobNotFoundException|any, data: CodePipeline.GetJobDetailsOutput|any) => void): Request;
+      getPipeline(params: CodePipeline.GetPipelineInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.PipelineNotFoundException|CodePipeline.PipelineVersionNotFoundException|any, data: CodePipeline.GetPipelineOutput|any) => void): Request;
+      getPipelineState(params: CodePipeline.GetPipelineStateInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.PipelineNotFoundException|any, data: CodePipeline.GetPipelineStateOutput|any) => void): Request;
+      getThirdPartyJobDetails(params: CodePipeline.GetThirdPartyJobDetailsInput, callback?: (err: CodePipeline.JobNotFoundException|CodePipeline.ValidationException|CodePipeline.InvalidClientTokenException|CodePipeline.InvalidJobException|any, data: CodePipeline.GetThirdPartyJobDetailsOutput|any) => void): Request;
+      listActionTypes(params: CodePipeline.ListActionTypesInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.InvalidNextTokenException|any, data: CodePipeline.ListActionTypesOutput|any) => void): Request;
+      listPipelines(params: CodePipeline.ListPipelinesInput, callback?: (err: CodePipeline.InvalidNextTokenException|any, data: CodePipeline.ListPipelinesOutput|any) => void): Request;
+      pollForJobs(params: CodePipeline.PollForJobsInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.ActionTypeNotFoundException|any, data: CodePipeline.PollForJobsOutput|any) => void): Request;
+      pollForThirdPartyJobs(params: CodePipeline.PollForThirdPartyJobsInput, callback?: (err: CodePipeline.ActionTypeNotFoundException|CodePipeline.ValidationException|any, data: CodePipeline.PollForThirdPartyJobsOutput|any) => void): Request;
+      putActionRevision(params: CodePipeline.PutActionRevisionInput, callback?: (err: CodePipeline.PipelineNotFoundException|CodePipeline.StageNotFoundException|CodePipeline.ActionNotFoundException|CodePipeline.ValidationException|any, data: CodePipeline.PutActionRevisionOutput|any) => void): Request;
+      putJobFailureResult(params: CodePipeline.PutJobFailureResultInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.JobNotFoundException|CodePipeline.InvalidJobStateException|any, data: any) => void): Request;
+      putJobSuccessResult(params: CodePipeline.PutJobSuccessResultInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.JobNotFoundException|CodePipeline.InvalidJobStateException|any, data: any) => void): Request;
+      putThirdPartyJobFailureResult(params: CodePipeline.PutThirdPartyJobFailureResultInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.JobNotFoundException|CodePipeline.InvalidJobStateException|CodePipeline.InvalidClientTokenException|any, data: any) => void): Request;
+      putThirdPartyJobSuccessResult(params: CodePipeline.PutThirdPartyJobSuccessResultInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.JobNotFoundException|CodePipeline.InvalidJobStateException|CodePipeline.InvalidClientTokenException|any, data: any) => void): Request;
+      startPipelineExecution(params: CodePipeline.StartPipelineExecutionInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.PipelineNotFoundException|any, data: CodePipeline.StartPipelineExecutionOutput|any) => void): Request;
+      updatePipeline(params: CodePipeline.UpdatePipelineInput, callback?: (err: CodePipeline.ValidationException|CodePipeline.InvalidStageDeclarationException|CodePipeline.InvalidActionDeclarationException|CodePipeline.InvalidBlockerDeclarationException|CodePipeline.InvalidStructureException|any, data: CodePipeline.UpdatePipelineOutput|any) => void): Request;
+    }
+    
+    export module CodePipeline {
+        export type AccessKeyId = string;
+        export type AccountId = string;    // pattern: &quot;[0-9]{12}&quot;
+        export type ActionCategory = string;
+        export type ActionConfigurationKey = string;    // max: 50, min: 1
+        export type ActionConfigurationMap = {[key:string]: ActionConfigurationValue};
+        export type ActionConfigurationPropertyList = ActionConfigurationProperty[];    // max: 10
+        export type ActionConfigurationPropertyType = string;
+        export type ActionConfigurationQueryableValue = string;    // pattern: &quot;[a-zA-Z0-9_-]+&quot;, max: 20, min: 1
+        export type ActionConfigurationValue = string;    // max: 250, min: 1
+        export type ActionExecutionStatus = string;
+        export type ActionName = string;    // pattern: &quot;[A-Za-z0-9.@\-_]+&quot;, max: 100, min: 1
+        export type ActionOwner = string;
+        export type ActionProvider = string;    // pattern: &quot;[0-9A-Za-z_-]+&quot;, max: 25, min: 1
+        export type ActionRunOrder = number;    // max: 999, min: 1
+        export type ActionStateList = ActionState[];
+        export type ActionTypeList = ActionType[];
+        export type ArtifactList = Artifact[];
+        export type ArtifactLocationType = string;
+        export type ArtifactName = string;    // pattern: &quot;[a-zA-Z0-9_\-]+&quot;, max: 100, min: 1
+        export type ArtifactStoreLocation = string;    // pattern: &quot;[a-zA-Z0-9\-\.]+&quot;, max: 63, min: 3
+        export type ArtifactStoreType = string;
+        export type BlockerName = string;    // max: 100, min: 1
+        export type BlockerType = string;
+        export type Boolean = boolean;
+        export type ClientId = string;    // pattern: &quot;[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}&quot;
+        export type ClientToken = string;
+        export type Code = string;
+        export type ContinuationToken = string;
+        export type Description = string;    // max: 2048, min: 1
+        export type DisabledReason = string;    // pattern: &quot;[a-zA-Z0-9!@ \(\)\.\*\?\-]+&quot;, max: 300, min: 1
+        export type Enabled = boolean;
+        export type EncryptionKeyId = string;    // max: 100, min: 1
+        export type EncryptionKeyType = string;
+        export type ExecutionId = string;
+        export type ExecutionSummary = string;
+        export type FailureType = string;
+        export type InputArtifactList = InputArtifact[];
+        export type JobId = string;    // pattern: &quot;[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}&quot;
+        export type JobList = Job[];
+        export type JobStatus = string;
+        export type LastChangedAt = number;
+        export type LastChangedBy = string;
+        export type MaxBatchSize = number;    // min: 1
+        export type MaximumArtifactCount = number;    // max: 5
+        export type Message = string;
+        export type MinimumArtifactCount = number;    // max: 5
+        export type NextToken = string;
+        export type Nonce = string;
+        export type OutputArtifactList = OutputArtifact[];
+        export type Percentage = number;    // max: 100
+        export type PipelineExecutionId = string;    // pattern: &quot;[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}&quot;
+        export type PipelineList = PipelineSummary[];
+        export type PipelineName = string;    // pattern: &quot;[A-Za-z0-9.@\-_]+&quot;, max: 100, min: 1
+        export type PipelineStageDeclarationList = StageDeclaration[];
+        export type PipelineVersion = number;    // min: 1
+        export type QueryParamMap = {[key:string]: ActionConfigurationQueryableValue};    // max: 1
+        export type Revision = string;
+        export type RevisionChangeId = string;
+        export type RevisionChangeIdentifier = string;
+        export type RevisionId = string;
+        export type RoleArn = string;    // pattern: &quot;arn:[^:]+:iam::[0-9]{12}:role/.*&quot;
+        export type S3BucketName = string;
+        export type S3ObjectKey = string;
+        export type SecretAccessKey = string;
+        export type SessionToken = string;
+        export type StageActionDeclarationList = ActionDeclaration[];
+        export type StageBlockerDeclarationList = BlockerDeclaration[];
+        export type StageName = string;    // pattern: &quot;[A-Za-z0-9.@\-_]+&quot;, max: 100, min: 1
+        export type StageStateList = StageState[];
+        export type StageTransitionType = string;
+        export type ThirdPartyJobId = string;    // max: 512, min: 1
+        export type ThirdPartyJobList = ThirdPartyJob[];
+        export type Timestamp = number;
+        export type Url = string;    // max: 2048, min: 1
+        export type UrlTemplate = string;    // max: 2048, min: 1
+        export type Version = string;    // pattern: &quot;[0-9A-Za-z_-]+&quot;, max: 9, min: 1
+
+        export interface AWSSessionCredentials {
+            accessKeyId: AccessKeyId;            
+            secretAccessKey: SecretAccessKey;            
+            sessionToken: SessionToken;            
+        }
+        export interface AcknowledgeJobInput {
+            jobId: JobId;            
+            nonce: Nonce;            
+        }
+        export interface AcknowledgeJobOutput {
+            status?: JobStatus;            
+        }
+        export interface AcknowledgeThirdPartyJobInput {
+            jobId: ThirdPartyJobId;            
+            nonce: Nonce;            
+            clientToken: ClientToken;            
+        }
+        export interface AcknowledgeThirdPartyJobOutput {
+            status?: JobStatus;            
+        }
+        export interface ActionConfiguration {
+            configuration?: ActionConfigurationMap;            
+        }
+        export interface ActionConfigurationProperty {
+            name: ActionConfigurationKey;            
+            required: Boolean;            
+            key: Boolean;            
+            secret: Boolean;            
+            queryable?: Boolean;            
+            description?: Description;            
+            type?: ActionConfigurationPropertyType;            
+        }
+        export interface ActionContext {
+            name?: ActionName;            
+        }
+        export interface ActionDeclaration {
+            name: ActionName;            
+            actionTypeId: ActionTypeId;            
+            runOrder?: ActionRunOrder;            
+            configuration?: ActionConfigurationMap;            
+            outputArtifacts?: OutputArtifactList;            
+            inputArtifacts?: InputArtifactList;            
+            roleArn?: RoleArn;            
+        }
+        export interface ActionExecution {
+            status?: ActionExecutionStatus;            
+            summary?: ExecutionSummary;            
+            lastStatusChange?: Timestamp;            
+            externalExecutionId?: ExecutionId;            
+            externalExecutionUrl?: Url;            
+            percentComplete?: Percentage;            
+            errorDetails?: ErrorDetails;            
+        }
+        export interface ActionNotFoundException {
+        }
+        export interface ActionRevision {
+            revisionId: RevisionId;            
+            revisionChangeId?: RevisionChangeId;            
+            created: Timestamp;            
+        }
+        export interface ActionState {
+            actionName?: ActionName;            
+            currentRevision?: ActionRevision;            
+            latestExecution?: ActionExecution;            
+            entityUrl?: Url;            
+            revisionUrl?: Url;            
+        }
+        export interface ActionType {
+            id: ActionTypeId;            
+            settings?: ActionTypeSettings;            
+            actionConfigurationProperties?: ActionConfigurationPropertyList;            
+            inputArtifactDetails: ArtifactDetails;            
+            outputArtifactDetails: ArtifactDetails;            
+        }
+        export interface ActionTypeId {
+            category: ActionCategory;            
+            owner: ActionOwner;            
+            provider: ActionProvider;            
+            version: Version;            
+        }
+        export interface ActionTypeNotFoundException {
+        }
+        export interface ActionTypeSettings {
+            thirdPartyConfigurationUrl?: Url;            
+            entityUrlTemplate?: UrlTemplate;            
+            executionUrlTemplate?: UrlTemplate;            
+            revisionUrlTemplate?: UrlTemplate;            
+        }
+        export interface Artifact {
+            name?: ArtifactName;            
+            revision?: Revision;            
+            location?: ArtifactLocation;            
+        }
+        export interface ArtifactDetails {
+            minimumCount: MinimumArtifactCount;            
+            maximumCount: MaximumArtifactCount;            
+        }
+        export interface ArtifactLocation {
+            type?: ArtifactLocationType;            
+            s3Location?: S3ArtifactLocation;            
+        }
+        export interface ArtifactStore {
+            type: ArtifactStoreType;            
+            location: ArtifactStoreLocation;            
+            encryptionKey?: EncryptionKey;            
+        }
+        export interface BlockerDeclaration {
+            name: BlockerName;            
+            type: BlockerType;            
+        }
+        export interface CreateCustomActionTypeInput {
+            category: ActionCategory;            
+            provider: ActionProvider;            
+            version: Version;            
+            settings?: ActionTypeSettings;            
+            configurationProperties?: ActionConfigurationPropertyList;            
+            inputArtifactDetails: ArtifactDetails;            
+            outputArtifactDetails: ArtifactDetails;            
+        }
+        export interface CreateCustomActionTypeOutput {
+            actionType: ActionType;            
+        }
+        export interface CreatePipelineInput {
+            pipeline: PipelineDeclaration;            
+        }
+        export interface CreatePipelineOutput {
+            pipeline?: PipelineDeclaration;            
+        }
+        export interface CurrentRevision {
+            revision: Revision;            
+            changeIdentifier: RevisionChangeIdentifier;            
+        }
+        export interface DeleteCustomActionTypeInput {
+            category: ActionCategory;            
+            provider: ActionProvider;            
+            version: Version;            
+        }
+        export interface DeletePipelineInput {
+            name: PipelineName;            
+        }
+        export interface DisableStageTransitionInput {
+            pipelineName: PipelineName;            
+            stageName: StageName;            
+            transitionType: StageTransitionType;            
+            reason: DisabledReason;            
+        }
+        export interface EnableStageTransitionInput {
+            pipelineName: PipelineName;            
+            stageName: StageName;            
+            transitionType: StageTransitionType;            
+        }
+        export interface EncryptionKey {
+            id: EncryptionKeyId;            
+            type: EncryptionKeyType;            
+        }
+        export interface ErrorDetails {
+            code?: Code;            
+            message?: Message;            
+        }
+        export interface ExecutionDetails {
+            summary?: ExecutionSummary;            
+            externalExecutionId?: ExecutionId;            
+            percentComplete?: Percentage;            
+        }
+        export interface FailureDetails {
+            type: FailureType;            
+            message: Message;            
+            externalExecutionId?: ExecutionId;            
+        }
+        export interface GetJobDetailsInput {
+            jobId: JobId;            
+        }
+        export interface GetJobDetailsOutput {
+            jobDetails?: JobDetails;            
+        }
+        export interface GetPipelineInput {
+            name: PipelineName;            
+            version?: PipelineVersion;            
+        }
+        export interface GetPipelineOutput {
+            pipeline?: PipelineDeclaration;            
+        }
+        export interface GetPipelineStateInput {
+            name: PipelineName;            
+        }
+        export interface GetPipelineStateOutput {
+            pipelineName?: PipelineName;            
+            pipelineVersion?: PipelineVersion;            
+            stageStates?: StageStateList;            
+            created?: Timestamp;            
+            updated?: Timestamp;            
+        }
+        export interface GetThirdPartyJobDetailsInput {
+            jobId: ThirdPartyJobId;            
+            clientToken: ClientToken;            
+        }
+        export interface GetThirdPartyJobDetailsOutput {
+            jobDetails?: ThirdPartyJobDetails;            
+        }
+        export interface InputArtifact {
+            name: ArtifactName;            
+        }
+        export interface InvalidActionDeclarationException {
+        }
+        export interface InvalidBlockerDeclarationException {
+        }
+        export interface InvalidClientTokenException {
+        }
+        export interface InvalidJobException {
+        }
+        export interface InvalidJobStateException {
+        }
+        export interface InvalidNextTokenException {
+        }
+        export interface InvalidNonceException {
+        }
+        export interface InvalidStageDeclarationException {
+        }
+        export interface InvalidStructureException {
+        }
+        export interface Job {
+            id?: JobId;            
+            data?: JobData;            
+            nonce?: Nonce;            
+            accountId?: AccountId;            
+        }
+        export interface JobData {
+            actionTypeId?: ActionTypeId;            
+            actionConfiguration?: ActionConfiguration;            
+            pipelineContext?: PipelineContext;            
+            inputArtifacts?: ArtifactList;            
+            outputArtifacts?: ArtifactList;            
+            artifactCredentials?: AWSSessionCredentials;            
+            continuationToken?: ContinuationToken;            
+            encryptionKey?: EncryptionKey;            
+        }
+        export interface JobDetails {
+            id?: JobId;            
+            data?: JobData;            
+            accountId?: AccountId;            
+        }
+        export interface JobNotFoundException {
+        }
+        export interface LimitExceededException {
+        }
+        export interface ListActionTypesInput {
+            actionOwnerFilter?: ActionOwner;            
+            nextToken?: NextToken;            
+        }
+        export interface ListActionTypesOutput {
+            actionTypes: ActionTypeList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListPipelinesInput {
+            nextToken?: NextToken;            
+        }
+        export interface ListPipelinesOutput {
+            pipelines?: PipelineList;            
+            nextToken?: NextToken;            
+        }
+        export interface OutputArtifact {
+            name: ArtifactName;            
+        }
+        export interface PipelineContext {
+            pipelineName?: PipelineName;            
+            stage?: StageContext;            
+            action?: ActionContext;            
+        }
+        export interface PipelineDeclaration {
+            name: PipelineName;            
+            roleArn: RoleArn;            
+            artifactStore: ArtifactStore;            
+            stages: PipelineStageDeclarationList;            
+            version?: PipelineVersion;            
+        }
+        export interface PipelineNameInUseException {
+        }
+        export interface PipelineNotFoundException {
+        }
+        export interface PipelineSummary {
+            name?: PipelineName;            
+            version?: PipelineVersion;            
+            created?: Timestamp;            
+            updated?: Timestamp;            
+        }
+        export interface PipelineVersionNotFoundException {
+        }
+        export interface PollForJobsInput {
+            actionTypeId: ActionTypeId;            
+            maxBatchSize?: MaxBatchSize;            
+            queryParam?: QueryParamMap;            
+        }
+        export interface PollForJobsOutput {
+            jobs?: JobList;            
+        }
+        export interface PollForThirdPartyJobsInput {
+            actionTypeId: ActionTypeId;            
+            maxBatchSize?: MaxBatchSize;            
+        }
+        export interface PollForThirdPartyJobsOutput {
+            jobs?: ThirdPartyJobList;            
+        }
+        export interface PutActionRevisionInput {
+            pipelineName: PipelineName;            
+            stageName: StageName;            
+            actionName: ActionName;            
+            actionRevision: ActionRevision;            
+        }
+        export interface PutActionRevisionOutput {
+            newRevision?: Boolean;            
+            pipelineExecutionId?: PipelineExecutionId;            
+        }
+        export interface PutJobFailureResultInput {
+            jobId: JobId;            
+            failureDetails: FailureDetails;            
+        }
+        export interface PutJobSuccessResultInput {
+            jobId: JobId;            
+            currentRevision?: CurrentRevision;            
+            continuationToken?: ContinuationToken;            
+            executionDetails?: ExecutionDetails;            
+        }
+        export interface PutThirdPartyJobFailureResultInput {
+            jobId: ThirdPartyJobId;            
+            clientToken: ClientToken;            
+            failureDetails: FailureDetails;            
+        }
+        export interface PutThirdPartyJobSuccessResultInput {
+            jobId: ThirdPartyJobId;            
+            clientToken: ClientToken;            
+            currentRevision?: CurrentRevision;            
+            continuationToken?: ContinuationToken;            
+            executionDetails?: ExecutionDetails;            
+        }
+        export interface S3ArtifactLocation {
+            bucketName: S3BucketName;            
+            objectKey: S3ObjectKey;            
+        }
+        export interface StageContext {
+            name?: StageName;            
+        }
+        export interface StageDeclaration {
+            name: StageName;            
+            blockers?: StageBlockerDeclarationList;            
+            actions: StageActionDeclarationList;            
+        }
+        export interface StageNotFoundException {
+        }
+        export interface StageState {
+            stageName?: StageName;            
+            inboundTransitionState?: TransitionState;            
+            actionStates?: ActionStateList;            
+        }
+        export interface StartPipelineExecutionInput {
+            name: PipelineName;            
+        }
+        export interface StartPipelineExecutionOutput {
+            pipelineExecutionId?: PipelineExecutionId;            
+        }
+        export interface ThirdPartyJob {
+            clientId?: ClientId;            
+            jobId?: JobId;            
+        }
+        export interface ThirdPartyJobData {
+            actionTypeId?: ActionTypeId;            
+            actionConfiguration?: ActionConfiguration;            
+            pipelineContext?: PipelineContext;            
+            inputArtifacts?: ArtifactList;            
+            outputArtifacts?: ArtifactList;            
+            artifactCredentials?: AWSSessionCredentials;            
+            continuationToken?: ContinuationToken;            
+            encryptionKey?: EncryptionKey;            
+        }
+        export interface ThirdPartyJobDetails {
+            id?: ThirdPartyJobId;            
+            data?: ThirdPartyJobData;            
+            nonce?: Nonce;            
+        }
+        export interface TransitionState {
+            enabled?: Enabled;            
+            lastChangedBy?: LastChangedBy;            
+            lastChangedAt?: LastChangedAt;            
+            disabledReason?: DisabledReason;            
+        }
+        export interface UpdatePipelineInput {
+            pipeline: PipelineDeclaration;            
+        }
+        export interface UpdatePipelineOutput {
+            pipeline?: PipelineDeclaration;            
+        }
+        export interface ValidationException {
+        }
 
-    export interface CodePipelineInvalidClientTokenException {
     }
-
-    export interface CodePipelineInvalidJobException {
-    }
-
-    export interface CodePipelineInvalidJobStateException {
-    }
-
-    export interface CodePipelineInvalidNextTokenException {
-    }
-
-    export interface CodePipelineInvalidNonceException {
-    }
-
-    export interface CodePipelineInvalidStageDeclarationException {
-    }
-
-    export interface CodePipelineInvalidStructureException {
-    }
-
-    export interface CodePipelineJob {
-        id?: CodePipelineJobId;
-        data?: CodePipelineJobData;
-        nonce?: CodePipelineNonce;
-        accountId?: CodePipelineAccountId;
-    }
-
-    export interface CodePipelineJobData {
-        actionTypeId?: CodePipelineActionTypeId;
-        actionConfiguration?: CodePipelineActionConfiguration;
-        pipelineContext?: CodePipelinePipelineContext;
-        inputArtifacts?: CodePipelineArtifactList;
-        outputArtifacts?: CodePipelineArtifactList;
-        artifactCredentials?: CodePipelineAWSSessionCredentials;
-        continuationToken?: CodePipelineContinuationToken;
-        encryptionKey?: CodePipelineEncryptionKey;
-    }
-
-    export interface CodePipelineJobDetails {
-        id?: CodePipelineJobId;
-        data?: CodePipelineJobData;
-        accountId?: CodePipelineAccountId;
-    }
-
-    export type CodePipelineJobId = string; // pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    export type CodePipelineJobList = Array<CodePipelineJob>;
-    export interface CodePipelineJobNotFoundException {
-    }
-
-    export type CodePipelineJobStatus = string;
-    export type CodePipelineLastChangedAt = number;
-    export type CodePipelineLastChangedBy = string;
-    export interface CodePipelineLimitExceededException {
-    }
-
-    export interface CodePipelineListActionTypesInput {
-        actionOwnerFilter?: CodePipelineActionOwner;
-        nextToken?: CodePipelineNextToken;
-    }
-
-    export interface CodePipelineListActionTypesOutput {
-        actionTypes: CodePipelineActionTypeList;
-        nextToken?: CodePipelineNextToken;
-    }
-
-    export interface CodePipelineListPipelinesInput {
-        nextToken?: CodePipelineNextToken;
-    }
-
-    export interface CodePipelineListPipelinesOutput {
-        pipelines?: CodePipelinePipelineList;
-        nextToken?: CodePipelineNextToken;
-    }
-
-    export type CodePipelineMaxBatchSize = number;
-    export type CodePipelineMaximumArtifactCount = number;
-    export type CodePipelineMessage = string;
-    export type CodePipelineMinimumArtifactCount = number;
-    export type CodePipelineNextToken = string;
-    export type CodePipelineNonce = string;
-    export interface CodePipelineOutputArtifact {
-        name: CodePipelineArtifactName;
-    }
-
-    export type CodePipelineOutputArtifactList = Array<CodePipelineOutputArtifact>;
-    export type CodePipelinePercentage = number;
-    export interface CodePipelinePipelineContext {
-        pipelineName?: CodePipelinePipelineName;
-        stage?: CodePipelineStageContext;
-        action?: CodePipelineActionContext;
-    }
-
-    export interface CodePipelinePipelineDeclaration {
-        name: CodePipelinePipelineName;
-        roleArn: CodePipelineRoleArn;
-        artifactStore: CodePipelineArtifactStore;
-        stages: CodePipelinePipelineStageDeclarationList;
-        version?: CodePipelinePipelineVersion;
-    }
-
-    export type CodePipelinePipelineExecutionId = string; // pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    export type CodePipelinePipelineList = Array<CodePipelinePipelineSummary>;
-    export type CodePipelinePipelineName = string; // pattern: "[A-Za-z0-9.@\-_]+"
-    export interface CodePipelinePipelineNameInUseException {
-    }
-
-    export interface CodePipelinePipelineNotFoundException {
-    }
-
-    export type CodePipelinePipelineStageDeclarationList = Array<CodePipelineStageDeclaration>;
-    export interface CodePipelinePipelineSummary {
-        name?: CodePipelinePipelineName;
-        version?: CodePipelinePipelineVersion;
-        created?: CodePipelineTimestamp;
-        updated?: CodePipelineTimestamp;
-    }
-
-    export type CodePipelinePipelineVersion = number;
-    export interface CodePipelinePipelineVersionNotFoundException {
-    }
-
-    export interface CodePipelinePollForJobsInput {
-        actionTypeId: CodePipelineActionTypeId;
-        maxBatchSize?: CodePipelineMaxBatchSize;
-        queryParam?: CodePipelineQueryParamMap;
-    }
-
-    export interface CodePipelinePollForJobsOutput {
-        jobs?: CodePipelineJobList;
-    }
-
-    export interface CodePipelinePollForThirdPartyJobsInput {
-        actionTypeId: CodePipelineActionTypeId;
-        maxBatchSize?: CodePipelineMaxBatchSize;
-    }
-
-    export interface CodePipelinePollForThirdPartyJobsOutput {
-        jobs?: CodePipelineThirdPartyJobList;
-    }
-
-    export interface CodePipelinePutActionRevisionInput {
-        pipelineName: CodePipelinePipelineName;
-        stageName: CodePipelineStageName;
-        actionName: CodePipelineActionName;
-        actionRevision: CodePipelineActionRevision;
-    }
-
-    export interface CodePipelinePutActionRevisionOutput {
-        newRevision?: CodePipelineBoolean;
-        pipelineExecutionId?: CodePipelinePipelineExecutionId;
-    }
-
-    export interface CodePipelinePutJobFailureResultInput {
-        jobId: CodePipelineJobId;
-        failureDetails: CodePipelineFailureDetails;
-    }
-
-    export interface CodePipelinePutJobSuccessResultInput {
-        jobId: CodePipelineJobId;
-        currentRevision?: CodePipelineCurrentRevision;
-        continuationToken?: CodePipelineContinuationToken;
-        executionDetails?: CodePipelineExecutionDetails;
-    }
-
-    export interface CodePipelinePutThirdPartyJobFailureResultInput {
-        jobId: CodePipelineThirdPartyJobId;
-        clientToken: CodePipelineClientToken;
-        failureDetails: CodePipelineFailureDetails;
-    }
-
-    export interface CodePipelinePutThirdPartyJobSuccessResultInput {
-        jobId: CodePipelineThirdPartyJobId;
-        clientToken: CodePipelineClientToken;
-        currentRevision?: CodePipelineCurrentRevision;
-        continuationToken?: CodePipelineContinuationToken;
-        executionDetails?: CodePipelineExecutionDetails;
-    }
-
-    export type CodePipelineQueryParamMap = any; // not really - it was 'map' instead - must fix this one
-    export type CodePipelineRevision = string;
-    export type CodePipelineRevisionChangeId = string;
-    export type CodePipelineRevisionChangeIdentifier = string;
-    export type CodePipelineRevisionId = string;
-    export type CodePipelineRoleArn = string; // pattern: "arn:[^:]+:iam::[0-9]{12}:role/.*"
-    export interface CodePipelineS3ArtifactLocation {
-        bucketName: CodePipelineS3BucketName;
-        objectKey: CodePipelineS3ObjectKey;
-    }
-
-    export type CodePipelineS3BucketName = string;
-    export type CodePipelineS3ObjectKey = string;
-    export type CodePipelineSecretAccessKey = string;
-    export type CodePipelineSessionToken = string;
-    export type CodePipelineStageActionDeclarationList = Array<CodePipelineActionDeclaration>;
-    export type CodePipelineStageBlockerDeclarationList = Array<CodePipelineBlockerDeclaration>;
-    export interface CodePipelineStageContext {
-        name?: CodePipelineStageName;
-    }
-
-    export interface CodePipelineStageDeclaration {
-        name: CodePipelineStageName;
-        blockers?: CodePipelineStageBlockerDeclarationList;
-        actions: CodePipelineStageActionDeclarationList;
-    }
-
-    export type CodePipelineStageName = string; // pattern: "[A-Za-z0-9.@\-_]+"
-    export interface CodePipelineStageNotFoundException {
-    }
-
-    export interface CodePipelineStageState {
-        stageName?: CodePipelineStageName;
-        inboundTransitionState?: CodePipelineTransitionState;
-        actionStates?: CodePipelineActionStateList;
-    }
-
-    export type CodePipelineStageStateList = Array<CodePipelineStageState>;
-    export type CodePipelineStageTransitionType = string;
-    export interface CodePipelineStartPipelineExecutionInput {
-        name: CodePipelinePipelineName;
-    }
-
-    export interface CodePipelineStartPipelineExecutionOutput {
-        pipelineExecutionId?: CodePipelinePipelineExecutionId;
-    }
-
-    export interface CodePipelineThirdPartyJob {
-        clientId?: CodePipelineClientId;
-        jobId?: CodePipelineJobId;
-    }
-
-    export interface CodePipelineThirdPartyJobData {
-        actionTypeId?: CodePipelineActionTypeId;
-        actionConfiguration?: CodePipelineActionConfiguration;
-        pipelineContext?: CodePipelinePipelineContext;
-        inputArtifacts?: CodePipelineArtifactList;
-        outputArtifacts?: CodePipelineArtifactList;
-        artifactCredentials?: CodePipelineAWSSessionCredentials;
-        continuationToken?: CodePipelineContinuationToken;
-        encryptionKey?: CodePipelineEncryptionKey;
-    }
-
-    export interface CodePipelineThirdPartyJobDetails {
-        id?: CodePipelineThirdPartyJobId;
-        data?: CodePipelineThirdPartyJobData;
-        nonce?: CodePipelineNonce;
-    }
-
-    export type CodePipelineThirdPartyJobId = string;
-    export type CodePipelineThirdPartyJobList = Array<CodePipelineThirdPartyJob>;
-    export type CodePipelineTimestamp = number;
-    export interface CodePipelineTransitionState {
-        enabled?: CodePipelineEnabled;
-        lastChangedBy?: CodePipelineLastChangedBy;
-        lastChangedAt?: CodePipelineLastChangedAt;
-        disabledReason?: CodePipelineDisabledReason;
-    }
-
-    export interface CodePipelineUpdatePipelineInput {
-        pipeline: CodePipelinePipelineDeclaration;
-    }
-
-    export interface CodePipelineUpdatePipelineOutput {
-        pipeline?: CodePipelinePipelineDeclaration;
-    }
-
-    export type CodePipelineUrl = string;
-    export type CodePipelineUrlTemplate = string;
-    export interface CodePipelineValidationException {
-    }
-
-    export type CodePipelineVersion = string; // pattern: "[0-9A-Za-z_-]+"
 }

--- a/output/aws-datapipeline.d.ts
+++ b/output/aws-datapipeline.d.ts
@@ -6,345 +6,291 @@ declare module "aws-sdk" {
 
     export class DataPipeline extends Service {
       constructor(options?: any);
-      activatePipeline(params: DataPipelineActivatePipelineInput, callback?: (err: DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineActivatePipelineOutput|any) => void): Request;
-      addTags(params: DataPipelineAddTagsInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineAddTagsOutput|any) => void): Request;
-      createPipeline(params: DataPipelineCreatePipelineInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineCreatePipelineOutput|any) => void): Request;
-      deactivatePipeline(params: DataPipelineDeactivatePipelineInput, callback?: (err: DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineDeactivatePipelineOutput|any) => void): Request;
-      deletePipeline(params: DataPipelineDeletePipelineInput, callback?: (err: DataPipelinePipelineNotFoundException|DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: any) => void): Request;
-      describeObjects(params: DataPipelineDescribeObjectsInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineDescribeObjectsOutput|any) => void): Request;
-      describePipelines(params: DataPipelineDescribePipelinesInput, callback?: (err: DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineDescribePipelinesOutput|any) => void): Request;
-      evaluateExpression(params: DataPipelineEvaluateExpressionInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineTaskNotFoundException|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineEvaluateExpressionOutput|any) => void): Request;
-      getPipelineDefinition(params: DataPipelineGetPipelineDefinitionInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineGetPipelineDefinitionOutput|any) => void): Request;
-      listPipelines(params: DataPipelineListPipelinesInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineListPipelinesOutput|any) => void): Request;
-      pollForTask(params: DataPipelinePollForTaskInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelineTaskNotFoundException|any, data: DataPipelinePollForTaskOutput|any) => void): Request;
-      putPipelineDefinition(params: DataPipelinePutPipelineDefinitionInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelinePutPipelineDefinitionOutput|any) => void): Request;
-      queryObjects(params: DataPipelineQueryObjectsInput, callback?: (err: DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineQueryObjectsOutput|any) => void): Request;
-      removeTags(params: DataPipelineRemoveTagsInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineRemoveTagsOutput|any) => void): Request;
-      reportTaskProgress(params: DataPipelineReportTaskProgressInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelineTaskNotFoundException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineReportTaskProgressOutput|any) => void): Request;
-      reportTaskRunnerHeartbeat(params: DataPipelineReportTaskRunnerHeartbeatInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: DataPipelineReportTaskRunnerHeartbeatOutput|any) => void): Request;
-      setStatus(params: DataPipelineSetStatusInput, callback?: (err: DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|DataPipelineInternalServiceError|DataPipelineInvalidRequestException|any, data: any) => void): Request;
-      setTaskStatus(params: DataPipelineSetTaskStatusInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineTaskNotFoundException|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineSetTaskStatusOutput|any) => void): Request;
-      validatePipelineDefinition(params: DataPipelineValidatePipelineDefinitionInput, callback?: (err: DataPipelineInternalServiceError|DataPipelineInvalidRequestException|DataPipelinePipelineNotFoundException|DataPipelinePipelineDeletedException|any, data: DataPipelineValidatePipelineDefinitionOutput|any) => void): Request;
+      activatePipeline(params: DataPipeline.ActivatePipelineInput, callback?: (err: DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.ActivatePipelineOutput|any) => void): Request;
+      addTags(params: DataPipeline.AddTagsInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.AddTagsOutput|any) => void): Request;
+      createPipeline(params: DataPipeline.CreatePipelineInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.CreatePipelineOutput|any) => void): Request;
+      deactivatePipeline(params: DataPipeline.DeactivatePipelineInput, callback?: (err: DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.DeactivatePipelineOutput|any) => void): Request;
+      deletePipeline(params: DataPipeline.DeletePipelineInput, callback?: (err: DataPipeline.PipelineNotFoundException|DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: any) => void): Request;
+      describeObjects(params: DataPipeline.DescribeObjectsInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.DescribeObjectsOutput|any) => void): Request;
+      describePipelines(params: DataPipeline.DescribePipelinesInput, callback?: (err: DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.DescribePipelinesOutput|any) => void): Request;
+      evaluateExpression(params: DataPipeline.EvaluateExpressionInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.TaskNotFoundException|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.EvaluateExpressionOutput|any) => void): Request;
+      getPipelineDefinition(params: DataPipeline.GetPipelineDefinitionInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.GetPipelineDefinitionOutput|any) => void): Request;
+      listPipelines(params: DataPipeline.ListPipelinesInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.ListPipelinesOutput|any) => void): Request;
+      pollForTask(params: DataPipeline.PollForTaskInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.TaskNotFoundException|any, data: DataPipeline.PollForTaskOutput|any) => void): Request;
+      putPipelineDefinition(params: DataPipeline.PutPipelineDefinitionInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.PutPipelineDefinitionOutput|any) => void): Request;
+      queryObjects(params: DataPipeline.QueryObjectsInput, callback?: (err: DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.QueryObjectsOutput|any) => void): Request;
+      removeTags(params: DataPipeline.RemoveTagsInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.RemoveTagsOutput|any) => void): Request;
+      reportTaskProgress(params: DataPipeline.ReportTaskProgressInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.TaskNotFoundException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.ReportTaskProgressOutput|any) => void): Request;
+      reportTaskRunnerHeartbeat(params: DataPipeline.ReportTaskRunnerHeartbeatInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: DataPipeline.ReportTaskRunnerHeartbeatOutput|any) => void): Request;
+      setStatus(params: DataPipeline.SetStatusInput, callback?: (err: DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|any, data: any) => void): Request;
+      setTaskStatus(params: DataPipeline.SetTaskStatusInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.TaskNotFoundException|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.SetTaskStatusOutput|any) => void): Request;
+      validatePipelineDefinition(params: DataPipeline.ValidatePipelineDefinitionInput, callback?: (err: DataPipeline.InternalServiceError|DataPipeline.InvalidRequestException|DataPipeline.PipelineNotFoundException|DataPipeline.PipelineDeletedException|any, data: DataPipeline.ValidatePipelineDefinitionOutput|any) => void): Request;
     }
+    
+    export module DataPipeline {
+        export type OperatorType = string;
+        export type ParameterAttributeList = ParameterAttribute[];
+        export type ParameterObjectList = ParameterObject[];
+        export type ParameterValueList = ParameterValue[];
+        export type PipelineDescriptionList = PipelineDescription[];
+        export type PipelineObjectList = PipelineObject[];
+        export type PipelineObjectMap = {[key:string]: PipelineObject};
+        export type SelectorList = Selector[];
+        export type TaskStatus = string;
+        export type ValidationErrors = ValidationError[];
+        export type ValidationWarnings = ValidationWarning[];
+        export type attributeNameString = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 256, min: 1
+        export type attributeValueString = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 10240
+        export type cancelActive = boolean;
+        export type errorMessage = string;
+        export type fieldList = Field[];
+        export type fieldNameString = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 256, min: 1
+        export type fieldStringValue = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 10240
+        export type id = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 1024, min: 1
+        export type idList = id[];
+        export type int = number;
+        export type longString = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 20971520
+        export type pipelineList = PipelineIdName[];
+        export type stringList = string[];
+        export type tagKey = string;    // max: 128, min: 1
+        export type tagList = Tag[];    // max: 10
+        export type tagValue = string;    // max: 256
+        export type taskId = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 2048, min: 1
+        export type timestamp = number;
+        export type validationMessage = string;    // pattern: &quot;[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*&quot;, max: 10000
+        export type validationMessages = validationMessage[];
 
-    export interface DataPipelineActivatePipelineInput {
-        pipelineId: DataPipelineid;
-        parameterValues?: DataPipelineParameterValueList;
-        startTimestamp?: DataPipelinetimestamp;
+        export interface ActivatePipelineInput {
+            pipelineId: id;            
+            parameterValues?: ParameterValueList;            
+            startTimestamp?: timestamp;            
+        }
+        export interface ActivatePipelineOutput {
+        }
+        export interface AddTagsInput {
+            pipelineId: id;            
+            tags: tagList;            
+        }
+        export interface AddTagsOutput {
+        }
+        export interface CreatePipelineInput {
+            name: id;            
+            uniqueId: id;            
+            description?: string;            
+            tags?: tagList;            
+        }
+        export interface CreatePipelineOutput {
+            pipelineId: id;            
+        }
+        export interface DeactivatePipelineInput {
+            pipelineId: id;            
+            cancelActive?: cancelActive;            
+        }
+        export interface DeactivatePipelineOutput {
+        }
+        export interface DeletePipelineInput {
+            pipelineId: id;            
+        }
+        export interface DescribeObjectsInput {
+            pipelineId: id;            
+            objectIds: idList;            
+            evaluateExpressions?: boolean;            
+            marker?: string;            
+        }
+        export interface DescribeObjectsOutput {
+            pipelineObjects: PipelineObjectList;            
+            marker?: string;            
+            hasMoreResults?: boolean;            
+        }
+        export interface DescribePipelinesInput {
+            pipelineIds: idList;            
+        }
+        export interface DescribePipelinesOutput {
+            pipelineDescriptionList: PipelineDescriptionList;            
+        }
+        export interface EvaluateExpressionInput {
+            pipelineId: id;            
+            objectId: id;            
+            expression: longString;            
+        }
+        export interface EvaluateExpressionOutput {
+            evaluatedExpression: longString;            
+        }
+        export interface Field {
+            key: fieldNameString;            
+            stringValue?: fieldStringValue;            
+            refValue?: fieldNameString;            
+        }
+        export interface GetPipelineDefinitionInput {
+            pipelineId: id;            
+            version?: string;            
+        }
+        export interface GetPipelineDefinitionOutput {
+            pipelineObjects?: PipelineObjectList;            
+            parameterObjects?: ParameterObjectList;            
+            parameterValues?: ParameterValueList;            
+        }
+        export interface InstanceIdentity {
+            document?: string;            
+            signature?: string;            
+        }
+        export interface InternalServiceError {
+            message?: errorMessage;            
+        }
+        export interface InvalidRequestException {
+            message?: errorMessage;            
+        }
+        export interface ListPipelinesInput {
+            marker?: string;            
+        }
+        export interface ListPipelinesOutput {
+            pipelineIdList: pipelineList;            
+            marker?: string;            
+            hasMoreResults?: boolean;            
+        }
+        export interface Operator {
+            type?: OperatorType;            
+            values?: stringList;            
+        }
+        export interface ParameterAttribute {
+            key: attributeNameString;            
+            stringValue: attributeValueString;            
+        }
+        export interface ParameterObject {
+            id: fieldNameString;            
+            attributes: ParameterAttributeList;            
+        }
+        export interface ParameterValue {
+            id: fieldNameString;            
+            stringValue: fieldStringValue;            
+        }
+        export interface PipelineDeletedException {
+            message?: errorMessage;            
+        }
+        export interface PipelineDescription {
+            pipelineId: id;            
+            name: id;            
+            fields: fieldList;            
+            description?: string;            
+            tags?: tagList;            
+        }
+        export interface PipelineIdName {
+            id?: id;            
+            name?: id;            
+        }
+        export interface PipelineNotFoundException {
+            message?: errorMessage;            
+        }
+        export interface PipelineObject {
+            id: id;            
+            name: id;            
+            fields: fieldList;            
+        }
+        export interface PollForTaskInput {
+            workerGroup: string;            
+            hostname?: id;            
+            instanceIdentity?: InstanceIdentity;            
+        }
+        export interface PollForTaskOutput {
+            taskObject?: TaskObject;            
+        }
+        export interface PutPipelineDefinitionInput {
+            pipelineId: id;            
+            pipelineObjects: PipelineObjectList;            
+            parameterObjects?: ParameterObjectList;            
+            parameterValues?: ParameterValueList;            
+        }
+        export interface PutPipelineDefinitionOutput {
+            validationErrors?: ValidationErrors;            
+            validationWarnings?: ValidationWarnings;            
+            errored: boolean;            
+        }
+        export interface Query {
+            selectors?: SelectorList;            
+        }
+        export interface QueryObjectsInput {
+            pipelineId: id;            
+            query?: Query;            
+            sphere: string;            
+            marker?: string;            
+            limit?: int;            
+        }
+        export interface QueryObjectsOutput {
+            ids?: idList;            
+            marker?: string;            
+            hasMoreResults?: boolean;            
+        }
+        export interface RemoveTagsInput {
+            pipelineId: id;            
+            tagKeys: stringList;            
+        }
+        export interface RemoveTagsOutput {
+        }
+        export interface ReportTaskProgressInput {
+            taskId: taskId;            
+            fields?: fieldList;            
+        }
+        export interface ReportTaskProgressOutput {
+            canceled: boolean;            
+        }
+        export interface ReportTaskRunnerHeartbeatInput {
+            taskrunnerId: id;            
+            workerGroup?: string;            
+            hostname?: id;            
+        }
+        export interface ReportTaskRunnerHeartbeatOutput {
+            terminate: boolean;            
+        }
+        export interface Selector {
+            fieldName?: string;            
+            operator?: Operator;            
+        }
+        export interface SetStatusInput {
+            pipelineId: id;            
+            objectIds: idList;            
+            status: string;            
+        }
+        export interface SetTaskStatusInput {
+            taskId: taskId;            
+            taskStatus: TaskStatus;            
+            errorId?: string;            
+            errorMessage?: errorMessage;            
+            errorStackTrace?: string;            
+        }
+        export interface SetTaskStatusOutput {
+        }
+        export interface Tag {
+            key: tagKey;            
+            value: tagValue;            
+        }
+        export interface TaskNotFoundException {
+            message?: errorMessage;            
+        }
+        export interface TaskObject {
+            taskId?: taskId;            
+            pipelineId?: id;            
+            attemptId?: id;            
+            objects?: PipelineObjectMap;            
+        }
+        export interface ValidatePipelineDefinitionInput {
+            pipelineId: id;            
+            pipelineObjects: PipelineObjectList;            
+            parameterObjects?: ParameterObjectList;            
+            parameterValues?: ParameterValueList;            
+        }
+        export interface ValidatePipelineDefinitionOutput {
+            validationErrors?: ValidationErrors;            
+            validationWarnings?: ValidationWarnings;            
+            errored: boolean;            
+        }
+        export interface ValidationError {
+            id?: id;            
+            errors?: validationMessages;            
+        }
+        export interface ValidationWarning {
+            id?: id;            
+            warnings?: validationMessages;            
+        }
+
     }
-
-    export interface DataPipelineActivatePipelineOutput {
-    }
-
-    export interface DataPipelineAddTagsInput {
-        pipelineId: DataPipelineid;
-        tags: DataPipelinetagList;
-    }
-
-    export interface DataPipelineAddTagsOutput {
-    }
-
-    export interface DataPipelineCreatePipelineInput {
-        name: DataPipelineid;
-        uniqueId: DataPipelineid;
-        description?: DataPipelinestring;
-        tags?: DataPipelinetagList;
-    }
-
-    export interface DataPipelineCreatePipelineOutput {
-        pipelineId: DataPipelineid;
-    }
-
-    export interface DataPipelineDeactivatePipelineInput {
-        pipelineId: DataPipelineid;
-        cancelActive?: DataPipelinecancelActive;
-    }
-
-    export interface DataPipelineDeactivatePipelineOutput {
-    }
-
-    export interface DataPipelineDeletePipelineInput {
-        pipelineId: DataPipelineid;
-    }
-
-    export interface DataPipelineDescribeObjectsInput {
-        pipelineId: DataPipelineid;
-        objectIds: DataPipelineidList;
-        evaluateExpressions?: DataPipelineboolean;
-        marker?: DataPipelinestring;
-    }
-
-    export interface DataPipelineDescribeObjectsOutput {
-        pipelineObjects: DataPipelinePipelineObjectList;
-        marker?: DataPipelinestring;
-        hasMoreResults?: DataPipelineboolean;
-    }
-
-    export interface DataPipelineDescribePipelinesInput {
-        pipelineIds: DataPipelineidList;
-    }
-
-    export interface DataPipelineDescribePipelinesOutput {
-        pipelineDescriptionList: DataPipelinePipelineDescriptionList;
-    }
-
-    export interface DataPipelineEvaluateExpressionInput {
-        pipelineId: DataPipelineid;
-        objectId: DataPipelineid;
-        expression: DataPipelinelongString;
-    }
-
-    export interface DataPipelineEvaluateExpressionOutput {
-        evaluatedExpression: DataPipelinelongString;
-    }
-
-    export interface DataPipelineField {
-        key: DataPipelinefieldNameString;
-        stringValue?: DataPipelinefieldStringValue;
-        refValue?: DataPipelinefieldNameString;
-    }
-
-    export interface DataPipelineGetPipelineDefinitionInput {
-        pipelineId: DataPipelineid;
-        version?: DataPipelinestring;
-    }
-
-    export interface DataPipelineGetPipelineDefinitionOutput {
-        pipelineObjects?: DataPipelinePipelineObjectList;
-        parameterObjects?: DataPipelineParameterObjectList;
-        parameterValues?: DataPipelineParameterValueList;
-    }
-
-    export interface DataPipelineInstanceIdentity {
-        document?: DataPipelinestring;
-        signature?: DataPipelinestring;
-    }
-
-    export interface DataPipelineInternalServiceError {
-        message?: DataPipelineerrorMessage;
-    }
-
-    export interface DataPipelineInvalidRequestException {
-        message?: DataPipelineerrorMessage;
-    }
-
-    export interface DataPipelineListPipelinesInput {
-        marker?: DataPipelinestring;
-    }
-
-    export interface DataPipelineListPipelinesOutput {
-        pipelineIdList: DataPipelinepipelineList;
-        marker?: DataPipelinestring;
-        hasMoreResults?: DataPipelineboolean;
-    }
-
-    export interface DataPipelineOperator {
-        type?: DataPipelineOperatorType;
-        values?: DataPipelinestringList;
-    }
-
-    export type DataPipelineOperatorType = string;
-    export interface DataPipelineParameterAttribute {
-        key: DataPipelineattributeNameString;
-        stringValue: DataPipelineattributeValueString;
-    }
-
-    export type DataPipelineParameterAttributeList = Array<DataPipelineParameterAttribute>;
-    export interface DataPipelineParameterObject {
-        id: DataPipelinefieldNameString;
-        attributes: DataPipelineParameterAttributeList;
-    }
-
-    export type DataPipelineParameterObjectList = Array<DataPipelineParameterObject>;
-    export interface DataPipelineParameterValue {
-        id: DataPipelinefieldNameString;
-        stringValue: DataPipelinefieldStringValue;
-    }
-
-    export type DataPipelineParameterValueList = Array<DataPipelineParameterValue>;
-    export interface DataPipelinePipelineDeletedException {
-        message?: DataPipelineerrorMessage;
-    }
-
-    export interface DataPipelinePipelineDescription {
-        pipelineId: DataPipelineid;
-        name: DataPipelineid;
-        fields: DataPipelinefieldList;
-        description?: DataPipelinestring;
-        tags?: DataPipelinetagList;
-    }
-
-    export type DataPipelinePipelineDescriptionList = Array<DataPipelinePipelineDescription>;
-    export interface DataPipelinePipelineIdName {
-        id?: DataPipelineid;
-        name?: DataPipelineid;
-    }
-
-    export interface DataPipelinePipelineNotFoundException {
-        message?: DataPipelineerrorMessage;
-    }
-
-    export interface DataPipelinePipelineObject {
-        id: DataPipelineid;
-        name: DataPipelineid;
-        fields: DataPipelinefieldList;
-    }
-
-    export type DataPipelinePipelineObjectList = Array<DataPipelinePipelineObject>;
-    export type DataPipelinePipelineObjectMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DataPipelinePollForTaskInput {
-        workerGroup: DataPipelinestring;
-        hostname?: DataPipelineid;
-        instanceIdentity?: DataPipelineInstanceIdentity;
-    }
-
-    export interface DataPipelinePollForTaskOutput {
-        taskObject?: DataPipelineTaskObject;
-    }
-
-    export interface DataPipelinePutPipelineDefinitionInput {
-        pipelineId: DataPipelineid;
-        pipelineObjects: DataPipelinePipelineObjectList;
-        parameterObjects?: DataPipelineParameterObjectList;
-        parameterValues?: DataPipelineParameterValueList;
-    }
-
-    export interface DataPipelinePutPipelineDefinitionOutput {
-        validationErrors?: DataPipelineValidationErrors;
-        validationWarnings?: DataPipelineValidationWarnings;
-        errored: DataPipelineboolean;
-    }
-
-    export interface DataPipelineQuery {
-        selectors?: DataPipelineSelectorList;
-    }
-
-    export interface DataPipelineQueryObjectsInput {
-        pipelineId: DataPipelineid;
-        query?: DataPipelineQuery;
-        sphere: DataPipelinestring;
-        marker?: DataPipelinestring;
-        limit?: DataPipelineint;
-    }
-
-    export interface DataPipelineQueryObjectsOutput {
-        ids?: DataPipelineidList;
-        marker?: DataPipelinestring;
-        hasMoreResults?: DataPipelineboolean;
-    }
-
-    export interface DataPipelineRemoveTagsInput {
-        pipelineId: DataPipelineid;
-        tagKeys: DataPipelinestringList;
-    }
-
-    export interface DataPipelineRemoveTagsOutput {
-    }
-
-    export interface DataPipelineReportTaskProgressInput {
-        taskId: DataPipelinetaskId;
-        fields?: DataPipelinefieldList;
-    }
-
-    export interface DataPipelineReportTaskProgressOutput {
-        canceled: DataPipelineboolean;
-    }
-
-    export interface DataPipelineReportTaskRunnerHeartbeatInput {
-        taskrunnerId: DataPipelineid;
-        workerGroup?: DataPipelinestring;
-        hostname?: DataPipelineid;
-    }
-
-    export interface DataPipelineReportTaskRunnerHeartbeatOutput {
-        terminate: DataPipelineboolean;
-    }
-
-    export interface DataPipelineSelector {
-        fieldName?: DataPipelinestring;
-        operator?: DataPipelineOperator;
-    }
-
-    export type DataPipelineSelectorList = Array<DataPipelineSelector>;
-    export interface DataPipelineSetStatusInput {
-        pipelineId: DataPipelineid;
-        objectIds: DataPipelineidList;
-        status: DataPipelinestring;
-    }
-
-    export interface DataPipelineSetTaskStatusInput {
-        taskId: DataPipelinetaskId;
-        taskStatus: DataPipelineTaskStatus;
-        errorId?: DataPipelinestring;
-        errorMessage?: DataPipelineerrorMessage;
-        errorStackTrace?: DataPipelinestring;
-    }
-
-    export interface DataPipelineSetTaskStatusOutput {
-    }
-
-    export interface DataPipelineTag {
-        key: DataPipelinetagKey;
-        value: DataPipelinetagValue;
-    }
-
-    export interface DataPipelineTaskNotFoundException {
-        message?: DataPipelineerrorMessage;
-    }
-
-    export interface DataPipelineTaskObject {
-        taskId?: DataPipelinetaskId;
-        pipelineId?: DataPipelineid;
-        attemptId?: DataPipelineid;
-        objects?: DataPipelinePipelineObjectMap;
-    }
-
-    export type DataPipelineTaskStatus = string;
-    export interface DataPipelineValidatePipelineDefinitionInput {
-        pipelineId: DataPipelineid;
-        pipelineObjects: DataPipelinePipelineObjectList;
-        parameterObjects?: DataPipelineParameterObjectList;
-        parameterValues?: DataPipelineParameterValueList;
-    }
-
-    export interface DataPipelineValidatePipelineDefinitionOutput {
-        validationErrors?: DataPipelineValidationErrors;
-        validationWarnings?: DataPipelineValidationWarnings;
-        errored: DataPipelineboolean;
-    }
-
-    export interface DataPipelineValidationError {
-        id?: DataPipelineid;
-        errors?: DataPipelinevalidationMessages;
-    }
-
-    export type DataPipelineValidationErrors = Array<DataPipelineValidationError>;
-    export interface DataPipelineValidationWarning {
-        id?: DataPipelineid;
-        warnings?: DataPipelinevalidationMessages;
-    }
-
-    export type DataPipelineValidationWarnings = Array<DataPipelineValidationWarning>;
-    export type DataPipelineattributeNameString = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelineattributeValueString = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelineboolean = boolean;
-    export type DataPipelinecancelActive = boolean;
-    export type DataPipelineerrorMessage = string;
-    export type DataPipelinefieldList = Array<DataPipelineField>;
-    export type DataPipelinefieldNameString = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelinefieldStringValue = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelineid = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelineidList = Array<DataPipelineid>;
-    export type DataPipelineint = number;
-    export type DataPipelinelongString = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelinepipelineList = Array<DataPipelinePipelineIdName>;
-    export type DataPipelinestring = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelinestringList = Array<DataPipelinestring>;
-    export type DataPipelinetagKey = string;
-    export type DataPipelinetagList = Array<DataPipelineTag>; // max: 10
-    export type DataPipelinetagValue = string;
-    export type DataPipelinetaskId = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelinetimestamp = number;
-    export type DataPipelinevalidationMessage = string; // pattern: "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*"
-    export type DataPipelinevalidationMessages = Array<DataPipelinevalidationMessage>;
 }

--- a/output/aws-devicefarm.d.ts
+++ b/output/aws-devicefarm.d.ts
@@ -6,606 +6,518 @@ declare module "aws-sdk" {
 
     export class DeviceFarm extends Service {
       constructor(options?: any);
-      createDevicePool(params: DeviceFarmCreateDevicePoolRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmCreateDevicePoolResult|any) => void): Request;
-      createProject(params: DeviceFarmCreateProjectRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmCreateProjectResult|any) => void): Request;
-      createUpload(params: DeviceFarmCreateUploadRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmCreateUploadResult|any) => void): Request;
-      deleteDevicePool(params: DeviceFarmDeleteDevicePoolRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmDeleteDevicePoolResult|any) => void): Request;
-      deleteProject(params: DeviceFarmDeleteProjectRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmDeleteProjectResult|any) => void): Request;
-      deleteRun(params: DeviceFarmDeleteRunRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmDeleteRunResult|any) => void): Request;
-      deleteUpload(params: DeviceFarmDeleteUploadRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmDeleteUploadResult|any) => void): Request;
-      getAccountSettings(params: DeviceFarmGetAccountSettingsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetAccountSettingsResult|any) => void): Request;
-      getDevice(params: DeviceFarmGetDeviceRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetDeviceResult|any) => void): Request;
-      getDevicePool(params: DeviceFarmGetDevicePoolRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetDevicePoolResult|any) => void): Request;
-      getDevicePoolCompatibility(params: DeviceFarmGetDevicePoolCompatibilityRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetDevicePoolCompatibilityResult|any) => void): Request;
-      getJob(params: DeviceFarmGetJobRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetJobResult|any) => void): Request;
-      getProject(params: DeviceFarmGetProjectRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetProjectResult|any) => void): Request;
-      getRun(params: DeviceFarmGetRunRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetRunResult|any) => void): Request;
-      getSuite(params: DeviceFarmGetSuiteRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetSuiteResult|any) => void): Request;
-      getTest(params: DeviceFarmGetTestRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetTestResult|any) => void): Request;
-      getUpload(params: DeviceFarmGetUploadRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmGetUploadResult|any) => void): Request;
-      listArtifacts(params: DeviceFarmListArtifactsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListArtifactsResult|any) => void): Request;
-      listDevicePools(params: DeviceFarmListDevicePoolsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListDevicePoolsResult|any) => void): Request;
-      listDevices(params: DeviceFarmListDevicesRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListDevicesResult|any) => void): Request;
-      listJobs(params: DeviceFarmListJobsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListJobsResult|any) => void): Request;
-      listProjects(params: DeviceFarmListProjectsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListProjectsResult|any) => void): Request;
-      listRuns(params: DeviceFarmListRunsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListRunsResult|any) => void): Request;
-      listSamples(params: DeviceFarmListSamplesRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListSamplesResult|any) => void): Request;
-      listSuites(params: DeviceFarmListSuitesRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListSuitesResult|any) => void): Request;
-      listTests(params: DeviceFarmListTestsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListTestsResult|any) => void): Request;
-      listUniqueProblems(params: DeviceFarmListUniqueProblemsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListUniqueProblemsResult|any) => void): Request;
-      listUploads(params: DeviceFarmListUploadsRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmListUploadsResult|any) => void): Request;
-      scheduleRun(params: DeviceFarmScheduleRunRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmIdempotencyException|DeviceFarmServiceAccountException|any, data: DeviceFarmScheduleRunResult|any) => void): Request;
-      updateDevicePool(params: DeviceFarmUpdateDevicePoolRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmUpdateDevicePoolResult|any) => void): Request;
-      updateProject(params: DeviceFarmUpdateProjectRequest, callback?: (err: DeviceFarmArgumentException|DeviceFarmNotFoundException|DeviceFarmLimitExceededException|DeviceFarmServiceAccountException|any, data: DeviceFarmUpdateProjectResult|any) => void): Request;
-    }
-
-    export type DeviceFarmAWSAccountNumber = string;
-    export interface DeviceFarmAccountSettings {
-        awsAccountNumber?: DeviceFarmAWSAccountNumber;
-        unmeteredDevices?: DeviceFarmPurchasedDevicesMap;
-    }
-
-    export type DeviceFarmAmazonResourceName = string;
-    export type DeviceFarmAmazonResourceNames = Array<DeviceFarmAmazonResourceName>;
-    export interface DeviceFarmArgumentException {
-        message?: DeviceFarmMessage;
-    }
-
-    export interface DeviceFarmArtifact {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        type?: DeviceFarmArtifactType;
-        extension?: DeviceFarmString;
-        url?: DeviceFarmURL;
-    }
-
-    export type DeviceFarmArtifactCategory = string;
-    export type DeviceFarmArtifactType = string;
-    export type DeviceFarmArtifacts = Array<DeviceFarmArtifact>;
-    export type DeviceFarmBillingMethod = string;
-    export type DeviceFarmBoolean = boolean;
-    export interface DeviceFarmCPU {
-        frequency?: DeviceFarmString;
-        architecture?: DeviceFarmString;
-        clock?: DeviceFarmDouble;
-    }
-
-    export type DeviceFarmContentType = string;
-    export interface DeviceFarmCounters {
-        total?: DeviceFarmInteger;
-        passed?: DeviceFarmInteger;
-        failed?: DeviceFarmInteger;
-        warned?: DeviceFarmInteger;
-        errored?: DeviceFarmInteger;
-        stopped?: DeviceFarmInteger;
-        skipped?: DeviceFarmInteger;
-    }
-
-    export interface DeviceFarmCreateDevicePoolRequest {
-        projectArn: DeviceFarmAmazonResourceName;
-        name: DeviceFarmName;
-        description?: DeviceFarmMessage;
-        rules: DeviceFarmRules;
-    }
-
-    export interface DeviceFarmCreateDevicePoolResult {
-        devicePool?: DeviceFarmDevicePool;
-    }
-
-    export interface DeviceFarmCreateProjectRequest {
-        name: DeviceFarmName;
-    }
-
-    export interface DeviceFarmCreateProjectResult {
-        project?: DeviceFarmProject;
-    }
-
-    export interface DeviceFarmCreateUploadRequest {
-        projectArn: DeviceFarmAmazonResourceName;
-        name: DeviceFarmName;
-        type: DeviceFarmUploadType;
-        contentType?: DeviceFarmContentType;
-    }
-
-    export interface DeviceFarmCreateUploadResult {
-        upload?: DeviceFarmUpload;
-    }
-
-    export type DeviceFarmDateTime = number;
-    export interface DeviceFarmDeleteDevicePoolRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmDeleteDevicePoolResult {
-    }
-
-    export interface DeviceFarmDeleteProjectRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmDeleteProjectResult {
-    }
-
-    export interface DeviceFarmDeleteRunRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmDeleteRunResult {
-    }
-
-    export interface DeviceFarmDeleteUploadRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmDeleteUploadResult {
-    }
-
-    export interface DeviceFarmDevice {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        manufacturer?: DeviceFarmString;
-        model?: DeviceFarmString;
-        formFactor?: DeviceFarmDeviceFormFactor;
-        platform?: DeviceFarmDevicePlatform;
-        os?: DeviceFarmString;
-        cpu?: DeviceFarmCPU;
-        resolution?: DeviceFarmResolution;
-        heapSize?: DeviceFarmLong;
-        memory?: DeviceFarmLong;
-        image?: DeviceFarmString;
-        carrier?: DeviceFarmString;
-        radio?: DeviceFarmString;
-    }
-
-    export type DeviceFarmDeviceAttribute = string;
-    export type DeviceFarmDeviceFormFactor = string;
-    export interface DeviceFarmDeviceMinutes {
-        total?: DeviceFarmDouble;
-        metered?: DeviceFarmDouble;
-        unmetered?: DeviceFarmDouble;
-    }
-
-    export type DeviceFarmDevicePlatform = string;
-    export interface DeviceFarmDevicePool {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        description?: DeviceFarmMessage;
-        type?: DeviceFarmDevicePoolType;
-        rules?: DeviceFarmRules;
-    }
-
-    export interface DeviceFarmDevicePoolCompatibilityResult {
-        device?: DeviceFarmDevice;
-        compatible?: DeviceFarmBoolean;
-        incompatibilityMessages?: DeviceFarmIncompatibilityMessages;
-    }
-
-    export type DeviceFarmDevicePoolCompatibilityResults = Array<DeviceFarmDevicePoolCompatibilityResult>;
-    export type DeviceFarmDevicePoolType = string;
-    export type DeviceFarmDevicePools = Array<DeviceFarmDevicePool>;
-    export type DeviceFarmDevices = Array<DeviceFarmDevice>;
-    export type DeviceFarmDouble = number;
-    export type DeviceFarmExecutionResult = string;
-    export type DeviceFarmExecutionStatus = string;
-    export type DeviceFarmFilter = string;
-    export interface DeviceFarmGetAccountSettingsRequest {
-    }
-
-    export interface DeviceFarmGetAccountSettingsResult {
-        accountSettings?: DeviceFarmAccountSettings;
-    }
-
-    export interface DeviceFarmGetDevicePoolCompatibilityRequest {
-        devicePoolArn: DeviceFarmAmazonResourceName;
-        appArn?: DeviceFarmAmazonResourceName;
-        testType?: DeviceFarmTestType;
-    }
-
-    export interface DeviceFarmGetDevicePoolCompatibilityResult {
-        compatibleDevices?: DeviceFarmDevicePoolCompatibilityResults;
-        incompatibleDevices?: DeviceFarmDevicePoolCompatibilityResults;
-    }
-
-    export interface DeviceFarmGetDevicePoolRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetDevicePoolResult {
-        devicePool?: DeviceFarmDevicePool;
-    }
-
-    export interface DeviceFarmGetDeviceRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetDeviceResult {
-        device?: DeviceFarmDevice;
-    }
-
-    export interface DeviceFarmGetJobRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetJobResult {
-        job?: DeviceFarmJob;
-    }
-
-    export interface DeviceFarmGetProjectRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetProjectResult {
-        project?: DeviceFarmProject;
-    }
-
-    export interface DeviceFarmGetRunRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetRunResult {
-        run?: DeviceFarmRun;
-    }
-
-    export interface DeviceFarmGetSuiteRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetSuiteResult {
-        suite?: DeviceFarmSuite;
-    }
-
-    export interface DeviceFarmGetTestRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetTestResult {
-        test?: DeviceFarmTest;
-    }
-
-    export interface DeviceFarmGetUploadRequest {
-        arn: DeviceFarmAmazonResourceName;
-    }
-
-    export interface DeviceFarmGetUploadResult {
-        upload?: DeviceFarmUpload;
-    }
-
-    export interface DeviceFarmIdempotencyException {
-        message?: DeviceFarmMessage;
-    }
-
-    export interface DeviceFarmIncompatibilityMessage {
-        message?: DeviceFarmMessage;
-        type?: DeviceFarmDeviceAttribute;
-    }
-
-    export type DeviceFarmIncompatibilityMessages = Array<DeviceFarmIncompatibilityMessage>;
-    export type DeviceFarmInteger = number;
-    export interface DeviceFarmJob {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        type?: DeviceFarmTestType;
-        created?: DeviceFarmDateTime;
-        status?: DeviceFarmExecutionStatus;
-        result?: DeviceFarmExecutionResult;
-        started?: DeviceFarmDateTime;
-        stopped?: DeviceFarmDateTime;
-        counters?: DeviceFarmCounters;
-        message?: DeviceFarmMessage;
-        device?: DeviceFarmDevice;
-        deviceMinutes?: DeviceFarmDeviceMinutes;
-    }
-
-    export type DeviceFarmJobs = Array<DeviceFarmJob>;
-    export interface DeviceFarmLimitExceededException {
-        message?: DeviceFarmMessage;
-    }
-
-    export interface DeviceFarmListArtifactsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        type: DeviceFarmArtifactCategory;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListArtifactsResult {
-        artifacts?: DeviceFarmArtifacts;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListDevicePoolsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        type?: DeviceFarmDevicePoolType;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListDevicePoolsResult {
-        devicePools?: DeviceFarmDevicePools;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListDevicesRequest {
-        arn?: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListDevicesResult {
-        devices?: DeviceFarmDevices;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListJobsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListJobsResult {
-        jobs?: DeviceFarmJobs;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListProjectsRequest {
-        arn?: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListProjectsResult {
-        projects?: DeviceFarmProjects;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListRunsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListRunsResult {
-        runs?: DeviceFarmRuns;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListSamplesRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListSamplesResult {
-        samples?: DeviceFarmSamples;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListSuitesRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListSuitesResult {
-        suites?: DeviceFarmSuites;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListTestsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListTestsResult {
-        tests?: DeviceFarmTests;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListUniqueProblemsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListUniqueProblemsResult {
-        uniqueProblems?: DeviceFarmUniqueProblemsByExecutionResultMap;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListUploadsRequest {
-        arn: DeviceFarmAmazonResourceName;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmListUploadsResult {
-        uploads?: DeviceFarmUploads;
-        nextToken?: DeviceFarmPaginationToken;
-    }
-
-    export interface DeviceFarmLocation {
-        latitude: DeviceFarmDouble;
-        longitude: DeviceFarmDouble;
-    }
-
-    export type DeviceFarmLong = number;
-    export type DeviceFarmMessage = string;
-    export type DeviceFarmMetadata = string;
-    export type DeviceFarmName = string;
-    export interface DeviceFarmNotFoundException {
-        message?: DeviceFarmMessage;
-    }
-
-    export type DeviceFarmPaginationToken = string;
-    export interface DeviceFarmProblem {
-        run?: DeviceFarmProblemDetail;
-        job?: DeviceFarmProblemDetail;
-        suite?: DeviceFarmProblemDetail;
-        test?: DeviceFarmProblemDetail;
-        device?: DeviceFarmDevice;
-        result?: DeviceFarmExecutionResult;
-        message?: DeviceFarmMessage;
-    }
-
-    export interface DeviceFarmProblemDetail {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-    }
-
-    export type DeviceFarmProblems = Array<DeviceFarmProblem>;
-    export interface DeviceFarmProject {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        created?: DeviceFarmDateTime;
-    }
-
-    export type DeviceFarmProjects = Array<DeviceFarmProject>;
-    export type DeviceFarmPurchasedDevicesMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DeviceFarmRadios {
-        wifi?: DeviceFarmBoolean;
-        bluetooth?: DeviceFarmBoolean;
-        nfc?: DeviceFarmBoolean;
-        gps?: DeviceFarmBoolean;
-    }
-
-    export interface DeviceFarmResolution {
-        width?: DeviceFarmInteger;
-        height?: DeviceFarmInteger;
-    }
-
-    export interface DeviceFarmRule {
-        attribute?: DeviceFarmDeviceAttribute;
-        operator?: DeviceFarmRuleOperator;
-        value?: DeviceFarmString;
-    }
-
-    export type DeviceFarmRuleOperator = string;
-    export type DeviceFarmRules = Array<DeviceFarmRule>;
-    export interface DeviceFarmRun {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        type?: DeviceFarmTestType;
-        platform?: DeviceFarmDevicePlatform;
-        created?: DeviceFarmDateTime;
-        status?: DeviceFarmExecutionStatus;
-        result?: DeviceFarmExecutionResult;
-        started?: DeviceFarmDateTime;
-        stopped?: DeviceFarmDateTime;
-        counters?: DeviceFarmCounters;
-        message?: DeviceFarmMessage;
-        totalJobs?: DeviceFarmInteger;
-        completedJobs?: DeviceFarmInteger;
-        billingMethod?: DeviceFarmBillingMethod;
-        deviceMinutes?: DeviceFarmDeviceMinutes;
-    }
-
-    export type DeviceFarmRuns = Array<DeviceFarmRun>;
-    export interface DeviceFarmSample {
-        arn?: DeviceFarmAmazonResourceName;
-        type?: DeviceFarmSampleType;
-        url?: DeviceFarmURL;
-    }
-
-    export type DeviceFarmSampleType = string;
-    export type DeviceFarmSamples = Array<DeviceFarmSample>;
-    export interface DeviceFarmScheduleRunConfiguration {
-        extraDataPackageArn?: DeviceFarmAmazonResourceName;
-        networkProfileArn?: DeviceFarmAmazonResourceName;
-        locale?: DeviceFarmString;
-        location?: DeviceFarmLocation;
-        radios?: DeviceFarmRadios;
-        auxiliaryApps?: DeviceFarmAmazonResourceNames;
-        billingMethod?: DeviceFarmBillingMethod;
-    }
+      createDevicePool(params: DeviceFarm.CreateDevicePoolRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.CreateDevicePoolResult|any) => void): Request;
+      createProject(params: DeviceFarm.CreateProjectRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.CreateProjectResult|any) => void): Request;
+      createUpload(params: DeviceFarm.CreateUploadRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.CreateUploadResult|any) => void): Request;
+      deleteDevicePool(params: DeviceFarm.DeleteDevicePoolRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.DeleteDevicePoolResult|any) => void): Request;
+      deleteProject(params: DeviceFarm.DeleteProjectRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.DeleteProjectResult|any) => void): Request;
+      deleteRun(params: DeviceFarm.DeleteRunRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.DeleteRunResult|any) => void): Request;
+      deleteUpload(params: DeviceFarm.DeleteUploadRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.DeleteUploadResult|any) => void): Request;
+      getAccountSettings(params: DeviceFarm.GetAccountSettingsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetAccountSettingsResult|any) => void): Request;
+      getDevice(params: DeviceFarm.GetDeviceRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetDeviceResult|any) => void): Request;
+      getDevicePool(params: DeviceFarm.GetDevicePoolRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetDevicePoolResult|any) => void): Request;
+      getDevicePoolCompatibility(params: DeviceFarm.GetDevicePoolCompatibilityRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetDevicePoolCompatibilityResult|any) => void): Request;
+      getJob(params: DeviceFarm.GetJobRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetJobResult|any) => void): Request;
+      getProject(params: DeviceFarm.GetProjectRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetProjectResult|any) => void): Request;
+      getRun(params: DeviceFarm.GetRunRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetRunResult|any) => void): Request;
+      getSuite(params: DeviceFarm.GetSuiteRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetSuiteResult|any) => void): Request;
+      getTest(params: DeviceFarm.GetTestRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetTestResult|any) => void): Request;
+      getUpload(params: DeviceFarm.GetUploadRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.GetUploadResult|any) => void): Request;
+      listArtifacts(params: DeviceFarm.ListArtifactsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListArtifactsResult|any) => void): Request;
+      listDevicePools(params: DeviceFarm.ListDevicePoolsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListDevicePoolsResult|any) => void): Request;
+      listDevices(params: DeviceFarm.ListDevicesRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListDevicesResult|any) => void): Request;
+      listJobs(params: DeviceFarm.ListJobsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListJobsResult|any) => void): Request;
+      listProjects(params: DeviceFarm.ListProjectsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListProjectsResult|any) => void): Request;
+      listRuns(params: DeviceFarm.ListRunsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListRunsResult|any) => void): Request;
+      listSamples(params: DeviceFarm.ListSamplesRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListSamplesResult|any) => void): Request;
+      listSuites(params: DeviceFarm.ListSuitesRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListSuitesResult|any) => void): Request;
+      listTests(params: DeviceFarm.ListTestsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListTestsResult|any) => void): Request;
+      listUniqueProblems(params: DeviceFarm.ListUniqueProblemsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListUniqueProblemsResult|any) => void): Request;
+      listUploads(params: DeviceFarm.ListUploadsRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ListUploadsResult|any) => void): Request;
+      scheduleRun(params: DeviceFarm.ScheduleRunRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.IdempotencyException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.ScheduleRunResult|any) => void): Request;
+      updateDevicePool(params: DeviceFarm.UpdateDevicePoolRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.UpdateDevicePoolResult|any) => void): Request;
+      updateProject(params: DeviceFarm.UpdateProjectRequest, callback?: (err: DeviceFarm.ArgumentException|DeviceFarm.NotFoundException|DeviceFarm.LimitExceededException|DeviceFarm.ServiceAccountException|any, data: DeviceFarm.UpdateProjectResult|any) => void): Request;
+    }
+    
+    export module DeviceFarm {
+        export type AWSAccountNumber = string;    // max: 16, min: 2
+        export type AmazonResourceName = string;    // min: 32
+        export type AmazonResourceNames = AmazonResourceName[];
+        export type ArtifactCategory = string;
+        export type ArtifactType = string;
+        export type Artifacts = Artifact[];
+        export type BillingMethod = string;
+        export type Boolean = boolean;
+        export type ContentType = string;    // max: 64
+        export type DateTime = number;
+        export type DeviceAttribute = string;
+        export type DeviceFormFactor = string;
+        export type DevicePlatform = string;
+        export type DevicePoolCompatibilityResults = DevicePoolCompatibilityResult[];
+        export type DevicePoolType = string;
+        export type DevicePools = DevicePool[];
+        export type Devices = Device[];
+        export type Double = number;
+        export type ExecutionResult = string;
+        export type ExecutionStatus = string;
+        export type Filter = string;    // max: 1024
+        export type IncompatibilityMessages = IncompatibilityMessage[];
+        export type Integer = number;
+        export type Jobs = Job[];
+        export type Long = number;
+        export type Message = string;    // max: 8192
+        export type Metadata = string;    // max: 1024
+        export type Name = string;    // max: 256
+        export type PaginationToken = string;    // max: 1024, min: 4
+        export type Problems = Problem[];
+        export type Projects = Project[];
+        export type PurchasedDevicesMap = {[key:string]: Integer};
+        export type RuleOperator = string;
+        export type Rules = Rule[];
+        export type Runs = Run[];
+        export type SampleType = string;
+        export type Samples = Sample[];
+        export type String = string;
+        export type Suites = Suite[];
+        export type TestParameters = {[key:string]: String};
+        export type TestType = string;
+        export type Tests = Test[];
+        export type URL = string;    // max: 2048
+        export type UniqueProblems = UniqueProblem[];
+        export type UniqueProblemsByExecutionResultMap = {[key:string]: UniqueProblems};
+        export type UploadStatus = string;
+        export type UploadType = string;
+        export type Uploads = Upload[];
+
+        export interface AccountSettings {
+            awsAccountNumber?: AWSAccountNumber;            
+            unmeteredDevices?: PurchasedDevicesMap;            
+        }
+        export interface ArgumentException {
+            message?: Message;            
+        }
+        export interface Artifact {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            type?: ArtifactType;            
+            extension?: String;            
+            url?: URL;            
+        }
+        export interface CPU {
+            frequency?: String;            
+            architecture?: String;            
+            clock?: Double;            
+        }
+        export interface Counters {
+            total?: Integer;            
+            passed?: Integer;            
+            failed?: Integer;            
+            warned?: Integer;            
+            errored?: Integer;            
+            stopped?: Integer;            
+            skipped?: Integer;            
+        }
+        export interface CreateDevicePoolRequest {
+            projectArn: AmazonResourceName;            
+            name: Name;            
+            description?: Message;            
+            rules: Rules;            
+        }
+        export interface CreateDevicePoolResult {
+            devicePool?: DevicePool;            
+        }
+        export interface CreateProjectRequest {
+            name: Name;            
+        }
+        export interface CreateProjectResult {
+            project?: Project;            
+        }
+        export interface CreateUploadRequest {
+            projectArn: AmazonResourceName;            
+            name: Name;            
+            type: UploadType;            
+            contentType?: ContentType;            
+        }
+        export interface CreateUploadResult {
+            upload?: Upload;            
+        }
+        export interface DeleteDevicePoolRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface DeleteDevicePoolResult {
+        }
+        export interface DeleteProjectRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface DeleteProjectResult {
+        }
+        export interface DeleteRunRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface DeleteRunResult {
+        }
+        export interface DeleteUploadRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface DeleteUploadResult {
+        }
+        export interface Device {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            manufacturer?: String;            
+            model?: String;            
+            formFactor?: DeviceFormFactor;            
+            platform?: DevicePlatform;            
+            os?: String;            
+            cpu?: CPU;            
+            resolution?: Resolution;            
+            heapSize?: Long;            
+            memory?: Long;            
+            image?: String;            
+            carrier?: String;            
+            radio?: String;            
+        }
+        export interface DeviceMinutes {
+            total?: Double;            
+            metered?: Double;            
+            unmetered?: Double;            
+        }
+        export interface DevicePool {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            description?: Message;            
+            type?: DevicePoolType;            
+            rules?: Rules;            
+        }
+        export interface DevicePoolCompatibilityResult {
+            device?: Device;            
+            compatible?: Boolean;            
+            incompatibilityMessages?: IncompatibilityMessages;            
+        }
+        export interface GetAccountSettingsRequest {
+        }
+        export interface GetAccountSettingsResult {
+            accountSettings?: AccountSettings;            
+        }
+        export interface GetDevicePoolCompatibilityRequest {
+            devicePoolArn: AmazonResourceName;            
+            appArn?: AmazonResourceName;            
+            testType?: TestType;            
+        }
+        export interface GetDevicePoolCompatibilityResult {
+            compatibleDevices?: DevicePoolCompatibilityResults;            
+            incompatibleDevices?: DevicePoolCompatibilityResults;            
+        }
+        export interface GetDevicePoolRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetDevicePoolResult {
+            devicePool?: DevicePool;            
+        }
+        export interface GetDeviceRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetDeviceResult {
+            device?: Device;            
+        }
+        export interface GetJobRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetJobResult {
+            job?: Job;            
+        }
+        export interface GetProjectRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetProjectResult {
+            project?: Project;            
+        }
+        export interface GetRunRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetRunResult {
+            run?: Run;            
+        }
+        export interface GetSuiteRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetSuiteResult {
+            suite?: Suite;            
+        }
+        export interface GetTestRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetTestResult {
+            test?: Test;            
+        }
+        export interface GetUploadRequest {
+            arn: AmazonResourceName;            
+        }
+        export interface GetUploadResult {
+            upload?: Upload;            
+        }
+        export interface IdempotencyException {
+            message?: Message;            
+        }
+        export interface IncompatibilityMessage {
+            message?: Message;            
+            type?: DeviceAttribute;            
+        }
+        export interface Job {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            type?: TestType;            
+            created?: DateTime;            
+            status?: ExecutionStatus;            
+            result?: ExecutionResult;            
+            started?: DateTime;            
+            stopped?: DateTime;            
+            counters?: Counters;            
+            message?: Message;            
+            device?: Device;            
+            deviceMinutes?: DeviceMinutes;            
+        }
+        export interface LimitExceededException {
+            message?: Message;            
+        }
+        export interface ListArtifactsRequest {
+            arn: AmazonResourceName;            
+            type: ArtifactCategory;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListArtifactsResult {
+            artifacts?: Artifacts;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListDevicePoolsRequest {
+            arn: AmazonResourceName;            
+            type?: DevicePoolType;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListDevicePoolsResult {
+            devicePools?: DevicePools;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListDevicesRequest {
+            arn?: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListDevicesResult {
+            devices?: Devices;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListJobsRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListJobsResult {
+            jobs?: Jobs;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListProjectsRequest {
+            arn?: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListProjectsResult {
+            projects?: Projects;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListRunsRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListRunsResult {
+            runs?: Runs;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListSamplesRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListSamplesResult {
+            samples?: Samples;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListSuitesRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListSuitesResult {
+            suites?: Suites;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListTestsRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListTestsResult {
+            tests?: Tests;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListUniqueProblemsRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListUniqueProblemsResult {
+            uniqueProblems?: UniqueProblemsByExecutionResultMap;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListUploadsRequest {
+            arn: AmazonResourceName;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListUploadsResult {
+            uploads?: Uploads;            
+            nextToken?: PaginationToken;            
+        }
+        export interface Location {
+            latitude: Double;            
+            longitude: Double;            
+        }
+        export interface NotFoundException {
+            message?: Message;            
+        }
+        export interface Problem {
+            run?: ProblemDetail;            
+            job?: ProblemDetail;            
+            suite?: ProblemDetail;            
+            test?: ProblemDetail;            
+            device?: Device;            
+            result?: ExecutionResult;            
+            message?: Message;            
+        }
+        export interface ProblemDetail {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+        }
+        export interface Project {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            created?: DateTime;            
+        }
+        export interface Radios {
+            wifi?: Boolean;            
+            bluetooth?: Boolean;            
+            nfc?: Boolean;            
+            gps?: Boolean;            
+        }
+        export interface Resolution {
+            width?: Integer;            
+            height?: Integer;            
+        }
+        export interface Rule {
+            attribute?: DeviceAttribute;            
+            operator?: RuleOperator;            
+            value?: String;            
+        }
+        export interface Run {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            type?: TestType;            
+            platform?: DevicePlatform;            
+            created?: DateTime;            
+            status?: ExecutionStatus;            
+            result?: ExecutionResult;            
+            started?: DateTime;            
+            stopped?: DateTime;            
+            counters?: Counters;            
+            message?: Message;            
+            totalJobs?: Integer;            
+            completedJobs?: Integer;            
+            billingMethod?: BillingMethod;            
+            deviceMinutes?: DeviceMinutes;            
+        }
+        export interface Sample {
+            arn?: AmazonResourceName;            
+            type?: SampleType;            
+            url?: URL;            
+        }
+        export interface ScheduleRunConfiguration {
+            extraDataPackageArn?: AmazonResourceName;            
+            networkProfileArn?: AmazonResourceName;            
+            locale?: String;            
+            location?: Location;            
+            radios?: Radios;            
+            auxiliaryApps?: AmazonResourceNames;            
+            billingMethod?: BillingMethod;            
+        }
+        export interface ScheduleRunRequest {
+            projectArn: AmazonResourceName;            
+            appArn?: AmazonResourceName;            
+            devicePoolArn: AmazonResourceName;            
+            name?: Name;            
+            test: ScheduleRunTest;            
+            configuration?: ScheduleRunConfiguration;            
+        }
+        export interface ScheduleRunResult {
+            run?: Run;            
+        }
+        export interface ScheduleRunTest {
+            type: TestType;            
+            testPackageArn?: AmazonResourceName;            
+            filter?: Filter;            
+            parameters?: TestParameters;            
+        }
+        export interface ServiceAccountException {
+            message?: Message;            
+        }
+        export interface Suite {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            type?: TestType;            
+            created?: DateTime;            
+            status?: ExecutionStatus;            
+            result?: ExecutionResult;            
+            started?: DateTime;            
+            stopped?: DateTime;            
+            counters?: Counters;            
+            message?: Message;            
+            deviceMinutes?: DeviceMinutes;            
+        }
+        export interface Test {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            type?: TestType;            
+            created?: DateTime;            
+            status?: ExecutionStatus;            
+            result?: ExecutionResult;            
+            started?: DateTime;            
+            stopped?: DateTime;            
+            counters?: Counters;            
+            message?: Message;            
+            deviceMinutes?: DeviceMinutes;            
+        }
+        export interface UniqueProblem {
+            message?: Message;            
+            problems?: Problems;            
+        }
+        export interface UpdateDevicePoolRequest {
+            arn: AmazonResourceName;            
+            name?: Name;            
+            description?: Message;            
+            rules?: Rules;            
+        }
+        export interface UpdateDevicePoolResult {
+            devicePool?: DevicePool;            
+        }
+        export interface UpdateProjectRequest {
+            arn: AmazonResourceName;            
+            name?: Name;            
+        }
+        export interface UpdateProjectResult {
+            project?: Project;            
+        }
+        export interface Upload {
+            arn?: AmazonResourceName;            
+            name?: Name;            
+            created?: DateTime;            
+            type?: UploadType;            
+            status?: UploadStatus;            
+            url?: URL;            
+            metadata?: Metadata;            
+            contentType?: ContentType;            
+            message?: Message;            
+        }
 
-    export interface DeviceFarmScheduleRunRequest {
-        projectArn: DeviceFarmAmazonResourceName;
-        appArn?: DeviceFarmAmazonResourceName;
-        devicePoolArn: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        test: DeviceFarmScheduleRunTest;
-        configuration?: DeviceFarmScheduleRunConfiguration;
     }
-
-    export interface DeviceFarmScheduleRunResult {
-        run?: DeviceFarmRun;
-    }
-
-    export interface DeviceFarmScheduleRunTest {
-        type: DeviceFarmTestType;
-        testPackageArn?: DeviceFarmAmazonResourceName;
-        filter?: DeviceFarmFilter;
-        parameters?: DeviceFarmTestParameters;
-    }
-
-    export interface DeviceFarmServiceAccountException {
-        message?: DeviceFarmMessage;
-    }
-
-    export type DeviceFarmString = string;
-    export interface DeviceFarmSuite {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        type?: DeviceFarmTestType;
-        created?: DeviceFarmDateTime;
-        status?: DeviceFarmExecutionStatus;
-        result?: DeviceFarmExecutionResult;
-        started?: DeviceFarmDateTime;
-        stopped?: DeviceFarmDateTime;
-        counters?: DeviceFarmCounters;
-        message?: DeviceFarmMessage;
-        deviceMinutes?: DeviceFarmDeviceMinutes;
-    }
-
-    export type DeviceFarmSuites = Array<DeviceFarmSuite>;
-    export interface DeviceFarmTest {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        type?: DeviceFarmTestType;
-        created?: DeviceFarmDateTime;
-        status?: DeviceFarmExecutionStatus;
-        result?: DeviceFarmExecutionResult;
-        started?: DeviceFarmDateTime;
-        stopped?: DeviceFarmDateTime;
-        counters?: DeviceFarmCounters;
-        message?: DeviceFarmMessage;
-        deviceMinutes?: DeviceFarmDeviceMinutes;
-    }
-
-    export type DeviceFarmTestParameters = any; // not really - it was 'map' instead - must fix this one
-    export type DeviceFarmTestType = string;
-    export type DeviceFarmTests = Array<DeviceFarmTest>;
-    export type DeviceFarmURL = string;
-    export interface DeviceFarmUniqueProblem {
-        message?: DeviceFarmMessage;
-        problems?: DeviceFarmProblems;
-    }
-
-    export type DeviceFarmUniqueProblems = Array<DeviceFarmUniqueProblem>;
-    export type DeviceFarmUniqueProblemsByExecutionResultMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DeviceFarmUpdateDevicePoolRequest {
-        arn: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        description?: DeviceFarmMessage;
-        rules?: DeviceFarmRules;
-    }
-
-    export interface DeviceFarmUpdateDevicePoolResult {
-        devicePool?: DeviceFarmDevicePool;
-    }
-
-    export interface DeviceFarmUpdateProjectRequest {
-        arn: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-    }
-
-    export interface DeviceFarmUpdateProjectResult {
-        project?: DeviceFarmProject;
-    }
-
-    export interface DeviceFarmUpload {
-        arn?: DeviceFarmAmazonResourceName;
-        name?: DeviceFarmName;
-        created?: DeviceFarmDateTime;
-        type?: DeviceFarmUploadType;
-        status?: DeviceFarmUploadStatus;
-        url?: DeviceFarmURL;
-        metadata?: DeviceFarmMetadata;
-        contentType?: DeviceFarmContentType;
-        message?: DeviceFarmMessage;
-    }
-
-    export type DeviceFarmUploadStatus = string;
-    export type DeviceFarmUploadType = string;
-    export type DeviceFarmUploads = Array<DeviceFarmUpload>;
 }

--- a/output/aws-directconnect.d.ts
+++ b/output/aws-directconnect.d.ts
@@ -6,281 +6,246 @@ declare module "aws-sdk" {
 
     export class DirectConnect extends Service {
       constructor(options?: any);
-      allocateConnectionOnInterconnect(params: DirectConnectAllocateConnectionOnInterconnectRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConnection|any) => void): Request;
-      allocatePrivateVirtualInterface(params: DirectConnectAllocatePrivateVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectVirtualInterface|any) => void): Request;
-      allocatePublicVirtualInterface(params: DirectConnectAllocatePublicVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectVirtualInterface|any) => void): Request;
-      confirmConnection(params: DirectConnectConfirmConnectionRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConfirmConnectionResponse|any) => void): Request;
-      confirmPrivateVirtualInterface(params: DirectConnectConfirmPrivateVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConfirmPrivateVirtualInterfaceResponse|any) => void): Request;
-      confirmPublicVirtualInterface(params: DirectConnectConfirmPublicVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConfirmPublicVirtualInterfaceResponse|any) => void): Request;
-      createConnection(params: DirectConnectCreateConnectionRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConnection|any) => void): Request;
-      createInterconnect(params: DirectConnectCreateInterconnectRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectInterconnect|any) => void): Request;
-      createPrivateVirtualInterface(params: DirectConnectCreatePrivateVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectVirtualInterface|any) => void): Request;
-      createPublicVirtualInterface(params: DirectConnectCreatePublicVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectVirtualInterface|any) => void): Request;
-      deleteConnection(params: DirectConnectDeleteConnectionRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConnection|any) => void): Request;
-      deleteInterconnect(params: DirectConnectDeleteInterconnectRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectDeleteInterconnectResponse|any) => void): Request;
-      deleteVirtualInterface(params: DirectConnectDeleteVirtualInterfaceRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectDeleteVirtualInterfaceResponse|any) => void): Request;
-      describeConnections(params: DirectConnectDescribeConnectionsRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConnections|any) => void): Request;
-      describeConnectionsOnInterconnect(params: DirectConnectDescribeConnectionsOnInterconnectRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectConnections|any) => void): Request;
-      describeInterconnects(params: DirectConnectDescribeInterconnectsRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectInterconnects|any) => void): Request;
-      describeLocations(callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectLocations|any) => void): Request;
-      describeVirtualGateways(callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectVirtualGateways|any) => void): Request;
-      describeVirtualInterfaces(params: DirectConnectDescribeVirtualInterfacesRequest, callback?: (err: DirectConnectDirectConnectServerException|DirectConnectDirectConnectClientException|any, data: DirectConnectVirtualInterfaces|any) => void): Request;
+      allocateConnectionOnInterconnect(params: DirectConnect.AllocateConnectionOnInterconnectRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Connection|any) => void): Request;
+      allocatePrivateVirtualInterface(params: DirectConnect.AllocatePrivateVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.VirtualInterface|any) => void): Request;
+      allocatePublicVirtualInterface(params: DirectConnect.AllocatePublicVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.VirtualInterface|any) => void): Request;
+      confirmConnection(params: DirectConnect.ConfirmConnectionRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.ConfirmConnectionResponse|any) => void): Request;
+      confirmPrivateVirtualInterface(params: DirectConnect.ConfirmPrivateVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.ConfirmPrivateVirtualInterfaceResponse|any) => void): Request;
+      confirmPublicVirtualInterface(params: DirectConnect.ConfirmPublicVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.ConfirmPublicVirtualInterfaceResponse|any) => void): Request;
+      createConnection(params: DirectConnect.CreateConnectionRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Connection|any) => void): Request;
+      createInterconnect(params: DirectConnect.CreateInterconnectRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Interconnect|any) => void): Request;
+      createPrivateVirtualInterface(params: DirectConnect.CreatePrivateVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.VirtualInterface|any) => void): Request;
+      createPublicVirtualInterface(params: DirectConnect.CreatePublicVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.VirtualInterface|any) => void): Request;
+      deleteConnection(params: DirectConnect.DeleteConnectionRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Connection|any) => void): Request;
+      deleteInterconnect(params: DirectConnect.DeleteInterconnectRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.DeleteInterconnectResponse|any) => void): Request;
+      deleteVirtualInterface(params: DirectConnect.DeleteVirtualInterfaceRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.DeleteVirtualInterfaceResponse|any) => void): Request;
+      describeConnections(params: DirectConnect.DescribeConnectionsRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Connections|any) => void): Request;
+      describeConnectionsOnInterconnect(params: DirectConnect.DescribeConnectionsOnInterconnectRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Connections|any) => void): Request;
+      describeInterconnects(params: DirectConnect.DescribeInterconnectsRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Interconnects|any) => void): Request;
+      describeLocations(callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.Locations|any) => void): Request;
+      describeVirtualGateways(callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.VirtualGateways|any) => void): Request;
+      describeVirtualInterfaces(params: DirectConnect.DescribeVirtualInterfacesRequest, callback?: (err: DirectConnect.DirectConnectServerException|DirectConnect.DirectConnectClientException|any, data: DirectConnect.VirtualInterfaces|any) => void): Request;
     }
+    
+    export module DirectConnect {
+        export type ASN = number;
+        export type AmazonAddress = string;
+        export type BGPAuthKey = string;
+        export type Bandwidth = string;
+        export type CIDR = string;
+        export type ConnectionId = string;
+        export type ConnectionList = Connection[];
+        export type ConnectionName = string;
+        export type ConnectionState = string;
+        export type CustomerAddress = string;
+        export type ErrorMessage = string;
+        export type InterconnectId = string;
+        export type InterconnectList = Interconnect[];
+        export type InterconnectName = string;
+        export type InterconnectState = string;
+        export type LocationCode = string;
+        export type LocationList = Location[];
+        export type LocationName = string;
+        export type OwnerAccount = string;
+        export type PartnerName = string;
+        export type Region = string;
+        export type RouteFilterPrefixList = RouteFilterPrefix[];
+        export type RouterConfig = string;
+        export type VLAN = number;
+        export type VirtualGatewayId = string;
+        export type VirtualGatewayList = VirtualGateway[];
+        export type VirtualGatewayState = string;
+        export type VirtualInterfaceId = string;
+        export type VirtualInterfaceList = VirtualInterface[];
+        export type VirtualInterfaceName = string;
+        export type VirtualInterfaceState = string;
+        export type VirtualInterfaceType = string;
 
-    export type DirectConnectASN = number;
-    export interface DirectConnectAllocateConnectionOnInterconnectRequest {
-        bandwidth: DirectConnectBandwidth;
-        connectionName: DirectConnectConnectionName;
-        ownerAccount: DirectConnectOwnerAccount;
-        interconnectId: DirectConnectInterconnectId;
-        vlan: DirectConnectVLAN;
+        export interface AllocateConnectionOnInterconnectRequest {
+            bandwidth: Bandwidth;            
+            connectionName: ConnectionName;            
+            ownerAccount: OwnerAccount;            
+            interconnectId: InterconnectId;            
+            vlan: VLAN;            
+        }
+        export interface AllocatePrivateVirtualInterfaceRequest {
+            connectionId: ConnectionId;            
+            ownerAccount: OwnerAccount;            
+            newPrivateVirtualInterfaceAllocation: NewPrivateVirtualInterfaceAllocation;            
+        }
+        export interface AllocatePublicVirtualInterfaceRequest {
+            connectionId: ConnectionId;            
+            ownerAccount: OwnerAccount;            
+            newPublicVirtualInterfaceAllocation: NewPublicVirtualInterfaceAllocation;            
+        }
+        export interface ConfirmConnectionRequest {
+            connectionId: ConnectionId;            
+        }
+        export interface ConfirmConnectionResponse {
+            connectionState?: ConnectionState;            
+        }
+        export interface ConfirmPrivateVirtualInterfaceRequest {
+            virtualInterfaceId: VirtualInterfaceId;            
+            virtualGatewayId: VirtualGatewayId;            
+        }
+        export interface ConfirmPrivateVirtualInterfaceResponse {
+            virtualInterfaceState?: VirtualInterfaceState;            
+        }
+        export interface ConfirmPublicVirtualInterfaceRequest {
+            virtualInterfaceId: VirtualInterfaceId;            
+        }
+        export interface ConfirmPublicVirtualInterfaceResponse {
+            virtualInterfaceState?: VirtualInterfaceState;            
+        }
+        export interface Connection {
+            ownerAccount?: OwnerAccount;            
+            connectionId?: ConnectionId;            
+            connectionName?: ConnectionName;            
+            connectionState?: ConnectionState;            
+            region?: Region;            
+            location?: LocationCode;            
+            bandwidth?: Bandwidth;            
+            vlan?: VLAN;            
+            partnerName?: PartnerName;            
+        }
+        export interface Connections {
+            connections?: ConnectionList;            
+        }
+        export interface CreateConnectionRequest {
+            location: LocationCode;            
+            bandwidth: Bandwidth;            
+            connectionName: ConnectionName;            
+        }
+        export interface CreateInterconnectRequest {
+            interconnectName: InterconnectName;            
+            bandwidth: Bandwidth;            
+            location: LocationCode;            
+        }
+        export interface CreatePrivateVirtualInterfaceRequest {
+            connectionId: ConnectionId;            
+            newPrivateVirtualInterface: NewPrivateVirtualInterface;            
+        }
+        export interface CreatePublicVirtualInterfaceRequest {
+            connectionId: ConnectionId;            
+            newPublicVirtualInterface: NewPublicVirtualInterface;            
+        }
+        export interface DeleteConnectionRequest {
+            connectionId: ConnectionId;            
+        }
+        export interface DeleteInterconnectRequest {
+            interconnectId: InterconnectId;            
+        }
+        export interface DeleteInterconnectResponse {
+            interconnectState?: InterconnectState;            
+        }
+        export interface DeleteVirtualInterfaceRequest {
+            virtualInterfaceId: VirtualInterfaceId;            
+        }
+        export interface DeleteVirtualInterfaceResponse {
+            virtualInterfaceState?: VirtualInterfaceState;            
+        }
+        export interface DescribeConnectionsOnInterconnectRequest {
+            interconnectId: InterconnectId;            
+        }
+        export interface DescribeConnectionsRequest {
+            connectionId?: ConnectionId;            
+        }
+        export interface DescribeInterconnectsRequest {
+            interconnectId?: InterconnectId;            
+        }
+        export interface DescribeVirtualInterfacesRequest {
+            connectionId?: ConnectionId;            
+            virtualInterfaceId?: VirtualInterfaceId;            
+        }
+        export interface DirectConnectClientException {
+            message?: ErrorMessage;            
+        }
+        export interface DirectConnectServerException {
+            message?: ErrorMessage;            
+        }
+        export interface Interconnect {
+            interconnectId?: InterconnectId;            
+            interconnectName?: InterconnectName;            
+            interconnectState?: InterconnectState;            
+            region?: Region;            
+            location?: LocationCode;            
+            bandwidth?: Bandwidth;            
+        }
+        export interface Interconnects {
+            interconnects?: InterconnectList;            
+        }
+        export interface Location {
+            locationCode?: LocationCode;            
+            locationName?: LocationName;            
+        }
+        export interface Locations {
+            locations?: LocationList;            
+        }
+        export interface NewPrivateVirtualInterface {
+            virtualInterfaceName: VirtualInterfaceName;            
+            vlan: VLAN;            
+            asn: ASN;            
+            authKey?: BGPAuthKey;            
+            amazonAddress?: AmazonAddress;            
+            customerAddress?: CustomerAddress;            
+            virtualGatewayId: VirtualGatewayId;            
+        }
+        export interface NewPrivateVirtualInterfaceAllocation {
+            virtualInterfaceName: VirtualInterfaceName;            
+            vlan: VLAN;            
+            asn: ASN;            
+            authKey?: BGPAuthKey;            
+            amazonAddress?: AmazonAddress;            
+            customerAddress?: CustomerAddress;            
+        }
+        export interface NewPublicVirtualInterface {
+            virtualInterfaceName: VirtualInterfaceName;            
+            vlan: VLAN;            
+            asn: ASN;            
+            authKey?: BGPAuthKey;            
+            amazonAddress: AmazonAddress;            
+            customerAddress: CustomerAddress;            
+            routeFilterPrefixes: RouteFilterPrefixList;            
+        }
+        export interface NewPublicVirtualInterfaceAllocation {
+            virtualInterfaceName: VirtualInterfaceName;            
+            vlan: VLAN;            
+            asn: ASN;            
+            authKey?: BGPAuthKey;            
+            amazonAddress: AmazonAddress;            
+            customerAddress: CustomerAddress;            
+            routeFilterPrefixes: RouteFilterPrefixList;            
+        }
+        export interface RouteFilterPrefix {
+            cidr?: CIDR;            
+        }
+        export interface VirtualGateway {
+            virtualGatewayId?: VirtualGatewayId;            
+            virtualGatewayState?: VirtualGatewayState;            
+        }
+        export interface VirtualGateways {
+            virtualGateways?: VirtualGatewayList;            
+        }
+        export interface VirtualInterface {
+            ownerAccount?: OwnerAccount;            
+            virtualInterfaceId?: VirtualInterfaceId;            
+            location?: LocationCode;            
+            connectionId?: ConnectionId;            
+            virtualInterfaceType?: VirtualInterfaceType;            
+            virtualInterfaceName?: VirtualInterfaceName;            
+            vlan?: VLAN;            
+            asn?: ASN;            
+            authKey?: BGPAuthKey;            
+            amazonAddress?: AmazonAddress;            
+            customerAddress?: CustomerAddress;            
+            virtualInterfaceState?: VirtualInterfaceState;            
+            customerRouterConfig?: RouterConfig;            
+            virtualGatewayId?: VirtualGatewayId;            
+            routeFilterPrefixes?: RouteFilterPrefixList;            
+        }
+        export interface VirtualInterfaces {
+            virtualInterfaces?: VirtualInterfaceList;            
+        }
+
     }
-
-    export interface DirectConnectAllocatePrivateVirtualInterfaceRequest {
-        connectionId: DirectConnectConnectionId;
-        ownerAccount: DirectConnectOwnerAccount;
-        newPrivateVirtualInterfaceAllocation: DirectConnectNewPrivateVirtualInterfaceAllocation;
-    }
-
-    export interface DirectConnectAllocatePublicVirtualInterfaceRequest {
-        connectionId: DirectConnectConnectionId;
-        ownerAccount: DirectConnectOwnerAccount;
-        newPublicVirtualInterfaceAllocation: DirectConnectNewPublicVirtualInterfaceAllocation;
-    }
-
-    export type DirectConnectAmazonAddress = string;
-    export type DirectConnectBGPAuthKey = string;
-    export type DirectConnectBandwidth = string;
-    export type DirectConnectCIDR = string;
-    export interface DirectConnectConfirmConnectionRequest {
-        connectionId: DirectConnectConnectionId;
-    }
-
-    export interface DirectConnectConfirmConnectionResponse {
-        connectionState?: DirectConnectConnectionState;
-    }
-
-    export interface DirectConnectConfirmPrivateVirtualInterfaceRequest {
-        virtualInterfaceId: DirectConnectVirtualInterfaceId;
-        virtualGatewayId: DirectConnectVirtualGatewayId;
-    }
-
-    export interface DirectConnectConfirmPrivateVirtualInterfaceResponse {
-        virtualInterfaceState?: DirectConnectVirtualInterfaceState;
-    }
-
-    export interface DirectConnectConfirmPublicVirtualInterfaceRequest {
-        virtualInterfaceId: DirectConnectVirtualInterfaceId;
-    }
-
-    export interface DirectConnectConfirmPublicVirtualInterfaceResponse {
-        virtualInterfaceState?: DirectConnectVirtualInterfaceState;
-    }
-
-    export interface DirectConnectConnection {
-        ownerAccount?: DirectConnectOwnerAccount;
-        connectionId?: DirectConnectConnectionId;
-        connectionName?: DirectConnectConnectionName;
-        connectionState?: DirectConnectConnectionState;
-        region?: DirectConnectRegion;
-        location?: DirectConnectLocationCode;
-        bandwidth?: DirectConnectBandwidth;
-        vlan?: DirectConnectVLAN;
-        partnerName?: DirectConnectPartnerName;
-    }
-
-    export type DirectConnectConnectionId = string;
-    export type DirectConnectConnectionList = Array<DirectConnectConnection>;
-    export type DirectConnectConnectionName = string;
-    export type DirectConnectConnectionState = string;
-    export interface DirectConnectConnections {
-        connections?: DirectConnectConnectionList;
-    }
-
-    export interface DirectConnectCreateConnectionRequest {
-        location: DirectConnectLocationCode;
-        bandwidth: DirectConnectBandwidth;
-        connectionName: DirectConnectConnectionName;
-    }
-
-    export interface DirectConnectCreateInterconnectRequest {
-        interconnectName: DirectConnectInterconnectName;
-        bandwidth: DirectConnectBandwidth;
-        location: DirectConnectLocationCode;
-    }
-
-    export interface DirectConnectCreatePrivateVirtualInterfaceRequest {
-        connectionId: DirectConnectConnectionId;
-        newPrivateVirtualInterface: DirectConnectNewPrivateVirtualInterface;
-    }
-
-    export interface DirectConnectCreatePublicVirtualInterfaceRequest {
-        connectionId: DirectConnectConnectionId;
-        newPublicVirtualInterface: DirectConnectNewPublicVirtualInterface;
-    }
-
-    export type DirectConnectCustomerAddress = string;
-    export interface DirectConnectDeleteConnectionRequest {
-        connectionId: DirectConnectConnectionId;
-    }
-
-    export interface DirectConnectDeleteInterconnectRequest {
-        interconnectId: DirectConnectInterconnectId;
-    }
-
-    export interface DirectConnectDeleteInterconnectResponse {
-        interconnectState?: DirectConnectInterconnectState;
-    }
-
-    export interface DirectConnectDeleteVirtualInterfaceRequest {
-        virtualInterfaceId: DirectConnectVirtualInterfaceId;
-    }
-
-    export interface DirectConnectDeleteVirtualInterfaceResponse {
-        virtualInterfaceState?: DirectConnectVirtualInterfaceState;
-    }
-
-    export interface DirectConnectDescribeConnectionsOnInterconnectRequest {
-        interconnectId: DirectConnectInterconnectId;
-    }
-
-    export interface DirectConnectDescribeConnectionsRequest {
-        connectionId?: DirectConnectConnectionId;
-    }
-
-    export interface DirectConnectDescribeInterconnectsRequest {
-        interconnectId?: DirectConnectInterconnectId;
-    }
-
-    export interface DirectConnectDescribeVirtualInterfacesRequest {
-        connectionId?: DirectConnectConnectionId;
-        virtualInterfaceId?: DirectConnectVirtualInterfaceId;
-    }
-
-    export interface DirectConnectDirectConnectClientException {
-        message?: DirectConnectErrorMessage;
-    }
-
-    export interface DirectConnectDirectConnectServerException {
-        message?: DirectConnectErrorMessage;
-    }
-
-    export type DirectConnectErrorMessage = string;
-    export interface DirectConnectInterconnect {
-        interconnectId?: DirectConnectInterconnectId;
-        interconnectName?: DirectConnectInterconnectName;
-        interconnectState?: DirectConnectInterconnectState;
-        region?: DirectConnectRegion;
-        location?: DirectConnectLocationCode;
-        bandwidth?: DirectConnectBandwidth;
-    }
-
-    export type DirectConnectInterconnectId = string;
-    export type DirectConnectInterconnectList = Array<DirectConnectInterconnect>;
-    export type DirectConnectInterconnectName = string;
-    export type DirectConnectInterconnectState = string;
-    export interface DirectConnectInterconnects {
-        interconnects?: DirectConnectInterconnectList;
-    }
-
-    export interface DirectConnectLocation {
-        locationCode?: DirectConnectLocationCode;
-        locationName?: DirectConnectLocationName;
-    }
-
-    export type DirectConnectLocationCode = string;
-    export type DirectConnectLocationList = Array<DirectConnectLocation>;
-    export type DirectConnectLocationName = string;
-    export interface DirectConnectLocations {
-        locations?: DirectConnectLocationList;
-    }
-
-    export interface DirectConnectNewPrivateVirtualInterface {
-        virtualInterfaceName: DirectConnectVirtualInterfaceName;
-        vlan: DirectConnectVLAN;
-        asn: DirectConnectASN;
-        authKey?: DirectConnectBGPAuthKey;
-        amazonAddress?: DirectConnectAmazonAddress;
-        customerAddress?: DirectConnectCustomerAddress;
-        virtualGatewayId: DirectConnectVirtualGatewayId;
-    }
-
-    export interface DirectConnectNewPrivateVirtualInterfaceAllocation {
-        virtualInterfaceName: DirectConnectVirtualInterfaceName;
-        vlan: DirectConnectVLAN;
-        asn: DirectConnectASN;
-        authKey?: DirectConnectBGPAuthKey;
-        amazonAddress?: DirectConnectAmazonAddress;
-        customerAddress?: DirectConnectCustomerAddress;
-    }
-
-    export interface DirectConnectNewPublicVirtualInterface {
-        virtualInterfaceName: DirectConnectVirtualInterfaceName;
-        vlan: DirectConnectVLAN;
-        asn: DirectConnectASN;
-        authKey?: DirectConnectBGPAuthKey;
-        amazonAddress: DirectConnectAmazonAddress;
-        customerAddress: DirectConnectCustomerAddress;
-        routeFilterPrefixes: DirectConnectRouteFilterPrefixList;
-    }
-
-    export interface DirectConnectNewPublicVirtualInterfaceAllocation {
-        virtualInterfaceName: DirectConnectVirtualInterfaceName;
-        vlan: DirectConnectVLAN;
-        asn: DirectConnectASN;
-        authKey?: DirectConnectBGPAuthKey;
-        amazonAddress: DirectConnectAmazonAddress;
-        customerAddress: DirectConnectCustomerAddress;
-        routeFilterPrefixes: DirectConnectRouteFilterPrefixList;
-    }
-
-    export type DirectConnectOwnerAccount = string;
-    export type DirectConnectPartnerName = string;
-    export type DirectConnectRegion = string;
-    export interface DirectConnectRouteFilterPrefix {
-        cidr?: DirectConnectCIDR;
-    }
-
-    export type DirectConnectRouteFilterPrefixList = Array<DirectConnectRouteFilterPrefix>;
-    export type DirectConnectRouterConfig = string;
-    export type DirectConnectVLAN = number;
-    export interface DirectConnectVirtualGateway {
-        virtualGatewayId?: DirectConnectVirtualGatewayId;
-        virtualGatewayState?: DirectConnectVirtualGatewayState;
-    }
-
-    export type DirectConnectVirtualGatewayId = string;
-    export type DirectConnectVirtualGatewayList = Array<DirectConnectVirtualGateway>;
-    export type DirectConnectVirtualGatewayState = string;
-    export interface DirectConnectVirtualGateways {
-        virtualGateways?: DirectConnectVirtualGatewayList;
-    }
-
-    export interface DirectConnectVirtualInterface {
-        ownerAccount?: DirectConnectOwnerAccount;
-        virtualInterfaceId?: DirectConnectVirtualInterfaceId;
-        location?: DirectConnectLocationCode;
-        connectionId?: DirectConnectConnectionId;
-        virtualInterfaceType?: DirectConnectVirtualInterfaceType;
-        virtualInterfaceName?: DirectConnectVirtualInterfaceName;
-        vlan?: DirectConnectVLAN;
-        asn?: DirectConnectASN;
-        authKey?: DirectConnectBGPAuthKey;
-        amazonAddress?: DirectConnectAmazonAddress;
-        customerAddress?: DirectConnectCustomerAddress;
-        virtualInterfaceState?: DirectConnectVirtualInterfaceState;
-        customerRouterConfig?: DirectConnectRouterConfig;
-        virtualGatewayId?: DirectConnectVirtualGatewayId;
-        routeFilterPrefixes?: DirectConnectRouteFilterPrefixList;
-    }
-
-    export type DirectConnectVirtualInterfaceId = string;
-    export type DirectConnectVirtualInterfaceList = Array<DirectConnectVirtualInterface>;
-    export type DirectConnectVirtualInterfaceName = string;
-    export type DirectConnectVirtualInterfaceState = string;
-    export type DirectConnectVirtualInterfaceType = string;
-    export interface DirectConnectVirtualInterfaces {
-        virtualInterfaces?: DirectConnectVirtualInterfaceList;
-    }
-
 }

--- a/output/aws-dynamodb.d.ts
+++ b/output/aws-dynamodb.d.ts
@@ -6,321 +6,277 @@ declare module "aws-sdk" {
 
     export class DynamoDB extends Service {
       constructor(options?: any);
-      batchGetItem(params: DynamoDBBatchGetItemInput, callback?: (err: DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBInternalServerError|any, data: DynamoDBBatchGetItemOutput|any) => void): Request;
-      batchWriteItem(params: DynamoDBBatchWriteItemInput, callback?: (err: DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBBatchWriteItemOutput|any) => void): Request;
-      createTable(params: DynamoDBCreateTableInput, callback?: (err: DynamoDBResourceInUseException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBCreateTableOutput|any) => void): Request;
-      deleteItem(params: DynamoDBDeleteItemInput, callback?: (err: DynamoDBConditionalCheckFailedException|DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBDeleteItemOutput|any) => void): Request;
-      deleteTable(params: DynamoDBDeleteTableInput, callback?: (err: DynamoDBResourceInUseException|DynamoDBResourceNotFoundException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBDeleteTableOutput|any) => void): Request;
-      describeTable(params: DynamoDBDescribeTableInput, callback?: (err: DynamoDBResourceNotFoundException|DynamoDBInternalServerError|any, data: DynamoDBDescribeTableOutput|any) => void): Request;
-      getItem(params: DynamoDBGetItemInput, callback?: (err: DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBInternalServerError|any, data: DynamoDBGetItemOutput|any) => void): Request;
-      listTables(params: DynamoDBListTablesInput, callback?: (err: DynamoDBInternalServerError|any, data: DynamoDBListTablesOutput|any) => void): Request;
-      putItem(params: DynamoDBPutItemInput, callback?: (err: DynamoDBConditionalCheckFailedException|DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBPutItemOutput|any) => void): Request;
-      query(params: DynamoDBQueryInput, callback?: (err: DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBInternalServerError|any, data: DynamoDBQueryOutput|any) => void): Request;
-      scan(params: DynamoDBScanInput, callback?: (err: DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBInternalServerError|any, data: DynamoDBScanOutput|any) => void): Request;
-      updateItem(params: DynamoDBUpdateItemInput, callback?: (err: DynamoDBConditionalCheckFailedException|DynamoDBProvisionedThroughputExceededException|DynamoDBResourceNotFoundException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBUpdateItemOutput|any) => void): Request;
-      updateTable(params: DynamoDBUpdateTableInput, callback?: (err: DynamoDBResourceInUseException|DynamoDBResourceNotFoundException|DynamoDBLimitExceededException|DynamoDBInternalServerError|any, data: DynamoDBUpdateTableOutput|any) => void): Request;
+      batchGetItem(params: DynamoDB.BatchGetItemInput, callback?: (err: DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.InternalServerError|any, data: DynamoDB.BatchGetItemOutput|any) => void): Request;
+      batchWriteItem(params: DynamoDB.BatchWriteItemInput, callback?: (err: DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.BatchWriteItemOutput|any) => void): Request;
+      createTable(params: DynamoDB.CreateTableInput, callback?: (err: DynamoDB.ResourceInUseException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.CreateTableOutput|any) => void): Request;
+      deleteItem(params: DynamoDB.DeleteItemInput, callback?: (err: DynamoDB.ConditionalCheckFailedException|DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.DeleteItemOutput|any) => void): Request;
+      deleteTable(params: DynamoDB.DeleteTableInput, callback?: (err: DynamoDB.ResourceInUseException|DynamoDB.ResourceNotFoundException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.DeleteTableOutput|any) => void): Request;
+      describeTable(params: DynamoDB.DescribeTableInput, callback?: (err: DynamoDB.ResourceNotFoundException|DynamoDB.InternalServerError|any, data: DynamoDB.DescribeTableOutput|any) => void): Request;
+      getItem(params: DynamoDB.GetItemInput, callback?: (err: DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.InternalServerError|any, data: DynamoDB.GetItemOutput|any) => void): Request;
+      listTables(params: DynamoDB.ListTablesInput, callback?: (err: DynamoDB.InternalServerError|any, data: DynamoDB.ListTablesOutput|any) => void): Request;
+      putItem(params: DynamoDB.PutItemInput, callback?: (err: DynamoDB.ConditionalCheckFailedException|DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.PutItemOutput|any) => void): Request;
+      query(params: DynamoDB.QueryInput, callback?: (err: DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.InternalServerError|any, data: DynamoDB.QueryOutput|any) => void): Request;
+      scan(params: DynamoDB.ScanInput, callback?: (err: DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.InternalServerError|any, data: DynamoDB.ScanOutput|any) => void): Request;
+      updateItem(params: DynamoDB.UpdateItemInput, callback?: (err: DynamoDB.ConditionalCheckFailedException|DynamoDB.ProvisionedThroughputExceededException|DynamoDB.ResourceNotFoundException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.UpdateItemOutput|any) => void): Request;
+      updateTable(params: DynamoDB.UpdateTableInput, callback?: (err: DynamoDB.ResourceInUseException|DynamoDB.ResourceNotFoundException|DynamoDB.LimitExceededException|DynamoDB.InternalServerError|any, data: DynamoDB.UpdateTableOutput|any) => void): Request;
     }
+    
+    export module DynamoDB {
+        export type AttributeAction = string;
+        export type AttributeMap = {[key:string]: AttributeValue};
+        export type AttributeName = string;    // max: 65535
+        export type AttributeNameList = AttributeName[];    // min: 1
+        export type AttributeUpdates = {[key:string]: AttributeValueUpdate};
+        export type AttributeValueList = AttributeValue[];
+        export type BatchGetRequestMap = {[key:string]: KeysAndAttributes};    // max: 100, min: 1
+        export type BatchGetResponseMap = {[key:string]: BatchResponse};
+        export type BatchWriteItemRequestMap = {[key:string]: WriteRequests};    // max: 25, min: 1
+        export type BatchWriteResponseMap = {[key:string]: BatchWriteResponse};
+        export type BinaryAttributeValue = any;    // type: blob
+        export type BinarySetAttributeValue = BinaryAttributeValue[];
+        export type BooleanObject = boolean;
+        export type ComparisonOperator = string;
+        export type ConsistentRead = boolean;
+        export type ConsumedCapacityUnits = number;
+        export type Date = number;
+        export type ErrorMessage = string;
+        export type ExpectedAttributeMap = {[key:string]: ExpectedAttributeValue};
+        export type FilterConditionMap = {[key:string]: Condition};
+        export type Integer = number;
+        export type ItemList = AttributeMap[];
+        export type KeyList = Key[];    // max: 100, min: 1
+        export type KeySchemaAttributeName = string;    // max: 255, min: 1
+        export type ListTablesInputLimit = number;    // max: 100, min: 1
+        export type Long = number;
+        export type NumberAttributeValue = string;
+        export type NumberSetAttributeValue = NumberAttributeValue[];
+        export type PositiveIntegerObject = number;    // min: 1
+        export type PositiveLongObject = number;    // min: 1
+        export type PutItemInputAttributeMap = {[key:string]: AttributeValue};
+        export type ReturnValue = string;
+        export type ScalarAttributeType = string;
+        export type String = string;
+        export type StringAttributeValue = string;
+        export type StringSetAttributeValue = StringAttributeValue[];
+        export type TableName = string;    // pattern: &quot;[a-zA-Z0-9_.-]+&quot;, max: 255, min: 3
+        export type TableNameList = TableName[];
+        export type TableStatus = string;
+        export type WriteRequests = WriteRequest[];    // max: 25, min: 1
 
-    export type DynamoDBAttributeAction = string;
-    export type DynamoDBAttributeMap = any; // not really - it was 'map' instead - must fix this one
-    export type DynamoDBAttributeName = string;
-    export type DynamoDBAttributeNameList = Array<DynamoDBAttributeName>;
-    export type DynamoDBAttributeUpdates = any; // not really - it was 'map' instead - must fix this one
-    export interface DynamoDBAttributeValue {
-        S?: DynamoDBStringAttributeValue;
-        N?: DynamoDBNumberAttributeValue;
-        B?: DynamoDBBinaryAttributeValue;
-        SS?: DynamoDBStringSetAttributeValue;
-        NS?: DynamoDBNumberSetAttributeValue;
-        BS?: DynamoDBBinarySetAttributeValue;
+        export interface AttributeValue {
+            S?: StringAttributeValue;            
+            N?: NumberAttributeValue;            
+            B?: BinaryAttributeValue;            
+            SS?: StringSetAttributeValue;            
+            NS?: NumberSetAttributeValue;            
+            BS?: BinarySetAttributeValue;            
+        }
+        export interface AttributeValueUpdate {
+            Value?: AttributeValue;            
+            Action?: AttributeAction;            
+        }
+        export interface BatchGetItemInput {
+            RequestItems: BatchGetRequestMap;            
+        }
+        export interface BatchGetItemOutput {
+            Responses?: BatchGetResponseMap;            
+            UnprocessedKeys?: BatchGetRequestMap;            
+        }
+        export interface BatchResponse {
+            Items?: ItemList;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface BatchWriteItemInput {
+            RequestItems: BatchWriteItemRequestMap;            
+        }
+        export interface BatchWriteItemOutput {
+            Responses?: BatchWriteResponseMap;            
+            UnprocessedItems?: BatchWriteItemRequestMap;            
+        }
+        export interface BatchWriteResponse {
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface Condition {
+            AttributeValueList?: AttributeValueList;            
+            ComparisonOperator: ComparisonOperator;            
+        }
+        export interface ConditionalCheckFailedException {
+            message?: ErrorMessage;            
+        }
+        export interface CreateTableInput {
+            TableName: TableName;            
+            KeySchema: KeySchema;            
+            ProvisionedThroughput: ProvisionedThroughput;            
+        }
+        export interface CreateTableOutput {
+            TableDescription?: TableDescription;            
+        }
+        export interface DeleteItemInput {
+            TableName: TableName;            
+            Key: Key;            
+            Expected?: ExpectedAttributeMap;            
+            ReturnValues?: ReturnValue;            
+        }
+        export interface DeleteItemOutput {
+            Attributes?: AttributeMap;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface DeleteRequest {
+            Key: Key;            
+        }
+        export interface DeleteTableInput {
+            TableName: TableName;            
+        }
+        export interface DeleteTableOutput {
+            TableDescription?: TableDescription;            
+        }
+        export interface DescribeTableInput {
+            TableName: TableName;            
+        }
+        export interface DescribeTableOutput {
+            Table?: TableDescription;            
+        }
+        export interface ExpectedAttributeValue {
+            Value?: AttributeValue;            
+            Exists?: BooleanObject;            
+        }
+        export interface GetItemInput {
+            TableName: TableName;            
+            Key: Key;            
+            AttributesToGet?: AttributeNameList;            
+            ConsistentRead?: ConsistentRead;            
+        }
+        export interface GetItemOutput {
+            Item?: AttributeMap;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface InternalServerError {
+            message?: ErrorMessage;            
+        }
+        export interface Key {
+            HashKeyElement: AttributeValue;            
+            RangeKeyElement?: AttributeValue;            
+        }
+        export interface KeySchema {
+            HashKeyElement: KeySchemaElement;            
+            RangeKeyElement?: KeySchemaElement;            
+        }
+        export interface KeySchemaElement {
+            AttributeName: KeySchemaAttributeName;            
+            AttributeType: ScalarAttributeType;            
+        }
+        export interface KeysAndAttributes {
+            Keys: KeyList;            
+            AttributesToGet?: AttributeNameList;            
+            ConsistentRead?: ConsistentRead;            
+        }
+        export interface LimitExceededException {
+            message?: ErrorMessage;            
+        }
+        export interface ListTablesInput {
+            ExclusiveStartTableName?: TableName;            
+            Limit?: ListTablesInputLimit;            
+        }
+        export interface ListTablesOutput {
+            TableNames?: TableNameList;            
+            LastEvaluatedTableName?: TableName;            
+        }
+        export interface ProvisionedThroughput {
+            ReadCapacityUnits: PositiveLongObject;            
+            WriteCapacityUnits: PositiveLongObject;            
+        }
+        export interface ProvisionedThroughputDescription {
+            LastIncreaseDateTime?: Date;            
+            LastDecreaseDateTime?: Date;            
+            NumberOfDecreasesToday?: PositiveLongObject;            
+            ReadCapacityUnits?: PositiveLongObject;            
+            WriteCapacityUnits?: PositiveLongObject;            
+        }
+        export interface ProvisionedThroughputExceededException {
+            message?: ErrorMessage;            
+        }
+        export interface PutItemInput {
+            TableName: TableName;            
+            Item: PutItemInputAttributeMap;            
+            Expected?: ExpectedAttributeMap;            
+            ReturnValues?: ReturnValue;            
+        }
+        export interface PutItemOutput {
+            Attributes?: AttributeMap;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface PutRequest {
+            Item: PutItemInputAttributeMap;            
+        }
+        export interface QueryInput {
+            TableName: TableName;            
+            AttributesToGet?: AttributeNameList;            
+            Limit?: PositiveIntegerObject;            
+            ConsistentRead?: ConsistentRead;            
+            Count?: BooleanObject;            
+            HashKeyValue: AttributeValue;            
+            RangeKeyCondition?: Condition;            
+            ScanIndexForward?: BooleanObject;            
+            ExclusiveStartKey?: Key;            
+        }
+        export interface QueryOutput {
+            Items?: ItemList;            
+            Count?: Integer;            
+            LastEvaluatedKey?: Key;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface ResourceInUseException {
+            message?: ErrorMessage;            
+        }
+        export interface ResourceNotFoundException {
+            message?: ErrorMessage;            
+        }
+        export interface ScanInput {
+            TableName: TableName;            
+            AttributesToGet?: AttributeNameList;            
+            Limit?: PositiveIntegerObject;            
+            Count?: BooleanObject;            
+            ScanFilter?: FilterConditionMap;            
+            ExclusiveStartKey?: Key;            
+        }
+        export interface ScanOutput {
+            Items?: ItemList;            
+            Count?: Integer;            
+            ScannedCount?: Integer;            
+            LastEvaluatedKey?: Key;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface TableDescription {
+            TableName?: TableName;            
+            KeySchema?: KeySchema;            
+            TableStatus?: TableStatus;            
+            CreationDateTime?: Date;            
+            ProvisionedThroughput?: ProvisionedThroughputDescription;            
+            TableSizeBytes?: Long;            
+            ItemCount?: Long;            
+        }
+        export interface UpdateItemInput {
+            TableName: TableName;            
+            Key: Key;            
+            AttributeUpdates: AttributeUpdates;            
+            Expected?: ExpectedAttributeMap;            
+            ReturnValues?: ReturnValue;            
+        }
+        export interface UpdateItemOutput {
+            Attributes?: AttributeMap;            
+            ConsumedCapacityUnits?: ConsumedCapacityUnits;            
+        }
+        export interface UpdateTableInput {
+            TableName: TableName;            
+            ProvisionedThroughput: ProvisionedThroughput;            
+        }
+        export interface UpdateTableOutput {
+            TableDescription?: TableDescription;            
+        }
+        export interface WriteRequest {
+            PutRequest?: PutRequest;            
+            DeleteRequest?: DeleteRequest;            
+        }
+
     }
-
-    export type DynamoDBAttributeValueList = Array<DynamoDBAttributeValue>;
-    export interface DynamoDBAttributeValueUpdate {
-        Value?: DynamoDBAttributeValue;
-        Action?: DynamoDBAttributeAction;
-    }
-
-    export interface DynamoDBBatchGetItemInput {
-        RequestItems: DynamoDBBatchGetRequestMap;
-    }
-
-    export interface DynamoDBBatchGetItemOutput {
-        Responses?: DynamoDBBatchGetResponseMap;
-        UnprocessedKeys?: DynamoDBBatchGetRequestMap;
-    }
-
-    export type DynamoDBBatchGetRequestMap = any; // not really - it was 'map' instead - must fix this one
-    export type DynamoDBBatchGetResponseMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DynamoDBBatchResponse {
-        Items?: DynamoDBItemList;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export interface DynamoDBBatchWriteItemInput {
-        RequestItems: DynamoDBBatchWriteItemRequestMap;
-    }
-
-    export interface DynamoDBBatchWriteItemOutput {
-        Responses?: DynamoDBBatchWriteResponseMap;
-        UnprocessedItems?: DynamoDBBatchWriteItemRequestMap;
-    }
-
-    export type DynamoDBBatchWriteItemRequestMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DynamoDBBatchWriteResponse {
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export type DynamoDBBatchWriteResponseMap = any; // not really - it was 'map' instead - must fix this one
-    export type DynamoDBBinaryAttributeValue = any; // not really - it was 'blob' instead - must fix this one
-    export type DynamoDBBinarySetAttributeValue = Array<DynamoDBBinaryAttributeValue>;
-    export type DynamoDBBooleanObject = boolean;
-    export type DynamoDBComparisonOperator = string;
-    export interface DynamoDBCondition {
-        AttributeValueList?: DynamoDBAttributeValueList;
-        ComparisonOperator: DynamoDBComparisonOperator;
-    }
-
-    export interface DynamoDBConditionalCheckFailedException {
-        message?: DynamoDBErrorMessage;
-    }
-
-    export type DynamoDBConsistentRead = boolean;
-    export type DynamoDBConsumedCapacityUnits = number;
-    export interface DynamoDBCreateTableInput {
-        TableName: DynamoDBTableName;
-        KeySchema: DynamoDBKeySchema;
-        ProvisionedThroughput: DynamoDBProvisionedThroughput;
-    }
-
-    export interface DynamoDBCreateTableOutput {
-        TableDescription?: DynamoDBTableDescription;
-    }
-
-    export type DynamoDBDate = number;
-    export interface DynamoDBDeleteItemInput {
-        TableName: DynamoDBTableName;
-        Key: DynamoDBKey;
-        Expected?: DynamoDBExpectedAttributeMap;
-        ReturnValues?: DynamoDBReturnValue;
-    }
-
-    export interface DynamoDBDeleteItemOutput {
-        Attributes?: DynamoDBAttributeMap;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export interface DynamoDBDeleteRequest {
-        Key: DynamoDBKey;
-    }
-
-    export interface DynamoDBDeleteTableInput {
-        TableName: DynamoDBTableName;
-    }
-
-    export interface DynamoDBDeleteTableOutput {
-        TableDescription?: DynamoDBTableDescription;
-    }
-
-    export interface DynamoDBDescribeTableInput {
-        TableName: DynamoDBTableName;
-    }
-
-    export interface DynamoDBDescribeTableOutput {
-        Table?: DynamoDBTableDescription;
-    }
-
-    export type DynamoDBErrorMessage = string;
-    export type DynamoDBExpectedAttributeMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DynamoDBExpectedAttributeValue {
-        Value?: DynamoDBAttributeValue;
-        Exists?: DynamoDBBooleanObject;
-    }
-
-    export type DynamoDBFilterConditionMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DynamoDBGetItemInput {
-        TableName: DynamoDBTableName;
-        Key: DynamoDBKey;
-        AttributesToGet?: DynamoDBAttributeNameList;
-        ConsistentRead?: DynamoDBConsistentRead;
-    }
-
-    export interface DynamoDBGetItemOutput {
-        Item?: DynamoDBAttributeMap;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export type DynamoDBInteger = number;
-    export interface DynamoDBInternalServerError {
-        message?: DynamoDBErrorMessage;
-    }
-
-    export type DynamoDBItemList = Array<DynamoDBAttributeMap>;
-    export interface DynamoDBKey {
-        HashKeyElement: DynamoDBAttributeValue;
-        RangeKeyElement?: DynamoDBAttributeValue;
-    }
-
-    export type DynamoDBKeyList = Array<DynamoDBKey>; // max: 100
-    export interface DynamoDBKeySchema {
-        HashKeyElement: DynamoDBKeySchemaElement;
-        RangeKeyElement?: DynamoDBKeySchemaElement;
-    }
-
-    export type DynamoDBKeySchemaAttributeName = string;
-    export interface DynamoDBKeySchemaElement {
-        AttributeName: DynamoDBKeySchemaAttributeName;
-        AttributeType: DynamoDBScalarAttributeType;
-    }
-
-    export interface DynamoDBKeysAndAttributes {
-        Keys: DynamoDBKeyList;
-        AttributesToGet?: DynamoDBAttributeNameList;
-        ConsistentRead?: DynamoDBConsistentRead;
-    }
-
-    export interface DynamoDBLimitExceededException {
-        message?: DynamoDBErrorMessage;
-    }
-
-    export interface DynamoDBListTablesInput {
-        ExclusiveStartTableName?: DynamoDBTableName;
-        Limit?: DynamoDBListTablesInputLimit;
-    }
-
-    export type DynamoDBListTablesInputLimit = number;
-    export interface DynamoDBListTablesOutput {
-        TableNames?: DynamoDBTableNameList;
-        LastEvaluatedTableName?: DynamoDBTableName;
-    }
-
-    export type DynamoDBLong = number;
-    export type DynamoDBNumberAttributeValue = string;
-    export type DynamoDBNumberSetAttributeValue = Array<DynamoDBNumberAttributeValue>;
-    export type DynamoDBPositiveIntegerObject = number;
-    export type DynamoDBPositiveLongObject = number;
-    export interface DynamoDBProvisionedThroughput {
-        ReadCapacityUnits: DynamoDBPositiveLongObject;
-        WriteCapacityUnits: DynamoDBPositiveLongObject;
-    }
-
-    export interface DynamoDBProvisionedThroughputDescription {
-        LastIncreaseDateTime?: DynamoDBDate;
-        LastDecreaseDateTime?: DynamoDBDate;
-        NumberOfDecreasesToday?: DynamoDBPositiveLongObject;
-        ReadCapacityUnits?: DynamoDBPositiveLongObject;
-        WriteCapacityUnits?: DynamoDBPositiveLongObject;
-    }
-
-    export interface DynamoDBProvisionedThroughputExceededException {
-        message?: DynamoDBErrorMessage;
-    }
-
-    export interface DynamoDBPutItemInput {
-        TableName: DynamoDBTableName;
-        Item: DynamoDBPutItemInputAttributeMap;
-        Expected?: DynamoDBExpectedAttributeMap;
-        ReturnValues?: DynamoDBReturnValue;
-    }
-
-    export type DynamoDBPutItemInputAttributeMap = any; // not really - it was 'map' instead - must fix this one
-    export interface DynamoDBPutItemOutput {
-        Attributes?: DynamoDBAttributeMap;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export interface DynamoDBPutRequest {
-        Item: DynamoDBPutItemInputAttributeMap;
-    }
-
-    export interface DynamoDBQueryInput {
-        TableName: DynamoDBTableName;
-        AttributesToGet?: DynamoDBAttributeNameList;
-        Limit?: DynamoDBPositiveIntegerObject;
-        ConsistentRead?: DynamoDBConsistentRead;
-        Count?: DynamoDBBooleanObject;
-        HashKeyValue: DynamoDBAttributeValue;
-        RangeKeyCondition?: DynamoDBCondition;
-        ScanIndexForward?: DynamoDBBooleanObject;
-        ExclusiveStartKey?: DynamoDBKey;
-    }
-
-    export interface DynamoDBQueryOutput {
-        Items?: DynamoDBItemList;
-        Count?: DynamoDBInteger;
-        LastEvaluatedKey?: DynamoDBKey;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export interface DynamoDBResourceInUseException {
-        message?: DynamoDBErrorMessage;
-    }
-
-    export interface DynamoDBResourceNotFoundException {
-        message?: DynamoDBErrorMessage;
-    }
-
-    export type DynamoDBReturnValue = string;
-    export type DynamoDBScalarAttributeType = string;
-    export interface DynamoDBScanInput {
-        TableName: DynamoDBTableName;
-        AttributesToGet?: DynamoDBAttributeNameList;
-        Limit?: DynamoDBPositiveIntegerObject;
-        Count?: DynamoDBBooleanObject;
-        ScanFilter?: DynamoDBFilterConditionMap;
-        ExclusiveStartKey?: DynamoDBKey;
-    }
-
-    export interface DynamoDBScanOutput {
-        Items?: DynamoDBItemList;
-        Count?: DynamoDBInteger;
-        ScannedCount?: DynamoDBInteger;
-        LastEvaluatedKey?: DynamoDBKey;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export type DynamoDBString = string;
-    export type DynamoDBStringAttributeValue = string;
-    export type DynamoDBStringSetAttributeValue = Array<DynamoDBStringAttributeValue>;
-    export interface DynamoDBTableDescription {
-        TableName?: DynamoDBTableName;
-        KeySchema?: DynamoDBKeySchema;
-        TableStatus?: DynamoDBTableStatus;
-        CreationDateTime?: DynamoDBDate;
-        ProvisionedThroughput?: DynamoDBProvisionedThroughputDescription;
-        TableSizeBytes?: DynamoDBLong;
-        ItemCount?: DynamoDBLong;
-    }
-
-    export type DynamoDBTableName = string; // pattern: "[a-zA-Z0-9_.-]+"
-    export type DynamoDBTableNameList = Array<DynamoDBTableName>;
-    export type DynamoDBTableStatus = string;
-    export interface DynamoDBUpdateItemInput {
-        TableName: DynamoDBTableName;
-        Key: DynamoDBKey;
-        AttributeUpdates: DynamoDBAttributeUpdates;
-        Expected?: DynamoDBExpectedAttributeMap;
-        ReturnValues?: DynamoDBReturnValue;
-    }
-
-    export interface DynamoDBUpdateItemOutput {
-        Attributes?: DynamoDBAttributeMap;
-        ConsumedCapacityUnits?: DynamoDBConsumedCapacityUnits;
-    }
-
-    export interface DynamoDBUpdateTableInput {
-        TableName: DynamoDBTableName;
-        ProvisionedThroughput: DynamoDBProvisionedThroughput;
-    }
-
-    export interface DynamoDBUpdateTableOutput {
-        TableDescription?: DynamoDBTableDescription;
-    }
-
-    export interface DynamoDBWriteRequest {
-        PutRequest?: DynamoDBPutRequest;
-        DeleteRequest?: DynamoDBDeleteRequest;
-    }
-
-    export type DynamoDBWriteRequests = Array<DynamoDBWriteRequest>; // max: 25
 }

--- a/output/aws-ec2.d.ts
+++ b/output/aws-ec2.d.ts
@@ -6,3633 +6,3155 @@ declare module "aws-sdk" {
 
     export class EC2 extends Service {
       constructor(options?: any);
-      acceptVpcPeeringConnection(params: EC2AcceptVpcPeeringConnectionRequest, callback?: (err: any, data: EC2AcceptVpcPeeringConnectionResult|any) => void): Request;
-      allocateAddress(params: EC2AllocateAddressRequest, callback?: (err: any, data: EC2AllocateAddressResult|any) => void): Request;
-      allocateHosts(params: EC2AllocateHostsRequest, callback?: (err: any, data: EC2AllocateHostsResult|any) => void): Request;
-      assignPrivateIpAddresses(params: EC2AssignPrivateIpAddressesRequest, callback?: (err: any, data: any) => void): Request;
-      associateAddress(params: EC2AssociateAddressRequest, callback?: (err: any, data: EC2AssociateAddressResult|any) => void): Request;
-      associateDhcpOptions(params: EC2AssociateDhcpOptionsRequest, callback?: (err: any, data: any) => void): Request;
-      associateRouteTable(params: EC2AssociateRouteTableRequest, callback?: (err: any, data: EC2AssociateRouteTableResult|any) => void): Request;
-      attachClassicLinkVpc(params: EC2AttachClassicLinkVpcRequest, callback?: (err: any, data: EC2AttachClassicLinkVpcResult|any) => void): Request;
-      attachInternetGateway(params: EC2AttachInternetGatewayRequest, callback?: (err: any, data: any) => void): Request;
-      attachNetworkInterface(params: EC2AttachNetworkInterfaceRequest, callback?: (err: any, data: EC2AttachNetworkInterfaceResult|any) => void): Request;
-      attachVolume(params: EC2AttachVolumeRequest, callback?: (err: any, data: EC2VolumeAttachment|any) => void): Request;
-      attachVpnGateway(params: EC2AttachVpnGatewayRequest, callback?: (err: any, data: EC2AttachVpnGatewayResult|any) => void): Request;
-      authorizeSecurityGroupEgress(params: EC2AuthorizeSecurityGroupEgressRequest, callback?: (err: any, data: any) => void): Request;
-      authorizeSecurityGroupIngress(params: EC2AuthorizeSecurityGroupIngressRequest, callback?: (err: any, data: any) => void): Request;
-      bundleInstance(params: EC2BundleInstanceRequest, callback?: (err: any, data: EC2BundleInstanceResult|any) => void): Request;
-      cancelBundleTask(params: EC2CancelBundleTaskRequest, callback?: (err: any, data: EC2CancelBundleTaskResult|any) => void): Request;
-      cancelConversionTask(params: EC2CancelConversionRequest, callback?: (err: any, data: any) => void): Request;
-      cancelExportTask(params: EC2CancelExportTaskRequest, callback?: (err: any, data: any) => void): Request;
-      cancelImportTask(params: EC2CancelImportTaskRequest, callback?: (err: any, data: EC2CancelImportTaskResult|any) => void): Request;
-      cancelReservedInstancesListing(params: EC2CancelReservedInstancesListingRequest, callback?: (err: any, data: EC2CancelReservedInstancesListingResult|any) => void): Request;
-      cancelSpotFleetRequests(params: EC2CancelSpotFleetRequestsRequest, callback?: (err: any, data: EC2CancelSpotFleetRequestsResponse|any) => void): Request;
-      cancelSpotInstanceRequests(params: EC2CancelSpotInstanceRequestsRequest, callback?: (err: any, data: EC2CancelSpotInstanceRequestsResult|any) => void): Request;
-      confirmProductInstance(params: EC2ConfirmProductInstanceRequest, callback?: (err: any, data: EC2ConfirmProductInstanceResult|any) => void): Request;
-      copyImage(params: EC2CopyImageRequest, callback?: (err: any, data: EC2CopyImageResult|any) => void): Request;
-      copySnapshot(params: EC2CopySnapshotRequest, callback?: (err: any, data: EC2CopySnapshotResult|any) => void): Request;
-      createCustomerGateway(params: EC2CreateCustomerGatewayRequest, callback?: (err: any, data: EC2CreateCustomerGatewayResult|any) => void): Request;
-      createDhcpOptions(params: EC2CreateDhcpOptionsRequest, callback?: (err: any, data: EC2CreateDhcpOptionsResult|any) => void): Request;
-      createFlowLogs(params: EC2CreateFlowLogsRequest, callback?: (err: any, data: EC2CreateFlowLogsResult|any) => void): Request;
-      createImage(params: EC2CreateImageRequest, callback?: (err: any, data: EC2CreateImageResult|any) => void): Request;
-      createInstanceExportTask(params: EC2CreateInstanceExportTaskRequest, callback?: (err: any, data: EC2CreateInstanceExportTaskResult|any) => void): Request;
-      createInternetGateway(params: EC2CreateInternetGatewayRequest, callback?: (err: any, data: EC2CreateInternetGatewayResult|any) => void): Request;
-      createKeyPair(params: EC2CreateKeyPairRequest, callback?: (err: any, data: EC2KeyPair|any) => void): Request;
-      createNetworkAcl(params: EC2CreateNetworkAclRequest, callback?: (err: any, data: EC2CreateNetworkAclResult|any) => void): Request;
-      createNetworkAclEntry(params: EC2CreateNetworkAclEntryRequest, callback?: (err: any, data: any) => void): Request;
-      createNetworkInterface(params: EC2CreateNetworkInterfaceRequest, callback?: (err: any, data: EC2CreateNetworkInterfaceResult|any) => void): Request;
-      createPlacementGroup(params: EC2CreatePlacementGroupRequest, callback?: (err: any, data: any) => void): Request;
-      createReservedInstancesListing(params: EC2CreateReservedInstancesListingRequest, callback?: (err: any, data: EC2CreateReservedInstancesListingResult|any) => void): Request;
-      createRoute(params: EC2CreateRouteRequest, callback?: (err: any, data: EC2CreateRouteResult|any) => void): Request;
-      createRouteTable(params: EC2CreateRouteTableRequest, callback?: (err: any, data: EC2CreateRouteTableResult|any) => void): Request;
-      createSecurityGroup(params: EC2CreateSecurityGroupRequest, callback?: (err: any, data: EC2CreateSecurityGroupResult|any) => void): Request;
-      createSnapshot(params: EC2CreateSnapshotRequest, callback?: (err: any, data: EC2Snapshot|any) => void): Request;
-      createSpotDatafeedSubscription(params: EC2CreateSpotDatafeedSubscriptionRequest, callback?: (err: any, data: EC2CreateSpotDatafeedSubscriptionResult|any) => void): Request;
-      createSubnet(params: EC2CreateSubnetRequest, callback?: (err: any, data: EC2CreateSubnetResult|any) => void): Request;
-      createTags(params: EC2CreateTagsRequest, callback?: (err: any, data: any) => void): Request;
-      createVolume(params: EC2CreateVolumeRequest, callback?: (err: any, data: EC2Volume|any) => void): Request;
-      createVpc(params: EC2CreateVpcRequest, callback?: (err: any, data: EC2CreateVpcResult|any) => void): Request;
-      createVpcEndpoint(params: EC2CreateVpcEndpointRequest, callback?: (err: any, data: EC2CreateVpcEndpointResult|any) => void): Request;
-      createVpcPeeringConnection(params: EC2CreateVpcPeeringConnectionRequest, callback?: (err: any, data: EC2CreateVpcPeeringConnectionResult|any) => void): Request;
-      createVpnConnection(params: EC2CreateVpnConnectionRequest, callback?: (err: any, data: EC2CreateVpnConnectionResult|any) => void): Request;
-      createVpnConnectionRoute(params: EC2CreateVpnConnectionRouteRequest, callback?: (err: any, data: any) => void): Request;
-      createVpnGateway(params: EC2CreateVpnGatewayRequest, callback?: (err: any, data: EC2CreateVpnGatewayResult|any) => void): Request;
-      deleteCustomerGateway(params: EC2DeleteCustomerGatewayRequest, callback?: (err: any, data: any) => void): Request;
-      deleteDhcpOptions(params: EC2DeleteDhcpOptionsRequest, callback?: (err: any, data: any) => void): Request;
-      deleteFlowLogs(params: EC2DeleteFlowLogsRequest, callback?: (err: any, data: EC2DeleteFlowLogsResult|any) => void): Request;
-      deleteInternetGateway(params: EC2DeleteInternetGatewayRequest, callback?: (err: any, data: any) => void): Request;
-      deleteKeyPair(params: EC2DeleteKeyPairRequest, callback?: (err: any, data: any) => void): Request;
-      deleteNetworkAcl(params: EC2DeleteNetworkAclRequest, callback?: (err: any, data: any) => void): Request;
-      deleteNetworkAclEntry(params: EC2DeleteNetworkAclEntryRequest, callback?: (err: any, data: any) => void): Request;
-      deleteNetworkInterface(params: EC2DeleteNetworkInterfaceRequest, callback?: (err: any, data: any) => void): Request;
-      deletePlacementGroup(params: EC2DeletePlacementGroupRequest, callback?: (err: any, data: any) => void): Request;
-      deleteRoute(params: EC2DeleteRouteRequest, callback?: (err: any, data: any) => void): Request;
-      deleteRouteTable(params: EC2DeleteRouteTableRequest, callback?: (err: any, data: any) => void): Request;
-      deleteSecurityGroup(params: EC2DeleteSecurityGroupRequest, callback?: (err: any, data: any) => void): Request;
-      deleteSnapshot(params: EC2DeleteSnapshotRequest, callback?: (err: any, data: any) => void): Request;
-      deleteSpotDatafeedSubscription(params: EC2DeleteSpotDatafeedSubscriptionRequest, callback?: (err: any, data: any) => void): Request;
-      deleteSubnet(params: EC2DeleteSubnetRequest, callback?: (err: any, data: any) => void): Request;
-      deleteTags(params: EC2DeleteTagsRequest, callback?: (err: any, data: any) => void): Request;
-      deleteVolume(params: EC2DeleteVolumeRequest, callback?: (err: any, data: any) => void): Request;
-      deleteVpc(params: EC2DeleteVpcRequest, callback?: (err: any, data: any) => void): Request;
-      deleteVpcEndpoints(params: EC2DeleteVpcEndpointsRequest, callback?: (err: any, data: EC2DeleteVpcEndpointsResult|any) => void): Request;
-      deleteVpcPeeringConnection(params: EC2DeleteVpcPeeringConnectionRequest, callback?: (err: any, data: EC2DeleteVpcPeeringConnectionResult|any) => void): Request;
-      deleteVpnConnection(params: EC2DeleteVpnConnectionRequest, callback?: (err: any, data: any) => void): Request;
-      deleteVpnConnectionRoute(params: EC2DeleteVpnConnectionRouteRequest, callback?: (err: any, data: any) => void): Request;
-      deleteVpnGateway(params: EC2DeleteVpnGatewayRequest, callback?: (err: any, data: any) => void): Request;
-      deregisterImage(params: EC2DeregisterImageRequest, callback?: (err: any, data: any) => void): Request;
-      describeAccountAttributes(params: EC2DescribeAccountAttributesRequest, callback?: (err: any, data: EC2DescribeAccountAttributesResult|any) => void): Request;
-      describeAddresses(params: EC2DescribeAddressesRequest, callback?: (err: any, data: EC2DescribeAddressesResult|any) => void): Request;
-      describeAvailabilityZones(params: EC2DescribeAvailabilityZonesRequest, callback?: (err: any, data: EC2DescribeAvailabilityZonesResult|any) => void): Request;
-      describeBundleTasks(params: EC2DescribeBundleTasksRequest, callback?: (err: any, data: EC2DescribeBundleTasksResult|any) => void): Request;
-      describeClassicLinkInstances(params: EC2DescribeClassicLinkInstancesRequest, callback?: (err: any, data: EC2DescribeClassicLinkInstancesResult|any) => void): Request;
-      describeConversionTasks(params: EC2DescribeConversionTasksRequest, callback?: (err: any, data: EC2DescribeConversionTasksResult|any) => void): Request;
-      describeCustomerGateways(params: EC2DescribeCustomerGatewaysRequest, callback?: (err: any, data: EC2DescribeCustomerGatewaysResult|any) => void): Request;
-      describeDhcpOptions(params: EC2DescribeDhcpOptionsRequest, callback?: (err: any, data: EC2DescribeDhcpOptionsResult|any) => void): Request;
-      describeExportTasks(params: EC2DescribeExportTasksRequest, callback?: (err: any, data: EC2DescribeExportTasksResult|any) => void): Request;
-      describeFlowLogs(params: EC2DescribeFlowLogsRequest, callback?: (err: any, data: EC2DescribeFlowLogsResult|any) => void): Request;
-      describeHosts(params: EC2DescribeHostsRequest, callback?: (err: any, data: EC2DescribeHostsResult|any) => void): Request;
-      describeIdFormat(params: EC2DescribeIdFormatRequest, callback?: (err: any, data: EC2DescribeIdFormatResult|any) => void): Request;
-      describeImageAttribute(params: EC2DescribeImageAttributeRequest, callback?: (err: any, data: EC2ImageAttribute|any) => void): Request;
-      describeImages(params: EC2DescribeImagesRequest, callback?: (err: any, data: EC2DescribeImagesResult|any) => void): Request;
-      describeImportImageTasks(params: EC2DescribeImportImageTasksRequest, callback?: (err: any, data: EC2DescribeImportImageTasksResult|any) => void): Request;
-      describeImportSnapshotTasks(params: EC2DescribeImportSnapshotTasksRequest, callback?: (err: any, data: EC2DescribeImportSnapshotTasksResult|any) => void): Request;
-      describeInstanceAttribute(params: EC2DescribeInstanceAttributeRequest, callback?: (err: any, data: EC2InstanceAttribute|any) => void): Request;
-      describeInstanceStatus(params: EC2DescribeInstanceStatusRequest, callback?: (err: any, data: EC2DescribeInstanceStatusResult|any) => void): Request;
-      describeInstances(params: EC2DescribeInstancesRequest, callback?: (err: any, data: EC2DescribeInstancesResult|any) => void): Request;
-      describeInternetGateways(params: EC2DescribeInternetGatewaysRequest, callback?: (err: any, data: EC2DescribeInternetGatewaysResult|any) => void): Request;
-      describeKeyPairs(params: EC2DescribeKeyPairsRequest, callback?: (err: any, data: EC2DescribeKeyPairsResult|any) => void): Request;
-      describeMovingAddresses(params: EC2DescribeMovingAddressesRequest, callback?: (err: any, data: EC2DescribeMovingAddressesResult|any) => void): Request;
-      describeNetworkAcls(params: EC2DescribeNetworkAclsRequest, callback?: (err: any, data: EC2DescribeNetworkAclsResult|any) => void): Request;
-      describeNetworkInterfaceAttribute(params: EC2DescribeNetworkInterfaceAttributeRequest, callback?: (err: any, data: EC2DescribeNetworkInterfaceAttributeResult|any) => void): Request;
-      describeNetworkInterfaces(params: EC2DescribeNetworkInterfacesRequest, callback?: (err: any, data: EC2DescribeNetworkInterfacesResult|any) => void): Request;
-      describePlacementGroups(params: EC2DescribePlacementGroupsRequest, callback?: (err: any, data: EC2DescribePlacementGroupsResult|any) => void): Request;
-      describePrefixLists(params: EC2DescribePrefixListsRequest, callback?: (err: any, data: EC2DescribePrefixListsResult|any) => void): Request;
-      describeRegions(params: EC2DescribeRegionsRequest, callback?: (err: any, data: EC2DescribeRegionsResult|any) => void): Request;
-      describeReservedInstances(params: EC2DescribeReservedInstancesRequest, callback?: (err: any, data: EC2DescribeReservedInstancesResult|any) => void): Request;
-      describeReservedInstancesListings(params: EC2DescribeReservedInstancesListingsRequest, callback?: (err: any, data: EC2DescribeReservedInstancesListingsResult|any) => void): Request;
-      describeReservedInstancesModifications(params: EC2DescribeReservedInstancesModificationsRequest, callback?: (err: any, data: EC2DescribeReservedInstancesModificationsResult|any) => void): Request;
-      describeReservedInstancesOfferings(params: EC2DescribeReservedInstancesOfferingsRequest, callback?: (err: any, data: EC2DescribeReservedInstancesOfferingsResult|any) => void): Request;
-      describeRouteTables(params: EC2DescribeRouteTablesRequest, callback?: (err: any, data: EC2DescribeRouteTablesResult|any) => void): Request;
-      describeSecurityGroups(params: EC2DescribeSecurityGroupsRequest, callback?: (err: any, data: EC2DescribeSecurityGroupsResult|any) => void): Request;
-      describeSnapshotAttribute(params: EC2DescribeSnapshotAttributeRequest, callback?: (err: any, data: EC2DescribeSnapshotAttributeResult|any) => void): Request;
-      describeSnapshots(params: EC2DescribeSnapshotsRequest, callback?: (err: any, data: EC2DescribeSnapshotsResult|any) => void): Request;
-      describeSpotDatafeedSubscription(params: EC2DescribeSpotDatafeedSubscriptionRequest, callback?: (err: any, data: EC2DescribeSpotDatafeedSubscriptionResult|any) => void): Request;
-      describeSpotFleetInstances(params: EC2DescribeSpotFleetInstancesRequest, callback?: (err: any, data: EC2DescribeSpotFleetInstancesResponse|any) => void): Request;
-      describeSpotFleetRequestHistory(params: EC2DescribeSpotFleetRequestHistoryRequest, callback?: (err: any, data: EC2DescribeSpotFleetRequestHistoryResponse|any) => void): Request;
-      describeSpotFleetRequests(params: EC2DescribeSpotFleetRequestsRequest, callback?: (err: any, data: EC2DescribeSpotFleetRequestsResponse|any) => void): Request;
-      describeSpotInstanceRequests(params: EC2DescribeSpotInstanceRequestsRequest, callback?: (err: any, data: EC2DescribeSpotInstanceRequestsResult|any) => void): Request;
-      describeSpotPriceHistory(params: EC2DescribeSpotPriceHistoryRequest, callback?: (err: any, data: EC2DescribeSpotPriceHistoryResult|any) => void): Request;
-      describeSubnets(params: EC2DescribeSubnetsRequest, callback?: (err: any, data: EC2DescribeSubnetsResult|any) => void): Request;
-      describeTags(params: EC2DescribeTagsRequest, callback?: (err: any, data: EC2DescribeTagsResult|any) => void): Request;
-      describeVolumeAttribute(params: EC2DescribeVolumeAttributeRequest, callback?: (err: any, data: EC2DescribeVolumeAttributeResult|any) => void): Request;
-      describeVolumeStatus(params: EC2DescribeVolumeStatusRequest, callback?: (err: any, data: EC2DescribeVolumeStatusResult|any) => void): Request;
-      describeVolumes(params: EC2DescribeVolumesRequest, callback?: (err: any, data: EC2DescribeVolumesResult|any) => void): Request;
-      describeVpcAttribute(params: EC2DescribeVpcAttributeRequest, callback?: (err: any, data: EC2DescribeVpcAttributeResult|any) => void): Request;
-      describeVpcClassicLink(params: EC2DescribeVpcClassicLinkRequest, callback?: (err: any, data: EC2DescribeVpcClassicLinkResult|any) => void): Request;
-      describeVpcEndpointServices(params: EC2DescribeVpcEndpointServicesRequest, callback?: (err: any, data: EC2DescribeVpcEndpointServicesResult|any) => void): Request;
-      describeVpcEndpoints(params: EC2DescribeVpcEndpointsRequest, callback?: (err: any, data: EC2DescribeVpcEndpointsResult|any) => void): Request;
-      describeVpcPeeringConnections(params: EC2DescribeVpcPeeringConnectionsRequest, callback?: (err: any, data: EC2DescribeVpcPeeringConnectionsResult|any) => void): Request;
-      describeVpcs(params: EC2DescribeVpcsRequest, callback?: (err: any, data: EC2DescribeVpcsResult|any) => void): Request;
-      describeVpnConnections(params: EC2DescribeVpnConnectionsRequest, callback?: (err: any, data: EC2DescribeVpnConnectionsResult|any) => void): Request;
-      describeVpnGateways(params: EC2DescribeVpnGatewaysRequest, callback?: (err: any, data: EC2DescribeVpnGatewaysResult|any) => void): Request;
-      detachClassicLinkVpc(params: EC2DetachClassicLinkVpcRequest, callback?: (err: any, data: EC2DetachClassicLinkVpcResult|any) => void): Request;
-      detachInternetGateway(params: EC2DetachInternetGatewayRequest, callback?: (err: any, data: any) => void): Request;
-      detachNetworkInterface(params: EC2DetachNetworkInterfaceRequest, callback?: (err: any, data: any) => void): Request;
-      detachVolume(params: EC2DetachVolumeRequest, callback?: (err: any, data: EC2VolumeAttachment|any) => void): Request;
-      detachVpnGateway(params: EC2DetachVpnGatewayRequest, callback?: (err: any, data: any) => void): Request;
-      disableVgwRoutePropagation(params: EC2DisableVgwRoutePropagationRequest, callback?: (err: any, data: any) => void): Request;
-      disableVpcClassicLink(params: EC2DisableVpcClassicLinkRequest, callback?: (err: any, data: EC2DisableVpcClassicLinkResult|any) => void): Request;
-      disassociateAddress(params: EC2DisassociateAddressRequest, callback?: (err: any, data: any) => void): Request;
-      disassociateRouteTable(params: EC2DisassociateRouteTableRequest, callback?: (err: any, data: any) => void): Request;
-      enableVgwRoutePropagation(params: EC2EnableVgwRoutePropagationRequest, callback?: (err: any, data: any) => void): Request;
-      enableVolumeIO(params: EC2EnableVolumeIORequest, callback?: (err: any, data: any) => void): Request;
-      enableVpcClassicLink(params: EC2EnableVpcClassicLinkRequest, callback?: (err: any, data: EC2EnableVpcClassicLinkResult|any) => void): Request;
-      getConsoleOutput(params: EC2GetConsoleOutputRequest, callback?: (err: any, data: EC2GetConsoleOutputResult|any) => void): Request;
-      getPasswordData(params: EC2GetPasswordDataRequest, callback?: (err: any, data: EC2GetPasswordDataResult|any) => void): Request;
-      importImage(params: EC2ImportImageRequest, callback?: (err: any, data: EC2ImportImageResult|any) => void): Request;
-      importInstance(params: EC2ImportInstanceRequest, callback?: (err: any, data: EC2ImportInstanceResult|any) => void): Request;
-      importKeyPair(params: EC2ImportKeyPairRequest, callback?: (err: any, data: EC2ImportKeyPairResult|any) => void): Request;
-      importSnapshot(params: EC2ImportSnapshotRequest, callback?: (err: any, data: EC2ImportSnapshotResult|any) => void): Request;
-      importVolume(params: EC2ImportVolumeRequest, callback?: (err: any, data: EC2ImportVolumeResult|any) => void): Request;
-      modifyHosts(params: EC2ModifyHostsRequest, callback?: (err: any, data: EC2ModifyHostsResult|any) => void): Request;
-      modifyIdFormat(params: EC2ModifyIdFormatRequest, callback?: (err: any, data: any) => void): Request;
-      modifyImageAttribute(params: EC2ModifyImageAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifyInstanceAttribute(params: EC2ModifyInstanceAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifyInstancePlacement(params: EC2ModifyInstancePlacementRequest, callback?: (err: any, data: EC2ModifyInstancePlacementResult|any) => void): Request;
-      modifyNetworkInterfaceAttribute(params: EC2ModifyNetworkInterfaceAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifyReservedInstances(params: EC2ModifyReservedInstancesRequest, callback?: (err: any, data: EC2ModifyReservedInstancesResult|any) => void): Request;
-      modifySnapshotAttribute(params: EC2ModifySnapshotAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifySpotFleetRequest(params: EC2ModifySpotFleetRequestRequest, callback?: (err: any, data: EC2ModifySpotFleetRequestResponse|any) => void): Request;
-      modifySubnetAttribute(params: EC2ModifySubnetAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifyVolumeAttribute(params: EC2ModifyVolumeAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifyVpcAttribute(params: EC2ModifyVpcAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      modifyVpcEndpoint(params: EC2ModifyVpcEndpointRequest, callback?: (err: any, data: EC2ModifyVpcEndpointResult|any) => void): Request;
-      monitorInstances(params: EC2MonitorInstancesRequest, callback?: (err: any, data: EC2MonitorInstancesResult|any) => void): Request;
-      moveAddressToVpc(params: EC2MoveAddressToVpcRequest, callback?: (err: any, data: EC2MoveAddressToVpcResult|any) => void): Request;
-      purchaseReservedInstancesOffering(params: EC2PurchaseReservedInstancesOfferingRequest, callback?: (err: any, data: EC2PurchaseReservedInstancesOfferingResult|any) => void): Request;
-      rebootInstances(params: EC2RebootInstancesRequest, callback?: (err: any, data: any) => void): Request;
-      registerImage(params: EC2RegisterImageRequest, callback?: (err: any, data: EC2RegisterImageResult|any) => void): Request;
-      rejectVpcPeeringConnection(params: EC2RejectVpcPeeringConnectionRequest, callback?: (err: any, data: EC2RejectVpcPeeringConnectionResult|any) => void): Request;
-      releaseAddress(params: EC2ReleaseAddressRequest, callback?: (err: any, data: any) => void): Request;
-      releaseHosts(params: EC2ReleaseHostsRequest, callback?: (err: any, data: EC2ReleaseHostsResult|any) => void): Request;
-      replaceNetworkAclAssociation(params: EC2ReplaceNetworkAclAssociationRequest, callback?: (err: any, data: EC2ReplaceNetworkAclAssociationResult|any) => void): Request;
-      replaceNetworkAclEntry(params: EC2ReplaceNetworkAclEntryRequest, callback?: (err: any, data: any) => void): Request;
-      replaceRoute(params: EC2ReplaceRouteRequest, callback?: (err: any, data: any) => void): Request;
-      replaceRouteTableAssociation(params: EC2ReplaceRouteTableAssociationRequest, callback?: (err: any, data: EC2ReplaceRouteTableAssociationResult|any) => void): Request;
-      reportInstanceStatus(params: EC2ReportInstanceStatusRequest, callback?: (err: any, data: any) => void): Request;
-      requestSpotFleet(params: EC2RequestSpotFleetRequest, callback?: (err: any, data: EC2RequestSpotFleetResponse|any) => void): Request;
-      requestSpotInstances(params: EC2RequestSpotInstancesRequest, callback?: (err: any, data: EC2RequestSpotInstancesResult|any) => void): Request;
-      resetImageAttribute(params: EC2ResetImageAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      resetInstanceAttribute(params: EC2ResetInstanceAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      resetNetworkInterfaceAttribute(params: EC2ResetNetworkInterfaceAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      resetSnapshotAttribute(params: EC2ResetSnapshotAttributeRequest, callback?: (err: any, data: any) => void): Request;
-      restoreAddressToClassic(params: EC2RestoreAddressToClassicRequest, callback?: (err: any, data: EC2RestoreAddressToClassicResult|any) => void): Request;
-      revokeSecurityGroupEgress(params: EC2RevokeSecurityGroupEgressRequest, callback?: (err: any, data: any) => void): Request;
-      revokeSecurityGroupIngress(params: EC2RevokeSecurityGroupIngressRequest, callback?: (err: any, data: any) => void): Request;
-      runInstances(params: EC2RunInstancesRequest, callback?: (err: any, data: EC2Reservation|any) => void): Request;
-      startInstances(params: EC2StartInstancesRequest, callback?: (err: any, data: EC2StartInstancesResult|any) => void): Request;
-      stopInstances(params: EC2StopInstancesRequest, callback?: (err: any, data: EC2StopInstancesResult|any) => void): Request;
-      terminateInstances(params: EC2TerminateInstancesRequest, callback?: (err: any, data: EC2TerminateInstancesResult|any) => void): Request;
-      unassignPrivateIpAddresses(params: EC2UnassignPrivateIpAddressesRequest, callback?: (err: any, data: any) => void): Request;
-      unmonitorInstances(params: EC2UnmonitorInstancesRequest, callback?: (err: any, data: EC2UnmonitorInstancesResult|any) => void): Request;
-    }
-
-    export interface EC2AcceptVpcPeeringConnectionRequest {
-        DryRun?: EC2Boolean;
-        VpcPeeringConnectionId?: EC2String;
-    }
-
-    export interface EC2AcceptVpcPeeringConnectionResult {
-        VpcPeeringConnection?: EC2VpcPeeringConnection;
-    }
-
-    export interface EC2AccountAttribute {
-        AttributeName?: EC2String;
-        AttributeValues?: EC2AccountAttributeValueList;
-    }
-
-    export type EC2AccountAttributeList = Array<EC2AccountAttribute>;
-    export type EC2AccountAttributeName = string;
-    export type EC2AccountAttributeNameStringList = Array<EC2AccountAttributeName>;
-    export interface EC2AccountAttributeValue {
-        AttributeValue?: EC2String;
-    }
-
-    export type EC2AccountAttributeValueList = Array<EC2AccountAttributeValue>;
-    export interface EC2ActiveInstance {
-        InstanceType?: EC2String;
-        InstanceId?: EC2String;
-        SpotInstanceRequestId?: EC2String;
-    }
-
-    export type EC2ActiveInstanceSet = Array<EC2ActiveInstance>;
-    export interface EC2Address {
-        InstanceId?: EC2String;
-        PublicIp?: EC2String;
-        AllocationId?: EC2String;
-        AssociationId?: EC2String;
-        Domain?: EC2DomainType;
-        NetworkInterfaceId?: EC2String;
-        NetworkInterfaceOwnerId?: EC2String;
-        PrivateIpAddress?: EC2String;
-    }
-
-    export type EC2AddressList = Array<EC2Address>;
-    export type EC2Affinity = string;
-    export interface EC2AllocateAddressRequest {
-        DryRun?: EC2Boolean;
-        Domain?: EC2DomainType;
-    }
-
-    export interface EC2AllocateAddressResult {
-        PublicIp?: EC2String;
-        Domain?: EC2DomainType;
-        AllocationId?: EC2String;
-    }
-
-    export interface EC2AllocateHostsRequest {
-        AutoPlacement?: EC2AutoPlacement;
-        ClientToken?: EC2String;
-        InstanceType: EC2String;
-        Quantity: EC2Integer;
-        AvailabilityZone: EC2String;
-    }
-
-    export interface EC2AllocateHostsResult {
-        HostIds?: EC2ResponseHostIdList;
-    }
-
-    export type EC2AllocationIdList = Array<EC2String>;
-    export type EC2AllocationState = string;
-    export type EC2AllocationStrategy = string;
-    export type EC2ArchitectureValues = string;
-    export interface EC2AssignPrivateIpAddressesRequest {
-        NetworkInterfaceId: EC2String;
-        PrivateIpAddresses?: EC2PrivateIpAddressStringList;
-        SecondaryPrivateIpAddressCount?: EC2Integer;
-        AllowReassignment?: EC2Boolean;
-    }
-
-    export interface EC2AssociateAddressRequest {
-        DryRun?: EC2Boolean;
-        InstanceId?: EC2String;
-        PublicIp?: EC2String;
-        AllocationId?: EC2String;
-        NetworkInterfaceId?: EC2String;
-        PrivateIpAddress?: EC2String;
-        AllowReassociation?: EC2Boolean;
-    }
-
-    export interface EC2AssociateAddressResult {
-        AssociationId?: EC2String;
-    }
-
-    export interface EC2AssociateDhcpOptionsRequest {
-        DryRun?: EC2Boolean;
-        DhcpOptionsId: EC2String;
-        VpcId: EC2String;
-    }
-
-    export interface EC2AssociateRouteTableRequest {
-        DryRun?: EC2Boolean;
-        SubnetId: EC2String;
-        RouteTableId: EC2String;
-    }
-
-    export interface EC2AssociateRouteTableResult {
-        AssociationId?: EC2String;
-    }
-
-    export interface EC2AttachClassicLinkVpcRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        VpcId: EC2String;
-        Groups: EC2GroupIdStringList;
-    }
-
-    export interface EC2AttachClassicLinkVpcResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2AttachInternetGatewayRequest {
-        DryRun?: EC2Boolean;
-        InternetGatewayId: EC2String;
-        VpcId: EC2String;
-    }
-
-    export interface EC2AttachNetworkInterfaceRequest {
-        DryRun?: EC2Boolean;
-        NetworkInterfaceId: EC2String;
-        InstanceId: EC2String;
-        DeviceIndex: EC2Integer;
-    }
-
-    export interface EC2AttachNetworkInterfaceResult {
-        AttachmentId?: EC2String;
-    }
-
-    export interface EC2AttachVolumeRequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-        InstanceId: EC2String;
-        Device: EC2String;
-    }
-
-    export interface EC2AttachVpnGatewayRequest {
-        DryRun?: EC2Boolean;
-        VpnGatewayId: EC2String;
-        VpcId: EC2String;
-    }
-
-    export interface EC2AttachVpnGatewayResult {
-        VpcAttachment?: EC2VpcAttachment;
-    }
-
-    export type EC2AttachmentStatus = string;
-    export interface EC2AttributeBooleanValue {
-        Value?: EC2Boolean;
-    }
-
-    export interface EC2AttributeValue {
-        Value?: EC2String;
-    }
-
-    export interface EC2AuthorizeSecurityGroupEgressRequest {
-        DryRun?: EC2Boolean;
-        GroupId: EC2String;
-        SourceSecurityGroupName?: EC2String;
-        SourceSecurityGroupOwnerId?: EC2String;
-        IpProtocol?: EC2String;
-        FromPort?: EC2Integer;
-        ToPort?: EC2Integer;
-        CidrIp?: EC2String;
-        IpPermissions?: EC2IpPermissionList;
-    }
-
-    export interface EC2AuthorizeSecurityGroupIngressRequest {
-        DryRun?: EC2Boolean;
-        GroupName?: EC2String;
-        GroupId?: EC2String;
-        SourceSecurityGroupName?: EC2String;
-        SourceSecurityGroupOwnerId?: EC2String;
-        IpProtocol?: EC2String;
-        FromPort?: EC2Integer;
-        ToPort?: EC2Integer;
-        CidrIp?: EC2String;
-        IpPermissions?: EC2IpPermissionList;
-    }
-
-    export type EC2AutoPlacement = string;
-    export interface EC2AvailabilityZone {
-        ZoneName?: EC2String;
-        State?: EC2AvailabilityZoneState;
-        RegionName?: EC2String;
-        Messages?: EC2AvailabilityZoneMessageList;
-    }
-
-    export type EC2AvailabilityZoneList = Array<EC2AvailabilityZone>;
-    export interface EC2AvailabilityZoneMessage {
-        Message?: EC2String;
-    }
-
-    export type EC2AvailabilityZoneMessageList = Array<EC2AvailabilityZoneMessage>;
-    export type EC2AvailabilityZoneState = string;
-    export interface EC2AvailableCapacity {
-        AvailableInstanceCapacity?: EC2AvailableInstanceCapacityList;
-        AvailableVCpus?: EC2Integer;
-    }
-
-    export type EC2AvailableInstanceCapacityList = Array<EC2InstanceCapacity>;
-    export type EC2BatchState = string;
-    export type EC2Blob = any; // not really - it was 'blob' instead - must fix this one
-    export interface EC2BlobAttributeValue {
-        Value?: EC2Blob;
-    }
-
-    export interface EC2BlockDeviceMapping {
-        VirtualName?: EC2String;
-        DeviceName?: EC2String;
-        Ebs?: EC2EbsBlockDevice;
-        NoDevice?: EC2String;
-    }
-
-    export type EC2BlockDeviceMappingList = Array<EC2BlockDeviceMapping>;
-    export type EC2BlockDeviceMappingRequestList = Array<EC2BlockDeviceMapping>;
-    export type EC2Boolean = boolean;
-    export type EC2BundleIdStringList = Array<EC2String>;
-    export interface EC2BundleInstanceRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        Storage: EC2Storage;
-    }
-
-    export interface EC2BundleInstanceResult {
-        BundleTask?: EC2BundleTask;
-    }
-
-    export interface EC2BundleTask {
-        InstanceId?: EC2String;
-        BundleId?: EC2String;
-        State?: EC2BundleTaskState;
-        StartTime?: EC2DateTime;
-        UpdateTime?: EC2DateTime;
-        Storage?: EC2Storage;
-        Progress?: EC2String;
-        BundleTaskError?: EC2BundleTaskError;
-    }
-
-    export interface EC2BundleTaskError {
-        Code?: EC2String;
-        Message?: EC2String;
-    }
-
-    export type EC2BundleTaskList = Array<EC2BundleTask>;
-    export type EC2BundleTaskState = string;
-    export type EC2CancelBatchErrorCode = string;
-    export interface EC2CancelBundleTaskRequest {
-        DryRun?: EC2Boolean;
-        BundleId: EC2String;
-    }
-
-    export interface EC2CancelBundleTaskResult {
-        BundleTask?: EC2BundleTask;
-    }
-
-    export interface EC2CancelConversionRequest {
-        DryRun?: EC2Boolean;
-        ConversionTaskId: EC2String;
-        ReasonMessage?: EC2String;
-    }
-
-    export interface EC2CancelExportTaskRequest {
-        ExportTaskId: EC2String;
-    }
-
-    export interface EC2CancelImportTaskRequest {
-        DryRun?: EC2Boolean;
-        ImportTaskId?: EC2String;
-        CancelReason?: EC2String;
-    }
-
-    export interface EC2CancelImportTaskResult {
-        ImportTaskId?: EC2String;
-        State?: EC2String;
-        PreviousState?: EC2String;
-    }
-
-    export interface EC2CancelReservedInstancesListingRequest {
-        ReservedInstancesListingId: EC2String;
-    }
-
-    export interface EC2CancelReservedInstancesListingResult {
-        ReservedInstancesListings?: EC2ReservedInstancesListingList;
-    }
-
-    export interface EC2CancelSpotFleetRequestsError {
-        Code: EC2CancelBatchErrorCode;
-        Message: EC2String;
-    }
-
-    export interface EC2CancelSpotFleetRequestsErrorItem {
-        SpotFleetRequestId: EC2String;
-        Error: EC2CancelSpotFleetRequestsError;
-    }
-
-    export type EC2CancelSpotFleetRequestsErrorSet = Array<EC2CancelSpotFleetRequestsErrorItem>;
-    export interface EC2CancelSpotFleetRequestsRequest {
-        DryRun?: EC2Boolean;
-        SpotFleetRequestIds: EC2ValueStringList;
-        TerminateInstances: EC2Boolean;
-    }
-
-    export interface EC2CancelSpotFleetRequestsResponse {
-        UnsuccessfulFleetRequests?: EC2CancelSpotFleetRequestsErrorSet;
-        SuccessfulFleetRequests?: EC2CancelSpotFleetRequestsSuccessSet;
-    }
-
-    export interface EC2CancelSpotFleetRequestsSuccessItem {
-        SpotFleetRequestId: EC2String;
-        CurrentSpotFleetRequestState: EC2BatchState;
-        PreviousSpotFleetRequestState: EC2BatchState;
-    }
-
-    export type EC2CancelSpotFleetRequestsSuccessSet = Array<EC2CancelSpotFleetRequestsSuccessItem>;
-    export type EC2CancelSpotInstanceRequestState = string;
-    export interface EC2CancelSpotInstanceRequestsRequest {
-        DryRun?: EC2Boolean;
-        SpotInstanceRequestIds: EC2SpotInstanceRequestIdList;
-    }
-
-    export interface EC2CancelSpotInstanceRequestsResult {
-        CancelledSpotInstanceRequests?: EC2CancelledSpotInstanceRequestList;
-    }
-
-    export interface EC2CancelledSpotInstanceRequest {
-        SpotInstanceRequestId?: EC2String;
-        State?: EC2CancelSpotInstanceRequestState;
-    }
-
-    export type EC2CancelledSpotInstanceRequestList = Array<EC2CancelledSpotInstanceRequest>;
-    export interface EC2ClassicLinkInstance {
-        InstanceId?: EC2String;
-        VpcId?: EC2String;
-        Groups?: EC2GroupIdentifierList;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2ClassicLinkInstanceList = Array<EC2ClassicLinkInstance>;
-    export interface EC2ClientData {
-        UploadStart?: EC2DateTime;
-        UploadEnd?: EC2DateTime;
-        UploadSize?: EC2Double;
-        Comment?: EC2String;
-    }
-
-    export interface EC2ConfirmProductInstanceRequest {
-        DryRun?: EC2Boolean;
-        ProductCode: EC2String;
-        InstanceId: EC2String;
-    }
-
-    export interface EC2ConfirmProductInstanceResult {
-        OwnerId?: EC2String;
-        Return?: EC2Boolean;
-    }
-
-    export type EC2ContainerFormat = string;
-    export type EC2ConversionIdStringList = Array<EC2String>;
-    export interface EC2ConversionTask {
-        ConversionTaskId: EC2String;
-        ExpirationTime?: EC2String;
-        ImportInstance?: EC2ImportInstanceTaskDetails;
-        ImportVolume?: EC2ImportVolumeTaskDetails;
-        State: EC2ConversionTaskState;
-        StatusMessage?: EC2String;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2ConversionTaskState = string;
-    export interface EC2CopyImageRequest {
-        DryRun?: EC2Boolean;
-        SourceRegion: EC2String;
-        SourceImageId: EC2String;
-        Name: EC2String;
-        Description?: EC2String;
-        ClientToken?: EC2String;
-    }
-
-    export interface EC2CopyImageResult {
-        ImageId?: EC2String;
-    }
-
-    export interface EC2CopySnapshotRequest {
-        DryRun?: EC2Boolean;
-        SourceRegion: EC2String;
-        SourceSnapshotId: EC2String;
-        Description?: EC2String;
-        DestinationRegion?: EC2String;
-        PresignedUrl?: EC2String;
-        Encrypted?: EC2Boolean;
-        KmsKeyId?: EC2String;
-    }
-
-    export interface EC2CopySnapshotResult {
-        SnapshotId?: EC2String;
-    }
-
-    export interface EC2CreateCustomerGatewayRequest {
-        DryRun?: EC2Boolean;
-        Type: EC2GatewayType;
-        PublicIp: EC2String;
-        BgpAsn: EC2Integer;
-    }
-
-    export interface EC2CreateCustomerGatewayResult {
-        CustomerGateway?: EC2CustomerGateway;
-    }
-
-    export interface EC2CreateDhcpOptionsRequest {
-        DryRun?: EC2Boolean;
-        DhcpConfigurations: EC2NewDhcpConfigurationList;
-    }
-
-    export interface EC2CreateDhcpOptionsResult {
-        DhcpOptions?: EC2DhcpOptions;
-    }
-
-    export interface EC2CreateFlowLogsRequest {
-        ResourceIds: EC2ValueStringList;
-        ResourceType: EC2FlowLogsResourceType;
-        TrafficType: EC2TrafficType;
-        LogGroupName: EC2String;
-        DeliverLogsPermissionArn: EC2String;
-        ClientToken?: EC2String;
-    }
-
-    export interface EC2CreateFlowLogsResult {
-        FlowLogIds?: EC2ValueStringList;
-        ClientToken?: EC2String;
-        Unsuccessful?: EC2UnsuccessfulItemSet;
-    }
-
-    export interface EC2CreateImageRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        Name: EC2String;
-        Description?: EC2String;
-        NoReboot?: EC2Boolean;
-        BlockDeviceMappings?: EC2BlockDeviceMappingRequestList;
-    }
-
-    export interface EC2CreateImageResult {
-        ImageId?: EC2String;
-    }
-
-    export interface EC2CreateInstanceExportTaskRequest {
-        Description?: EC2String;
-        InstanceId: EC2String;
-        TargetEnvironment?: EC2ExportEnvironment;
-        ExportToS3Task?: EC2ExportToS3TaskSpecification;
-    }
-
-    export interface EC2CreateInstanceExportTaskResult {
-        ExportTask?: EC2ExportTask;
-    }
-
-    export interface EC2CreateInternetGatewayRequest {
-        DryRun?: EC2Boolean;
-    }
-
-    export interface EC2CreateInternetGatewayResult {
-        InternetGateway?: EC2InternetGateway;
-    }
-
-    export interface EC2CreateKeyPairRequest {
-        DryRun?: EC2Boolean;
-        KeyName: EC2String;
-    }
-
-    export interface EC2CreateNetworkAclEntryRequest {
-        DryRun?: EC2Boolean;
-        NetworkAclId: EC2String;
-        RuleNumber: EC2Integer;
-        Protocol: EC2String;
-        RuleAction: EC2RuleAction;
-        Egress: EC2Boolean;
-        CidrBlock: EC2String;
-        IcmpTypeCode?: EC2IcmpTypeCode;
-        PortRange?: EC2PortRange;
-    }
-
-    export interface EC2CreateNetworkAclRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-    }
-
-    export interface EC2CreateNetworkAclResult {
-        NetworkAcl?: EC2NetworkAcl;
-    }
-
-    export interface EC2CreateNetworkInterfaceRequest {
-        SubnetId: EC2String;
-        Description?: EC2String;
-        PrivateIpAddress?: EC2String;
-        Groups?: EC2SecurityGroupIdStringList;
-        PrivateIpAddresses?: EC2PrivateIpAddressSpecificationList;
-        SecondaryPrivateIpAddressCount?: EC2Integer;
-        DryRun?: EC2Boolean;
-    }
-
-    export interface EC2CreateNetworkInterfaceResult {
-        NetworkInterface?: EC2NetworkInterface;
-    }
-
-    export interface EC2CreatePlacementGroupRequest {
-        DryRun?: EC2Boolean;
-        GroupName: EC2String;
-        Strategy: EC2PlacementStrategy;
-    }
-
-    export interface EC2CreateReservedInstancesListingRequest {
-        ReservedInstancesId: EC2String;
-        InstanceCount: EC2Integer;
-        PriceSchedules: EC2PriceScheduleSpecificationList;
-        ClientToken: EC2String;
-    }
-
-    export interface EC2CreateReservedInstancesListingResult {
-        ReservedInstancesListings?: EC2ReservedInstancesListingList;
-    }
-
-    export interface EC2CreateRouteRequest {
-        DryRun?: EC2Boolean;
-        RouteTableId: EC2String;
-        DestinationCidrBlock: EC2String;
-        GatewayId?: EC2String;
-        InstanceId?: EC2String;
-        NetworkInterfaceId?: EC2String;
-        VpcPeeringConnectionId?: EC2String;
-    }
-
-    export interface EC2CreateRouteResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2CreateRouteTableRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-    }
-
-    export interface EC2CreateRouteTableResult {
-        RouteTable?: EC2RouteTable;
-    }
-
-    export interface EC2CreateSecurityGroupRequest {
-        DryRun?: EC2Boolean;
-        GroupName: EC2String;
-        Description: EC2String;
-        VpcId?: EC2String;
-    }
-
-    export interface EC2CreateSecurityGroupResult {
-        GroupId?: EC2String;
-    }
-
-    export interface EC2CreateSnapshotRequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-        Description?: EC2String;
-    }
-
-    export interface EC2CreateSpotDatafeedSubscriptionRequest {
-        DryRun?: EC2Boolean;
-        Bucket: EC2String;
-        Prefix?: EC2String;
-    }
-
-    export interface EC2CreateSpotDatafeedSubscriptionResult {
-        SpotDatafeedSubscription?: EC2SpotDatafeedSubscription;
-    }
-
-    export interface EC2CreateSubnetRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-        CidrBlock: EC2String;
-        AvailabilityZone?: EC2String;
-    }
-
-    export interface EC2CreateSubnetResult {
-        Subnet?: EC2Subnet;
-    }
-
-    export interface EC2CreateTagsRequest {
-        DryRun?: EC2Boolean;
-        Resources: EC2ResourceIdList;
-        Tags: EC2TagList;
-    }
-
-    export interface EC2CreateVolumePermission {
-        UserId?: EC2String;
-        Group?: EC2PermissionGroup;
-    }
-
-    export type EC2CreateVolumePermissionList = Array<EC2CreateVolumePermission>;
-    export interface EC2CreateVolumePermissionModifications {
-        Add?: EC2CreateVolumePermissionList;
-        Remove?: EC2CreateVolumePermissionList;
-    }
-
-    export interface EC2CreateVolumeRequest {
-        DryRun?: EC2Boolean;
-        Size?: EC2Integer;
-        SnapshotId?: EC2String;
-        AvailabilityZone: EC2String;
-        VolumeType?: EC2VolumeType;
-        Iops?: EC2Integer;
-        Encrypted?: EC2Boolean;
-        KmsKeyId?: EC2String;
-    }
-
-    export interface EC2CreateVpcEndpointRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-        ServiceName: EC2String;
-        PolicyDocument?: EC2String;
-        RouteTableIds?: EC2ValueStringList;
-        ClientToken?: EC2String;
-    }
-
-    export interface EC2CreateVpcEndpointResult {
-        VpcEndpoint?: EC2VpcEndpoint;
-        ClientToken?: EC2String;
-    }
-
-    export interface EC2CreateVpcPeeringConnectionRequest {
-        DryRun?: EC2Boolean;
-        VpcId?: EC2String;
-        PeerVpcId?: EC2String;
-        PeerOwnerId?: EC2String;
-    }
-
-    export interface EC2CreateVpcPeeringConnectionResult {
-        VpcPeeringConnection?: EC2VpcPeeringConnection;
-    }
-
-    export interface EC2CreateVpcRequest {
-        DryRun?: EC2Boolean;
-        CidrBlock: EC2String;
-        InstanceTenancy?: EC2Tenancy;
-    }
-
-    export interface EC2CreateVpcResult {
-        Vpc?: EC2Vpc;
-    }
-
-    export interface EC2CreateVpnConnectionRequest {
-        DryRun?: EC2Boolean;
-        Type: EC2String;
-        CustomerGatewayId: EC2String;
-        VpnGatewayId: EC2String;
-        Options?: EC2VpnConnectionOptionsSpecification;
-    }
-
-    export interface EC2CreateVpnConnectionResult {
-        VpnConnection?: EC2VpnConnection;
-    }
-
-    export interface EC2CreateVpnConnectionRouteRequest {
-        VpnConnectionId: EC2String;
-        DestinationCidrBlock: EC2String;
-    }
-
-    export interface EC2CreateVpnGatewayRequest {
-        DryRun?: EC2Boolean;
-        Type: EC2GatewayType;
-        AvailabilityZone?: EC2String;
-    }
-
-    export interface EC2CreateVpnGatewayResult {
-        VpnGateway?: EC2VpnGateway;
-    }
-
-    export type EC2CurrencyCodeValues = string;
-    export interface EC2CustomerGateway {
-        CustomerGatewayId?: EC2String;
-        State?: EC2String;
-        Type?: EC2String;
-        IpAddress?: EC2String;
-        BgpAsn?: EC2String;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2CustomerGatewayIdStringList = Array<EC2String>;
-    export type EC2CustomerGatewayList = Array<EC2CustomerGateway>;
-    export type EC2DatafeedSubscriptionState = string;
-    export type EC2DateTime = number;
-    export interface EC2DeleteCustomerGatewayRequest {
-        DryRun?: EC2Boolean;
-        CustomerGatewayId: EC2String;
-    }
-
-    export interface EC2DeleteDhcpOptionsRequest {
-        DryRun?: EC2Boolean;
-        DhcpOptionsId: EC2String;
-    }
-
-    export interface EC2DeleteFlowLogsRequest {
-        FlowLogIds: EC2ValueStringList;
-    }
-
-    export interface EC2DeleteFlowLogsResult {
-        Unsuccessful?: EC2UnsuccessfulItemSet;
-    }
-
-    export interface EC2DeleteInternetGatewayRequest {
-        DryRun?: EC2Boolean;
-        InternetGatewayId: EC2String;
-    }
-
-    export interface EC2DeleteKeyPairRequest {
-        DryRun?: EC2Boolean;
-        KeyName: EC2String;
-    }
-
-    export interface EC2DeleteNetworkAclEntryRequest {
-        DryRun?: EC2Boolean;
-        NetworkAclId: EC2String;
-        RuleNumber: EC2Integer;
-        Egress: EC2Boolean;
-    }
-
-    export interface EC2DeleteNetworkAclRequest {
-        DryRun?: EC2Boolean;
-        NetworkAclId: EC2String;
-    }
-
-    export interface EC2DeleteNetworkInterfaceRequest {
-        DryRun?: EC2Boolean;
-        NetworkInterfaceId: EC2String;
-    }
-
-    export interface EC2DeletePlacementGroupRequest {
-        DryRun?: EC2Boolean;
-        GroupName: EC2String;
-    }
-
-    export interface EC2DeleteRouteRequest {
-        DryRun?: EC2Boolean;
-        RouteTableId: EC2String;
-        DestinationCidrBlock: EC2String;
-    }
-
-    export interface EC2DeleteRouteTableRequest {
-        DryRun?: EC2Boolean;
-        RouteTableId: EC2String;
-    }
-
-    export interface EC2DeleteSecurityGroupRequest {
-        DryRun?: EC2Boolean;
-        GroupName?: EC2String;
-        GroupId?: EC2String;
-    }
-
-    export interface EC2DeleteSnapshotRequest {
-        DryRun?: EC2Boolean;
-        SnapshotId: EC2String;
-    }
-
-    export interface EC2DeleteSpotDatafeedSubscriptionRequest {
-        DryRun?: EC2Boolean;
-    }
-
-    export interface EC2DeleteSubnetRequest {
-        DryRun?: EC2Boolean;
-        SubnetId: EC2String;
-    }
-
-    export interface EC2DeleteTagsRequest {
-        DryRun?: EC2Boolean;
-        Resources: EC2ResourceIdList;
-        Tags?: EC2TagList;
-    }
-
-    export interface EC2DeleteVolumeRequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-    }
-
-    export interface EC2DeleteVpcEndpointsRequest {
-        DryRun?: EC2Boolean;
-        VpcEndpointIds: EC2ValueStringList;
-    }
-
-    export interface EC2DeleteVpcEndpointsResult {
-        Unsuccessful?: EC2UnsuccessfulItemSet;
-    }
-
-    export interface EC2DeleteVpcPeeringConnectionRequest {
-        DryRun?: EC2Boolean;
-        VpcPeeringConnectionId: EC2String;
-    }
-
-    export interface EC2DeleteVpcPeeringConnectionResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2DeleteVpcRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-    }
-
-    export interface EC2DeleteVpnConnectionRequest {
-        DryRun?: EC2Boolean;
-        VpnConnectionId: EC2String;
-    }
-
-    export interface EC2DeleteVpnConnectionRouteRequest {
-        VpnConnectionId: EC2String;
-        DestinationCidrBlock: EC2String;
-    }
-
-    export interface EC2DeleteVpnGatewayRequest {
-        DryRun?: EC2Boolean;
-        VpnGatewayId: EC2String;
-    }
-
-    export interface EC2DeregisterImageRequest {
-        DryRun?: EC2Boolean;
-        ImageId: EC2String;
-    }
-
-    export interface EC2DescribeAccountAttributesRequest {
-        DryRun?: EC2Boolean;
-        AttributeNames?: EC2AccountAttributeNameStringList;
-    }
-
-    export interface EC2DescribeAccountAttributesResult {
-        AccountAttributes?: EC2AccountAttributeList;
-    }
-
-    export interface EC2DescribeAddressesRequest {
-        DryRun?: EC2Boolean;
-        PublicIps?: EC2PublicIpStringList;
-        Filters?: EC2FilterList;
-        AllocationIds?: EC2AllocationIdList;
-    }
-
-    export interface EC2DescribeAddressesResult {
-        Addresses?: EC2AddressList;
-    }
-
-    export interface EC2DescribeAvailabilityZonesRequest {
-        DryRun?: EC2Boolean;
-        ZoneNames?: EC2ZoneNameStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeAvailabilityZonesResult {
-        AvailabilityZones?: EC2AvailabilityZoneList;
-    }
-
-    export interface EC2DescribeBundleTasksRequest {
-        DryRun?: EC2Boolean;
-        BundleIds?: EC2BundleIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeBundleTasksResult {
-        BundleTasks?: EC2BundleTaskList;
-    }
-
-    export interface EC2DescribeClassicLinkInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds?: EC2InstanceIdStringList;
-        Filters?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeClassicLinkInstancesResult {
-        Instances?: EC2ClassicLinkInstanceList;
-        NextToken?: EC2String;
-    }
-
-    export type EC2DescribeConversionTaskList = Array<EC2ConversionTask>;
-    export interface EC2DescribeConversionTasksRequest {
-        DryRun?: EC2Boolean;
-        Filters?: EC2FilterList;
-        ConversionTaskIds?: EC2ConversionIdStringList;
-    }
-
-    export interface EC2DescribeConversionTasksResult {
-        ConversionTasks?: EC2DescribeConversionTaskList;
-    }
-
-    export interface EC2DescribeCustomerGatewaysRequest {
-        DryRun?: EC2Boolean;
-        CustomerGatewayIds?: EC2CustomerGatewayIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeCustomerGatewaysResult {
-        CustomerGateways?: EC2CustomerGatewayList;
-    }
-
-    export interface EC2DescribeDhcpOptionsRequest {
-        DryRun?: EC2Boolean;
-        DhcpOptionsIds?: EC2DhcpOptionsIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeDhcpOptionsResult {
-        DhcpOptions?: EC2DhcpOptionsList;
-    }
-
-    export interface EC2DescribeExportTasksRequest {
-        ExportTaskIds?: EC2ExportTaskIdStringList;
-    }
-
-    export interface EC2DescribeExportTasksResult {
-        ExportTasks?: EC2ExportTaskList;
-    }
-
-    export interface EC2DescribeFlowLogsRequest {
-        FlowLogIds?: EC2ValueStringList;
-        Filter?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeFlowLogsResult {
-        FlowLogs?: EC2FlowLogSet;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeHostsRequest {
-        HostIds?: EC2RequestHostIdList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-        Filter?: EC2FilterList;
-    }
-
-    export interface EC2DescribeHostsResult {
-        Hosts?: EC2HostList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeIdFormatRequest {
-        Resource?: EC2String;
-    }
-
-    export interface EC2DescribeIdFormatResult {
-        Statuses?: EC2IdFormatList;
-    }
-
-    export interface EC2DescribeImageAttributeRequest {
-        DryRun?: EC2Boolean;
-        ImageId: EC2String;
-        Attribute: EC2ImageAttributeName;
-    }
-
-    export interface EC2DescribeImagesRequest {
-        DryRun?: EC2Boolean;
-        ImageIds?: EC2ImageIdStringList;
-        Owners?: EC2OwnerStringList;
-        ExecutableUsers?: EC2ExecutableByStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeImagesResult {
-        Images?: EC2ImageList;
-    }
-
-    export interface EC2DescribeImportImageTasksRequest {
-        DryRun?: EC2Boolean;
-        ImportTaskIds?: EC2ImportTaskIdList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeImportImageTasksResult {
-        ImportImageTasks?: EC2ImportImageTaskList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeImportSnapshotTasksRequest {
-        DryRun?: EC2Boolean;
-        ImportTaskIds?: EC2ImportTaskIdList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeImportSnapshotTasksResult {
-        ImportSnapshotTasks?: EC2ImportSnapshotTaskList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeInstanceAttributeRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        Attribute: EC2InstanceAttributeName;
-    }
-
-    export interface EC2DescribeInstanceStatusRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds?: EC2InstanceIdStringList;
-        Filters?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-        IncludeAllInstances?: EC2Boolean;
-    }
-
-    export interface EC2DescribeInstanceStatusResult {
-        InstanceStatuses?: EC2InstanceStatusList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds?: EC2InstanceIdStringList;
-        Filters?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeInstancesResult {
-        Reservations?: EC2ReservationList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeInternetGatewaysRequest {
-        DryRun?: EC2Boolean;
-        InternetGatewayIds?: EC2ValueStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeInternetGatewaysResult {
-        InternetGateways?: EC2InternetGatewayList;
-    }
-
-    export interface EC2DescribeKeyPairsRequest {
-        DryRun?: EC2Boolean;
-        KeyNames?: EC2KeyNameStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeKeyPairsResult {
-        KeyPairs?: EC2KeyPairList;
-    }
-
-    export interface EC2DescribeMovingAddressesRequest {
-        DryRun?: EC2Boolean;
-        PublicIps?: EC2ValueStringList;
-        NextToken?: EC2String;
-        Filters?: EC2FilterList;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeMovingAddressesResult {
-        MovingAddressStatuses?: EC2MovingAddressStatusSet;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeNetworkAclsRequest {
-        DryRun?: EC2Boolean;
-        NetworkAclIds?: EC2ValueStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeNetworkAclsResult {
-        NetworkAcls?: EC2NetworkAclList;
-    }
-
-    export interface EC2DescribeNetworkInterfaceAttributeRequest {
-        DryRun?: EC2Boolean;
-        NetworkInterfaceId: EC2String;
-        Attribute?: EC2NetworkInterfaceAttribute;
-    }
-
-    export interface EC2DescribeNetworkInterfaceAttributeResult {
-        NetworkInterfaceId?: EC2String;
-        Description?: EC2AttributeValue;
-        SourceDestCheck?: EC2AttributeBooleanValue;
-        Groups?: EC2GroupIdentifierList;
-        Attachment?: EC2NetworkInterfaceAttachment;
-    }
-
-    export interface EC2DescribeNetworkInterfacesRequest {
-        DryRun?: EC2Boolean;
-        NetworkInterfaceIds?: EC2NetworkInterfaceIdList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeNetworkInterfacesResult {
-        NetworkInterfaces?: EC2NetworkInterfaceList;
-    }
-
-    export interface EC2DescribePlacementGroupsRequest {
-        DryRun?: EC2Boolean;
-        GroupNames?: EC2PlacementGroupStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribePlacementGroupsResult {
-        PlacementGroups?: EC2PlacementGroupList;
-    }
-
-    export interface EC2DescribePrefixListsRequest {
-        DryRun?: EC2Boolean;
-        PrefixListIds?: EC2ValueStringList;
-        Filters?: EC2FilterList;
-        MaxResults?: EC2Integer;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribePrefixListsResult {
-        PrefixLists?: EC2PrefixListSet;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeRegionsRequest {
-        DryRun?: EC2Boolean;
-        RegionNames?: EC2RegionNameStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeRegionsResult {
-        Regions?: EC2RegionList;
-    }
-
-    export interface EC2DescribeReservedInstancesListingsRequest {
-        ReservedInstancesId?: EC2String;
-        ReservedInstancesListingId?: EC2String;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeReservedInstancesListingsResult {
-        ReservedInstancesListings?: EC2ReservedInstancesListingList;
-    }
-
-    export interface EC2DescribeReservedInstancesModificationsRequest {
-        ReservedInstancesModificationIds?: EC2ReservedInstancesModificationIdStringList;
-        NextToken?: EC2String;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeReservedInstancesModificationsResult {
-        ReservedInstancesModifications?: EC2ReservedInstancesModificationList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeReservedInstancesOfferingsRequest {
-        DryRun?: EC2Boolean;
-        ReservedInstancesOfferingIds?: EC2ReservedInstancesOfferingIdStringList;
-        InstanceType?: EC2InstanceType;
-        AvailabilityZone?: EC2String;
-        ProductDescription?: EC2RIProductDescription;
-        Filters?: EC2FilterList;
-        InstanceTenancy?: EC2Tenancy;
-        OfferingType?: EC2OfferingTypeValues;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-        IncludeMarketplace?: EC2Boolean;
-        MinDuration?: EC2Long;
-        MaxDuration?: EC2Long;
-        MaxInstanceCount?: EC2Integer;
-    }
-
-    export interface EC2DescribeReservedInstancesOfferingsResult {
-        ReservedInstancesOfferings?: EC2ReservedInstancesOfferingList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeReservedInstancesRequest {
-        DryRun?: EC2Boolean;
-        ReservedInstancesIds?: EC2ReservedInstancesIdStringList;
-        Filters?: EC2FilterList;
-        OfferingType?: EC2OfferingTypeValues;
-    }
-
-    export interface EC2DescribeReservedInstancesResult {
-        ReservedInstances?: EC2ReservedInstancesList;
-    }
-
-    export interface EC2DescribeRouteTablesRequest {
-        DryRun?: EC2Boolean;
-        RouteTableIds?: EC2ValueStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeRouteTablesResult {
-        RouteTables?: EC2RouteTableList;
-    }
-
-    export interface EC2DescribeSecurityGroupsRequest {
-        DryRun?: EC2Boolean;
-        GroupNames?: EC2GroupNameStringList;
-        GroupIds?: EC2GroupIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeSecurityGroupsResult {
-        SecurityGroups?: EC2SecurityGroupList;
-    }
-
-    export interface EC2DescribeSnapshotAttributeRequest {
-        DryRun?: EC2Boolean;
-        SnapshotId: EC2String;
-        Attribute: EC2SnapshotAttributeName;
-    }
-
-    export interface EC2DescribeSnapshotAttributeResult {
-        SnapshotId?: EC2String;
-        CreateVolumePermissions?: EC2CreateVolumePermissionList;
-        ProductCodes?: EC2ProductCodeList;
-    }
-
-    export interface EC2DescribeSnapshotsRequest {
-        DryRun?: EC2Boolean;
-        SnapshotIds?: EC2SnapshotIdStringList;
-        OwnerIds?: EC2OwnerStringList;
-        RestorableByUserIds?: EC2RestorableByStringList;
-        Filters?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeSnapshotsResult {
-        Snapshots?: EC2SnapshotList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeSpotDatafeedSubscriptionRequest {
-        DryRun?: EC2Boolean;
-    }
-
-    export interface EC2DescribeSpotDatafeedSubscriptionResult {
-        SpotDatafeedSubscription?: EC2SpotDatafeedSubscription;
-    }
-
-    export interface EC2DescribeSpotFleetInstancesRequest {
-        DryRun?: EC2Boolean;
-        SpotFleetRequestId: EC2String;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeSpotFleetInstancesResponse {
-        SpotFleetRequestId: EC2String;
-        ActiveInstances: EC2ActiveInstanceSet;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeSpotFleetRequestHistoryRequest {
-        DryRun?: EC2Boolean;
-        SpotFleetRequestId: EC2String;
-        EventType?: EC2EventType;
-        StartTime: EC2DateTime;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeSpotFleetRequestHistoryResponse {
-        SpotFleetRequestId: EC2String;
-        StartTime: EC2DateTime;
-        LastEvaluatedTime: EC2DateTime;
-        HistoryRecords: EC2HistoryRecords;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeSpotFleetRequestsRequest {
-        DryRun?: EC2Boolean;
-        SpotFleetRequestIds?: EC2ValueStringList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeSpotFleetRequestsResponse {
-        SpotFleetRequestConfigs: EC2SpotFleetRequestConfigSet;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeSpotInstanceRequestsRequest {
-        DryRun?: EC2Boolean;
-        SpotInstanceRequestIds?: EC2SpotInstanceRequestIdList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeSpotInstanceRequestsResult {
-        SpotInstanceRequests?: EC2SpotInstanceRequestList;
-    }
-
-    export interface EC2DescribeSpotPriceHistoryRequest {
-        DryRun?: EC2Boolean;
-        StartTime?: EC2DateTime;
-        EndTime?: EC2DateTime;
-        InstanceTypes?: EC2InstanceTypeList;
-        ProductDescriptions?: EC2ProductDescriptionList;
-        Filters?: EC2FilterList;
-        AvailabilityZone?: EC2String;
-        MaxResults?: EC2Integer;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeSpotPriceHistoryResult {
-        SpotPriceHistory?: EC2SpotPriceHistoryList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeSubnetsRequest {
-        DryRun?: EC2Boolean;
-        SubnetIds?: EC2SubnetIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeSubnetsResult {
-        Subnets?: EC2SubnetList;
-    }
-
-    export interface EC2DescribeTagsRequest {
-        DryRun?: EC2Boolean;
-        Filters?: EC2FilterList;
-        MaxResults?: EC2Integer;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeTagsResult {
-        Tags?: EC2TagDescriptionList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVolumeAttributeRequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-        Attribute?: EC2VolumeAttributeName;
-    }
-
-    export interface EC2DescribeVolumeAttributeResult {
-        VolumeId?: EC2String;
-        AutoEnableIO?: EC2AttributeBooleanValue;
-        ProductCodes?: EC2ProductCodeList;
-    }
-
-    export interface EC2DescribeVolumeStatusRequest {
-        DryRun?: EC2Boolean;
-        VolumeIds?: EC2VolumeIdStringList;
-        Filters?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeVolumeStatusResult {
-        VolumeStatuses?: EC2VolumeStatusList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVolumesRequest {
-        DryRun?: EC2Boolean;
-        VolumeIds?: EC2VolumeIdStringList;
-        Filters?: EC2FilterList;
-        NextToken?: EC2String;
-        MaxResults?: EC2Integer;
-    }
-
-    export interface EC2DescribeVolumesResult {
-        Volumes?: EC2VolumeList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVpcAttributeRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-        Attribute?: EC2VpcAttributeName;
-    }
-
-    export interface EC2DescribeVpcAttributeResult {
-        VpcId?: EC2String;
-        EnableDnsSupport?: EC2AttributeBooleanValue;
-        EnableDnsHostnames?: EC2AttributeBooleanValue;
-    }
-
-    export interface EC2DescribeVpcClassicLinkRequest {
-        DryRun?: EC2Boolean;
-        VpcIds?: EC2VpcClassicLinkIdList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeVpcClassicLinkResult {
-        Vpcs?: EC2VpcClassicLinkList;
-    }
-
-    export interface EC2DescribeVpcEndpointServicesRequest {
-        DryRun?: EC2Boolean;
-        MaxResults?: EC2Integer;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVpcEndpointServicesResult {
-        ServiceNames?: EC2ValueStringList;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVpcEndpointsRequest {
-        DryRun?: EC2Boolean;
-        VpcEndpointIds?: EC2ValueStringList;
-        Filters?: EC2FilterList;
-        MaxResults?: EC2Integer;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVpcEndpointsResult {
-        VpcEndpoints?: EC2VpcEndpointSet;
-        NextToken?: EC2String;
-    }
-
-    export interface EC2DescribeVpcPeeringConnectionsRequest {
-        DryRun?: EC2Boolean;
-        VpcPeeringConnectionIds?: EC2ValueStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeVpcPeeringConnectionsResult {
-        VpcPeeringConnections?: EC2VpcPeeringConnectionList;
-    }
-
-    export interface EC2DescribeVpcsRequest {
-        DryRun?: EC2Boolean;
-        VpcIds?: EC2VpcIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeVpcsResult {
-        Vpcs?: EC2VpcList;
-    }
-
-    export interface EC2DescribeVpnConnectionsRequest {
-        DryRun?: EC2Boolean;
-        VpnConnectionIds?: EC2VpnConnectionIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeVpnConnectionsResult {
-        VpnConnections?: EC2VpnConnectionList;
-    }
-
-    export interface EC2DescribeVpnGatewaysRequest {
-        DryRun?: EC2Boolean;
-        VpnGatewayIds?: EC2VpnGatewayIdStringList;
-        Filters?: EC2FilterList;
-    }
-
-    export interface EC2DescribeVpnGatewaysResult {
-        VpnGateways?: EC2VpnGatewayList;
-    }
-
-    export interface EC2DetachClassicLinkVpcRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        VpcId: EC2String;
-    }
-
-    export interface EC2DetachClassicLinkVpcResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2DetachInternetGatewayRequest {
-        DryRun?: EC2Boolean;
-        InternetGatewayId: EC2String;
-        VpcId: EC2String;
-    }
-
-    export interface EC2DetachNetworkInterfaceRequest {
-        DryRun?: EC2Boolean;
-        AttachmentId: EC2String;
-        Force?: EC2Boolean;
-    }
-
-    export interface EC2DetachVolumeRequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-        InstanceId?: EC2String;
-        Device?: EC2String;
-        Force?: EC2Boolean;
-    }
-
-    export interface EC2DetachVpnGatewayRequest {
-        DryRun?: EC2Boolean;
-        VpnGatewayId: EC2String;
-        VpcId: EC2String;
-    }
-
-    export type EC2DeviceType = string;
-    export interface EC2DhcpConfiguration {
-        Key?: EC2String;
-        Values?: EC2DhcpConfigurationValueList;
-    }
-
-    export type EC2DhcpConfigurationList = Array<EC2DhcpConfiguration>;
-    export type EC2DhcpConfigurationValueList = Array<EC2AttributeValue>;
-    export interface EC2DhcpOptions {
-        DhcpOptionsId?: EC2String;
-        DhcpConfigurations?: EC2DhcpConfigurationList;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2DhcpOptionsIdStringList = Array<EC2String>;
-    export type EC2DhcpOptionsList = Array<EC2DhcpOptions>;
-    export interface EC2DisableVgwRoutePropagationRequest {
-        RouteTableId: EC2String;
-        GatewayId: EC2String;
-    }
-
-    export interface EC2DisableVpcClassicLinkRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-    }
-
-    export interface EC2DisableVpcClassicLinkResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2DisassociateAddressRequest {
-        DryRun?: EC2Boolean;
-        PublicIp?: EC2String;
-        AssociationId?: EC2String;
-    }
-
-    export interface EC2DisassociateRouteTableRequest {
-        DryRun?: EC2Boolean;
-        AssociationId: EC2String;
-    }
-
-    export interface EC2DiskImage {
-        Image?: EC2DiskImageDetail;
-        Description?: EC2String;
-        Volume?: EC2VolumeDetail;
-    }
-
-    export interface EC2DiskImageDescription {
-        Format: EC2DiskImageFormat;
-        Size: EC2Long;
-        ImportManifestUrl: EC2String;
-        Checksum?: EC2String;
-    }
-
-    export interface EC2DiskImageDetail {
-        Format: EC2DiskImageFormat;
-        Bytes: EC2Long;
-        ImportManifestUrl: EC2String;
-    }
-
-    export type EC2DiskImageFormat = string;
-    export type EC2DiskImageList = Array<EC2DiskImage>;
-    export interface EC2DiskImageVolumeDescription {
-        Size?: EC2Long;
-        Id: EC2String;
-    }
-
-    export type EC2DomainType = string;
-    export type EC2Double = number;
-    export interface EC2EbsBlockDevice {
-        SnapshotId?: EC2String;
-        VolumeSize?: EC2Integer;
-        DeleteOnTermination?: EC2Boolean;
-        VolumeType?: EC2VolumeType;
-        Iops?: EC2Integer;
-        Encrypted?: EC2Boolean;
-    }
-
-    export interface EC2EbsInstanceBlockDevice {
-        VolumeId?: EC2String;
-        Status?: EC2AttachmentStatus;
-        AttachTime?: EC2DateTime;
-        DeleteOnTermination?: EC2Boolean;
-    }
-
-    export interface EC2EbsInstanceBlockDeviceSpecification {
-        VolumeId?: EC2String;
-        DeleteOnTermination?: EC2Boolean;
-    }
-
-    export interface EC2EnableVgwRoutePropagationRequest {
-        RouteTableId: EC2String;
-        GatewayId: EC2String;
-    }
-
-    export interface EC2EnableVolumeIORequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-    }
-
-    export interface EC2EnableVpcClassicLinkRequest {
-        DryRun?: EC2Boolean;
-        VpcId: EC2String;
-    }
-
-    export interface EC2EnableVpcClassicLinkResult {
-        Return?: EC2Boolean;
-    }
-
-    export type EC2EventCode = string;
-    export interface EC2EventInformation {
-        InstanceId?: EC2String;
-        EventSubType?: EC2String;
-        EventDescription?: EC2String;
-    }
-
-    export type EC2EventType = string;
-    export type EC2ExcessCapacityTerminationPolicy = string;
-    export type EC2ExecutableByStringList = Array<EC2String>;
-    export type EC2ExportEnvironment = string;
-    export interface EC2ExportTask {
-        ExportTaskId?: EC2String;
-        Description?: EC2String;
-        State?: EC2ExportTaskState;
-        StatusMessage?: EC2String;
-        InstanceExportDetails?: EC2InstanceExportDetails;
-        ExportToS3Task?: EC2ExportToS3Task;
-    }
-
-    export type EC2ExportTaskIdStringList = Array<EC2String>;
-    export type EC2ExportTaskList = Array<EC2ExportTask>;
-    export type EC2ExportTaskState = string;
-    export interface EC2ExportToS3Task {
-        DiskImageFormat?: EC2DiskImageFormat;
-        ContainerFormat?: EC2ContainerFormat;
-        S3Bucket?: EC2String;
-        S3Key?: EC2String;
-    }
-
-    export interface EC2ExportToS3TaskSpecification {
-        DiskImageFormat?: EC2DiskImageFormat;
-        ContainerFormat?: EC2ContainerFormat;
-        S3Bucket?: EC2String;
-        S3Prefix?: EC2String;
-    }
-
-    export interface EC2Filter {
-        Name?: EC2String;
-        Values?: EC2ValueStringList;
-    }
-
-    export type EC2FilterList = Array<EC2Filter>;
-    export type EC2Float = number;
-    export interface EC2FlowLog {
-        CreationTime?: EC2DateTime;
-        FlowLogId?: EC2String;
-        FlowLogStatus?: EC2String;
-        ResourceId?: EC2String;
-        TrafficType?: EC2TrafficType;
-        LogGroupName?: EC2String;
-        DeliverLogsStatus?: EC2String;
-        DeliverLogsErrorMessage?: EC2String;
-        DeliverLogsPermissionArn?: EC2String;
-    }
-
-    export type EC2FlowLogSet = Array<EC2FlowLog>;
-    export type EC2FlowLogsResourceType = string;
-    export type EC2GatewayType = string;
-    export interface EC2GetConsoleOutputRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-    }
-
-    export interface EC2GetConsoleOutputResult {
-        InstanceId?: EC2String;
-        Timestamp?: EC2DateTime;
-        Output?: EC2String;
-    }
-
-    export interface EC2GetPasswordDataRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-    }
-
-    export interface EC2GetPasswordDataResult {
-        InstanceId?: EC2String;
-        Timestamp?: EC2DateTime;
-        PasswordData?: EC2String;
-    }
-
-    export type EC2GroupIdStringList = Array<EC2String>;
-    export interface EC2GroupIdentifier {
-        GroupName?: EC2String;
-        GroupId?: EC2String;
-    }
-
-    export type EC2GroupIdentifierList = Array<EC2GroupIdentifier>;
-    export type EC2GroupNameStringList = Array<EC2String>;
-    export interface EC2HistoryRecord {
-        Timestamp: EC2DateTime;
-        EventType: EC2EventType;
-        EventInformation: EC2EventInformation;
-    }
-
-    export type EC2HistoryRecords = Array<EC2HistoryRecord>;
-    export interface EC2Host {
-        HostId?: EC2String;
-        AutoPlacement?: EC2AutoPlacement;
-        HostReservationId?: EC2String;
-        ClientToken?: EC2String;
-        HostProperties?: EC2HostProperties;
-        State?: EC2AllocationState;
-        AvailabilityZone?: EC2String;
-        Instances?: EC2HostInstanceList;
-        AvailableCapacity?: EC2AvailableCapacity;
-    }
-
-    export interface EC2HostInstance {
-        InstanceId?: EC2String;
-        InstanceType?: EC2String;
-    }
-
-    export type EC2HostInstanceList = Array<EC2HostInstance>;
-    export type EC2HostList = Array<EC2Host>;
-    export interface EC2HostProperties {
-        Sockets?: EC2Integer;
-        Cores?: EC2Integer;
-        TotalVCpus?: EC2Integer;
-        InstanceType?: EC2String;
-    }
-
-    export type EC2HostTenancy = string;
-    export type EC2HypervisorType = string;
-    export interface EC2IamInstanceProfile {
-        Arn?: EC2String;
-        Id?: EC2String;
-    }
-
-    export interface EC2IamInstanceProfileSpecification {
-        Arn?: EC2String;
-        Name?: EC2String;
-    }
-
-    export interface EC2IcmpTypeCode {
-        Type?: EC2Integer;
-        Code?: EC2Integer;
-    }
-
-    export interface EC2IdFormat {
-        Resource?: EC2String;
-        UseLongIds?: EC2Boolean;
-        Deadline?: EC2DateTime;
-    }
-
-    export type EC2IdFormatList = Array<EC2IdFormat>;
-    export interface EC2Image {
-        ImageId?: EC2String;
-        ImageLocation?: EC2String;
-        State?: EC2ImageState;
-        OwnerId?: EC2String;
-        CreationDate?: EC2String;
-        Public?: EC2Boolean;
-        ProductCodes?: EC2ProductCodeList;
-        Architecture?: EC2ArchitectureValues;
-        ImageType?: EC2ImageTypeValues;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        Platform?: EC2PlatformValues;
-        SriovNetSupport?: EC2String;
-        StateReason?: EC2StateReason;
-        ImageOwnerAlias?: EC2String;
-        Name?: EC2String;
-        Description?: EC2String;
-        RootDeviceType?: EC2DeviceType;
-        RootDeviceName?: EC2String;
-        BlockDeviceMappings?: EC2BlockDeviceMappingList;
-        VirtualizationType?: EC2VirtualizationType;
-        Tags?: EC2TagList;
-        Hypervisor?: EC2HypervisorType;
-    }
-
-    export interface EC2ImageAttribute {
-        ImageId?: EC2String;
-        LaunchPermissions?: EC2LaunchPermissionList;
-        ProductCodes?: EC2ProductCodeList;
-        KernelId?: EC2AttributeValue;
-        RamdiskId?: EC2AttributeValue;
-        Description?: EC2AttributeValue;
-        SriovNetSupport?: EC2AttributeValue;
-        BlockDeviceMappings?: EC2BlockDeviceMappingList;
-    }
-
-    export type EC2ImageAttributeName = string;
-    export interface EC2ImageDiskContainer {
-        Description?: EC2String;
-        Format?: EC2String;
-        Url?: EC2String;
-        UserBucket?: EC2UserBucket;
-        DeviceName?: EC2String;
-        SnapshotId?: EC2String;
-    }
-
-    export type EC2ImageDiskContainerList = Array<EC2ImageDiskContainer>;
-    export type EC2ImageIdStringList = Array<EC2String>;
-    export type EC2ImageList = Array<EC2Image>;
-    export type EC2ImageState = string;
-    export type EC2ImageTypeValues = string;
-    export interface EC2ImportImageRequest {
-        DryRun?: EC2Boolean;
-        Description?: EC2String;
-        DiskContainers?: EC2ImageDiskContainerList;
-        LicenseType?: EC2String;
-        Hypervisor?: EC2String;
-        Architecture?: EC2String;
-        Platform?: EC2String;
-        ClientData?: EC2ClientData;
-        ClientToken?: EC2String;
-        RoleName?: EC2String;
-    }
-
-    export interface EC2ImportImageResult {
-        ImportTaskId?: EC2String;
-        Architecture?: EC2String;
-        LicenseType?: EC2String;
-        Platform?: EC2String;
-        Hypervisor?: EC2String;
-        Description?: EC2String;
-        SnapshotDetails?: EC2SnapshotDetailList;
-        ImageId?: EC2String;
-        Progress?: EC2String;
-        StatusMessage?: EC2String;
-        Status?: EC2String;
-    }
-
-    export interface EC2ImportImageTask {
-        ImportTaskId?: EC2String;
-        Architecture?: EC2String;
-        LicenseType?: EC2String;
-        Platform?: EC2String;
-        Hypervisor?: EC2String;
-        Description?: EC2String;
-        SnapshotDetails?: EC2SnapshotDetailList;
-        ImageId?: EC2String;
-        Progress?: EC2String;
-        StatusMessage?: EC2String;
-        Status?: EC2String;
-    }
-
-    export type EC2ImportImageTaskList = Array<EC2ImportImageTask>;
-    export interface EC2ImportInstanceLaunchSpecification {
-        Architecture?: EC2ArchitectureValues;
-        GroupNames?: EC2SecurityGroupStringList;
-        GroupIds?: EC2SecurityGroupIdStringList;
-        AdditionalInfo?: EC2String;
-        UserData?: EC2UserData;
-        InstanceType?: EC2InstanceType;
-        Placement?: EC2Placement;
-        Monitoring?: EC2Boolean;
-        SubnetId?: EC2String;
-        InstanceInitiatedShutdownBehavior?: EC2ShutdownBehavior;
-        PrivateIpAddress?: EC2String;
-    }
-
-    export interface EC2ImportInstanceRequest {
-        DryRun?: EC2Boolean;
-        Description?: EC2String;
-        LaunchSpecification?: EC2ImportInstanceLaunchSpecification;
-        DiskImages?: EC2DiskImageList;
-        Platform: EC2PlatformValues;
-    }
-
-    export interface EC2ImportInstanceResult {
-        ConversionTask?: EC2ConversionTask;
-    }
-
-    export interface EC2ImportInstanceTaskDetails {
-        Volumes: EC2ImportInstanceVolumeDetailSet;
-        InstanceId?: EC2String;
-        Platform?: EC2PlatformValues;
-        Description?: EC2String;
-    }
-
-    export interface EC2ImportInstanceVolumeDetailItem {
-        BytesConverted: EC2Long;
-        AvailabilityZone: EC2String;
-        Image: EC2DiskImageDescription;
-        Volume: EC2DiskImageVolumeDescription;
-        Status: EC2String;
-        StatusMessage?: EC2String;
-        Description?: EC2String;
-    }
-
-    export type EC2ImportInstanceVolumeDetailSet = Array<EC2ImportInstanceVolumeDetailItem>;
-    export interface EC2ImportKeyPairRequest {
-        DryRun?: EC2Boolean;
-        KeyName: EC2String;
-        PublicKeyMaterial: EC2Blob;
-    }
-
-    export interface EC2ImportKeyPairResult {
-        KeyName?: EC2String;
-        KeyFingerprint?: EC2String;
-    }
-
-    export interface EC2ImportSnapshotRequest {
-        DryRun?: EC2Boolean;
-        Description?: EC2String;
-        DiskContainer?: EC2SnapshotDiskContainer;
-        ClientData?: EC2ClientData;
-        ClientToken?: EC2String;
-        RoleName?: EC2String;
-    }
-
-    export interface EC2ImportSnapshotResult {
-        ImportTaskId?: EC2String;
-        SnapshotTaskDetail?: EC2SnapshotTaskDetail;
-        Description?: EC2String;
-    }
-
-    export interface EC2ImportSnapshotTask {
-        ImportTaskId?: EC2String;
-        SnapshotTaskDetail?: EC2SnapshotTaskDetail;
-        Description?: EC2String;
-    }
-
-    export type EC2ImportSnapshotTaskList = Array<EC2ImportSnapshotTask>;
-    export type EC2ImportTaskIdList = Array<EC2String>;
-    export interface EC2ImportVolumeRequest {
-        DryRun?: EC2Boolean;
-        AvailabilityZone: EC2String;
-        Image: EC2DiskImageDetail;
-        Description?: EC2String;
-        Volume: EC2VolumeDetail;
-    }
-
-    export interface EC2ImportVolumeResult {
-        ConversionTask?: EC2ConversionTask;
-    }
-
-    export interface EC2ImportVolumeTaskDetails {
-        BytesConverted: EC2Long;
-        AvailabilityZone: EC2String;
-        Description?: EC2String;
-        Image: EC2DiskImageDescription;
-        Volume: EC2DiskImageVolumeDescription;
-    }
-
-    export interface EC2Instance {
-        InstanceId?: EC2String;
-        ImageId?: EC2String;
-        State?: EC2InstanceState;
-        PrivateDnsName?: EC2String;
-        PublicDnsName?: EC2String;
-        StateTransitionReason?: EC2String;
-        KeyName?: EC2String;
-        AmiLaunchIndex?: EC2Integer;
-        ProductCodes?: EC2ProductCodeList;
-        InstanceType?: EC2InstanceType;
-        LaunchTime?: EC2DateTime;
-        Placement?: EC2Placement;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        Platform?: EC2PlatformValues;
-        Monitoring?: EC2Monitoring;
-        SubnetId?: EC2String;
-        VpcId?: EC2String;
-        PrivateIpAddress?: EC2String;
-        PublicIpAddress?: EC2String;
-        StateReason?: EC2StateReason;
-        Architecture?: EC2ArchitectureValues;
-        RootDeviceType?: EC2DeviceType;
-        RootDeviceName?: EC2String;
-        BlockDeviceMappings?: EC2InstanceBlockDeviceMappingList;
-        VirtualizationType?: EC2VirtualizationType;
-        InstanceLifecycle?: EC2InstanceLifecycleType;
-        SpotInstanceRequestId?: EC2String;
-        ClientToken?: EC2String;
-        Tags?: EC2TagList;
-        SecurityGroups?: EC2GroupIdentifierList;
-        SourceDestCheck?: EC2Boolean;
-        Hypervisor?: EC2HypervisorType;
-        NetworkInterfaces?: EC2InstanceNetworkInterfaceList;
-        IamInstanceProfile?: EC2IamInstanceProfile;
-        EbsOptimized?: EC2Boolean;
-        SriovNetSupport?: EC2String;
-    }
-
-    export interface EC2InstanceAttribute {
-        InstanceId?: EC2String;
-        InstanceType?: EC2AttributeValue;
-        KernelId?: EC2AttributeValue;
-        RamdiskId?: EC2AttributeValue;
-        UserData?: EC2AttributeValue;
-        DisableApiTermination?: EC2AttributeBooleanValue;
-        InstanceInitiatedShutdownBehavior?: EC2AttributeValue;
-        RootDeviceName?: EC2AttributeValue;
-        BlockDeviceMappings?: EC2InstanceBlockDeviceMappingList;
-        ProductCodes?: EC2ProductCodeList;
-        EbsOptimized?: EC2AttributeBooleanValue;
-        SriovNetSupport?: EC2AttributeValue;
-        SourceDestCheck?: EC2AttributeBooleanValue;
-        Groups?: EC2GroupIdentifierList;
-    }
-
-    export type EC2InstanceAttributeName = string;
-    export interface EC2InstanceBlockDeviceMapping {
-        DeviceName?: EC2String;
-        Ebs?: EC2EbsInstanceBlockDevice;
-    }
-
-    export type EC2InstanceBlockDeviceMappingList = Array<EC2InstanceBlockDeviceMapping>;
-    export interface EC2InstanceBlockDeviceMappingSpecification {
-        DeviceName?: EC2String;
-        Ebs?: EC2EbsInstanceBlockDeviceSpecification;
-        VirtualName?: EC2String;
-        NoDevice?: EC2String;
-    }
-
-    export type EC2InstanceBlockDeviceMappingSpecificationList = Array<EC2InstanceBlockDeviceMappingSpecification>;
-    export interface EC2InstanceCapacity {
-        InstanceType?: EC2String;
-        AvailableCapacity?: EC2Integer;
-        TotalCapacity?: EC2Integer;
-    }
-
-    export interface EC2InstanceCount {
-        State?: EC2ListingState;
-        InstanceCount?: EC2Integer;
-    }
-
-    export type EC2InstanceCountList = Array<EC2InstanceCount>;
-    export interface EC2InstanceExportDetails {
-        InstanceId?: EC2String;
-        TargetEnvironment?: EC2ExportEnvironment;
-    }
-
-    export type EC2InstanceIdStringList = Array<EC2String>;
-    export type EC2InstanceLifecycleType = string;
-    export type EC2InstanceList = Array<EC2Instance>;
-    export interface EC2InstanceMonitoring {
-        InstanceId?: EC2String;
-        Monitoring?: EC2Monitoring;
-    }
-
-    export type EC2InstanceMonitoringList = Array<EC2InstanceMonitoring>;
-    export interface EC2InstanceNetworkInterface {
-        NetworkInterfaceId?: EC2String;
-        SubnetId?: EC2String;
-        VpcId?: EC2String;
-        Description?: EC2String;
-        OwnerId?: EC2String;
-        Status?: EC2NetworkInterfaceStatus;
-        MacAddress?: EC2String;
-        PrivateIpAddress?: EC2String;
-        PrivateDnsName?: EC2String;
-        SourceDestCheck?: EC2Boolean;
-        Groups?: EC2GroupIdentifierList;
-        Attachment?: EC2InstanceNetworkInterfaceAttachment;
-        Association?: EC2InstanceNetworkInterfaceAssociation;
-        PrivateIpAddresses?: EC2InstancePrivateIpAddressList;
-    }
-
-    export interface EC2InstanceNetworkInterfaceAssociation {
-        PublicIp?: EC2String;
-        PublicDnsName?: EC2String;
-        IpOwnerId?: EC2String;
-    }
-
-    export interface EC2InstanceNetworkInterfaceAttachment {
-        AttachmentId?: EC2String;
-        DeviceIndex?: EC2Integer;
-        Status?: EC2AttachmentStatus;
-        AttachTime?: EC2DateTime;
-        DeleteOnTermination?: EC2Boolean;
-    }
-
-    export type EC2InstanceNetworkInterfaceList = Array<EC2InstanceNetworkInterface>;
-    export interface EC2InstanceNetworkInterfaceSpecification {
-        NetworkInterfaceId?: EC2String;
-        DeviceIndex?: EC2Integer;
-        SubnetId?: EC2String;
-        Description?: EC2String;
-        PrivateIpAddress?: EC2String;
-        Groups?: EC2SecurityGroupIdStringList;
-        DeleteOnTermination?: EC2Boolean;
-        PrivateIpAddresses?: EC2PrivateIpAddressSpecificationList;
-        SecondaryPrivateIpAddressCount?: EC2Integer;
-        AssociatePublicIpAddress?: EC2Boolean;
-    }
-
-    export type EC2InstanceNetworkInterfaceSpecificationList = Array<EC2InstanceNetworkInterfaceSpecification>;
-    export interface EC2InstancePrivateIpAddress {
-        PrivateIpAddress?: EC2String;
-        PrivateDnsName?: EC2String;
-        Primary?: EC2Boolean;
-        Association?: EC2InstanceNetworkInterfaceAssociation;
-    }
-
-    export type EC2InstancePrivateIpAddressList = Array<EC2InstancePrivateIpAddress>;
-    export interface EC2InstanceState {
-        Code?: EC2Integer;
-        Name?: EC2InstanceStateName;
-    }
-
-    export interface EC2InstanceStateChange {
-        InstanceId?: EC2String;
-        CurrentState?: EC2InstanceState;
-        PreviousState?: EC2InstanceState;
-    }
-
-    export type EC2InstanceStateChangeList = Array<EC2InstanceStateChange>;
-    export type EC2InstanceStateName = string;
-    export interface EC2InstanceStatus {
-        InstanceId?: EC2String;
-        AvailabilityZone?: EC2String;
-        Events?: EC2InstanceStatusEventList;
-        InstanceState?: EC2InstanceState;
-        SystemStatus?: EC2InstanceStatusSummary;
-        InstanceStatus?: EC2InstanceStatusSummary;
-    }
-
-    export interface EC2InstanceStatusDetails {
-        Name?: EC2StatusName;
-        Status?: EC2StatusType;
-        ImpairedSince?: EC2DateTime;
-    }
-
-    export type EC2InstanceStatusDetailsList = Array<EC2InstanceStatusDetails>;
-    export interface EC2InstanceStatusEvent {
-        Code?: EC2EventCode;
-        Description?: EC2String;
-        NotBefore?: EC2DateTime;
-        NotAfter?: EC2DateTime;
-    }
-
-    export type EC2InstanceStatusEventList = Array<EC2InstanceStatusEvent>;
-    export type EC2InstanceStatusList = Array<EC2InstanceStatus>;
-    export interface EC2InstanceStatusSummary {
-        Status?: EC2SummaryStatus;
-        Details?: EC2InstanceStatusDetailsList;
-    }
-
-    export type EC2InstanceType = string;
-    export type EC2InstanceTypeList = Array<EC2InstanceType>;
-    export type EC2Integer = number;
-    export interface EC2InternetGateway {
-        InternetGatewayId?: EC2String;
-        Attachments?: EC2InternetGatewayAttachmentList;
-        Tags?: EC2TagList;
-    }
-
-    export interface EC2InternetGatewayAttachment {
-        VpcId?: EC2String;
-        State?: EC2AttachmentStatus;
-    }
-
-    export type EC2InternetGatewayAttachmentList = Array<EC2InternetGatewayAttachment>;
-    export type EC2InternetGatewayList = Array<EC2InternetGateway>;
-    export interface EC2IpPermission {
-        IpProtocol?: EC2String;
-        FromPort?: EC2Integer;
-        ToPort?: EC2Integer;
-        UserIdGroupPairs?: EC2UserIdGroupPairList;
-        IpRanges?: EC2IpRangeList;
-        PrefixListIds?: EC2PrefixListIdList;
-    }
-
-    export type EC2IpPermissionList = Array<EC2IpPermission>;
-    export interface EC2IpRange {
-        CidrIp?: EC2String;
-    }
-
-    export type EC2IpRangeList = Array<EC2IpRange>;
-    export type EC2KeyNameStringList = Array<EC2String>;
-    export interface EC2KeyPair {
-        KeyName?: EC2String;
-        KeyFingerprint?: EC2String;
-        KeyMaterial?: EC2String;
-    }
-
-    export interface EC2KeyPairInfo {
-        KeyName?: EC2String;
-        KeyFingerprint?: EC2String;
-    }
-
-    export type EC2KeyPairList = Array<EC2KeyPairInfo>;
-    export interface EC2LaunchPermission {
-        UserId?: EC2String;
-        Group?: EC2PermissionGroup;
-    }
-
-    export type EC2LaunchPermissionList = Array<EC2LaunchPermission>;
-    export interface EC2LaunchPermissionModifications {
-        Add?: EC2LaunchPermissionList;
-        Remove?: EC2LaunchPermissionList;
-    }
-
-    export interface EC2LaunchSpecification {
-        ImageId?: EC2String;
-        KeyName?: EC2String;
-        SecurityGroups?: EC2GroupIdentifierList;
-        UserData?: EC2String;
-        AddressingType?: EC2String;
-        InstanceType?: EC2InstanceType;
-        Placement?: EC2SpotPlacement;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        BlockDeviceMappings?: EC2BlockDeviceMappingList;
-        SubnetId?: EC2String;
-        NetworkInterfaces?: EC2InstanceNetworkInterfaceSpecificationList;
-        IamInstanceProfile?: EC2IamInstanceProfileSpecification;
-        EbsOptimized?: EC2Boolean;
-        Monitoring?: EC2RunInstancesMonitoringEnabled;
-    }
-
-    export type EC2LaunchSpecsList = Array<EC2SpotFleetLaunchSpecification>;
-    export type EC2ListingState = string;
-    export type EC2ListingStatus = string;
-    export type EC2Long = number;
-    export interface EC2ModifyHostsRequest {
-        HostIds: EC2RequestHostIdList;
-        AutoPlacement: EC2AutoPlacement;
-    }
-
-    export interface EC2ModifyHostsResult {
-        Successful?: EC2ResponseHostIdList;
-        Unsuccessful?: EC2UnsuccessfulItemList;
-    }
-
-    export interface EC2ModifyIdFormatRequest {
-        Resource: EC2String;
-        UseLongIds: EC2Boolean;
-    }
-
-    export interface EC2ModifyImageAttributeRequest {
-        DryRun?: EC2Boolean;
-        ImageId: EC2String;
-        Attribute?: EC2String;
-        OperationType?: EC2OperationType;
-        UserIds?: EC2UserIdStringList;
-        UserGroups?: EC2UserGroupStringList;
-        ProductCodes?: EC2ProductCodeStringList;
-        Value?: EC2String;
-        LaunchPermission?: EC2LaunchPermissionModifications;
-        Description?: EC2AttributeValue;
-    }
-
-    export interface EC2ModifyInstanceAttributeRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        Attribute?: EC2InstanceAttributeName;
-        Value?: EC2String;
-        BlockDeviceMappings?: EC2InstanceBlockDeviceMappingSpecificationList;
-        SourceDestCheck?: EC2AttributeBooleanValue;
-        DisableApiTermination?: EC2AttributeBooleanValue;
-        InstanceType?: EC2AttributeValue;
-        Kernel?: EC2AttributeValue;
-        Ramdisk?: EC2AttributeValue;
-        UserData?: EC2BlobAttributeValue;
-        InstanceInitiatedShutdownBehavior?: EC2AttributeValue;
-        Groups?: EC2GroupIdStringList;
-        EbsOptimized?: EC2AttributeBooleanValue;
-        SriovNetSupport?: EC2AttributeValue;
-    }
-
-    export interface EC2ModifyInstancePlacementRequest {
-        InstanceId: EC2String;
-        Tenancy?: EC2HostTenancy;
-        Affinity?: EC2Affinity;
-        HostId?: EC2String;
-    }
-
-    export interface EC2ModifyInstancePlacementResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2ModifyNetworkInterfaceAttributeRequest {
-        DryRun?: EC2Boolean;
-        NetworkInterfaceId: EC2String;
-        Description?: EC2AttributeValue;
-        SourceDestCheck?: EC2AttributeBooleanValue;
-        Groups?: EC2SecurityGroupIdStringList;
-        Attachment?: EC2NetworkInterfaceAttachmentChanges;
-    }
-
-    export interface EC2ModifyReservedInstancesRequest {
-        ClientToken?: EC2String;
-        ReservedInstancesIds: EC2ReservedInstancesIdStringList;
-        TargetConfigurations: EC2ReservedInstancesConfigurationList;
-    }
-
-    export interface EC2ModifyReservedInstancesResult {
-        ReservedInstancesModificationId?: EC2String;
-    }
-
-    export interface EC2ModifySnapshotAttributeRequest {
-        DryRun?: EC2Boolean;
-        SnapshotId: EC2String;
-        Attribute?: EC2SnapshotAttributeName;
-        OperationType?: EC2OperationType;
-        UserIds?: EC2UserIdStringList;
-        GroupNames?: EC2GroupNameStringList;
-        CreateVolumePermission?: EC2CreateVolumePermissionModifications;
-    }
-
-    export interface EC2ModifySpotFleetRequestRequest {
-        SpotFleetRequestId: EC2String;
-        TargetCapacity?: EC2Integer;
-        ExcessCapacityTerminationPolicy?: EC2ExcessCapacityTerminationPolicy;
-    }
-
-    export interface EC2ModifySpotFleetRequestResponse {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2ModifySubnetAttributeRequest {
-        SubnetId: EC2String;
-        MapPublicIpOnLaunch?: EC2AttributeBooleanValue;
-    }
-
-    export interface EC2ModifyVolumeAttributeRequest {
-        DryRun?: EC2Boolean;
-        VolumeId: EC2String;
-        AutoEnableIO?: EC2AttributeBooleanValue;
-    }
-
-    export interface EC2ModifyVpcAttributeRequest {
-        VpcId: EC2String;
-        EnableDnsSupport?: EC2AttributeBooleanValue;
-        EnableDnsHostnames?: EC2AttributeBooleanValue;
-    }
-
-    export interface EC2ModifyVpcEndpointRequest {
-        DryRun?: EC2Boolean;
-        VpcEndpointId: EC2String;
-        ResetPolicy?: EC2Boolean;
-        PolicyDocument?: EC2String;
-        AddRouteTableIds?: EC2ValueStringList;
-        RemoveRouteTableIds?: EC2ValueStringList;
-    }
-
-    export interface EC2ModifyVpcEndpointResult {
-        Return?: EC2Boolean;
-    }
+      acceptVpcPeeringConnection(params: EC2.AcceptVpcPeeringConnectionRequest, callback?: (err: any, data: EC2.AcceptVpcPeeringConnectionResult|any) => void): Request;
+      allocateAddress(params: EC2.AllocateAddressRequest, callback?: (err: any, data: EC2.AllocateAddressResult|any) => void): Request;
+      allocateHosts(params: EC2.AllocateHostsRequest, callback?: (err: any, data: EC2.AllocateHostsResult|any) => void): Request;
+      assignPrivateIpAddresses(params: EC2.AssignPrivateIpAddressesRequest, callback?: (err: any, data: any) => void): Request;
+      associateAddress(params: EC2.AssociateAddressRequest, callback?: (err: any, data: EC2.AssociateAddressResult|any) => void): Request;
+      associateDhcpOptions(params: EC2.AssociateDhcpOptionsRequest, callback?: (err: any, data: any) => void): Request;
+      associateRouteTable(params: EC2.AssociateRouteTableRequest, callback?: (err: any, data: EC2.AssociateRouteTableResult|any) => void): Request;
+      attachClassicLinkVpc(params: EC2.AttachClassicLinkVpcRequest, callback?: (err: any, data: EC2.AttachClassicLinkVpcResult|any) => void): Request;
+      attachInternetGateway(params: EC2.AttachInternetGatewayRequest, callback?: (err: any, data: any) => void): Request;
+      attachNetworkInterface(params: EC2.AttachNetworkInterfaceRequest, callback?: (err: any, data: EC2.AttachNetworkInterfaceResult|any) => void): Request;
+      attachVolume(params: EC2.AttachVolumeRequest, callback?: (err: any, data: EC2.VolumeAttachment|any) => void): Request;
+      attachVpnGateway(params: EC2.AttachVpnGatewayRequest, callback?: (err: any, data: EC2.AttachVpnGatewayResult|any) => void): Request;
+      authorizeSecurityGroupEgress(params: EC2.AuthorizeSecurityGroupEgressRequest, callback?: (err: any, data: any) => void): Request;
+      authorizeSecurityGroupIngress(params: EC2.AuthorizeSecurityGroupIngressRequest, callback?: (err: any, data: any) => void): Request;
+      bundleInstance(params: EC2.BundleInstanceRequest, callback?: (err: any, data: EC2.BundleInstanceResult|any) => void): Request;
+      cancelBundleTask(params: EC2.CancelBundleTaskRequest, callback?: (err: any, data: EC2.CancelBundleTaskResult|any) => void): Request;
+      cancelConversionTask(params: EC2.CancelConversionRequest, callback?: (err: any, data: any) => void): Request;
+      cancelExportTask(params: EC2.CancelExportTaskRequest, callback?: (err: any, data: any) => void): Request;
+      cancelImportTask(params: EC2.CancelImportTaskRequest, callback?: (err: any, data: EC2.CancelImportTaskResult|any) => void): Request;
+      cancelReservedInstancesListing(params: EC2.CancelReservedInstancesListingRequest, callback?: (err: any, data: EC2.CancelReservedInstancesListingResult|any) => void): Request;
+      cancelSpotFleetRequests(params: EC2.CancelSpotFleetRequestsRequest, callback?: (err: any, data: EC2.CancelSpotFleetRequestsResponse|any) => void): Request;
+      cancelSpotInstanceRequests(params: EC2.CancelSpotInstanceRequestsRequest, callback?: (err: any, data: EC2.CancelSpotInstanceRequestsResult|any) => void): Request;
+      confirmProductInstance(params: EC2.ConfirmProductInstanceRequest, callback?: (err: any, data: EC2.ConfirmProductInstanceResult|any) => void): Request;
+      copyImage(params: EC2.CopyImageRequest, callback?: (err: any, data: EC2.CopyImageResult|any) => void): Request;
+      copySnapshot(params: EC2.CopySnapshotRequest, callback?: (err: any, data: EC2.CopySnapshotResult|any) => void): Request;
+      createCustomerGateway(params: EC2.CreateCustomerGatewayRequest, callback?: (err: any, data: EC2.CreateCustomerGatewayResult|any) => void): Request;
+      createDhcpOptions(params: EC2.CreateDhcpOptionsRequest, callback?: (err: any, data: EC2.CreateDhcpOptionsResult|any) => void): Request;
+      createFlowLogs(params: EC2.CreateFlowLogsRequest, callback?: (err: any, data: EC2.CreateFlowLogsResult|any) => void): Request;
+      createImage(params: EC2.CreateImageRequest, callback?: (err: any, data: EC2.CreateImageResult|any) => void): Request;
+      createInstanceExportTask(params: EC2.CreateInstanceExportTaskRequest, callback?: (err: any, data: EC2.CreateInstanceExportTaskResult|any) => void): Request;
+      createInternetGateway(params: EC2.CreateInternetGatewayRequest, callback?: (err: any, data: EC2.CreateInternetGatewayResult|any) => void): Request;
+      createKeyPair(params: EC2.CreateKeyPairRequest, callback?: (err: any, data: EC2.KeyPair|any) => void): Request;
+      createNetworkAcl(params: EC2.CreateNetworkAclRequest, callback?: (err: any, data: EC2.CreateNetworkAclResult|any) => void): Request;
+      createNetworkAclEntry(params: EC2.CreateNetworkAclEntryRequest, callback?: (err: any, data: any) => void): Request;
+      createNetworkInterface(params: EC2.CreateNetworkInterfaceRequest, callback?: (err: any, data: EC2.CreateNetworkInterfaceResult|any) => void): Request;
+      createPlacementGroup(params: EC2.CreatePlacementGroupRequest, callback?: (err: any, data: any) => void): Request;
+      createReservedInstancesListing(params: EC2.CreateReservedInstancesListingRequest, callback?: (err: any, data: EC2.CreateReservedInstancesListingResult|any) => void): Request;
+      createRoute(params: EC2.CreateRouteRequest, callback?: (err: any, data: EC2.CreateRouteResult|any) => void): Request;
+      createRouteTable(params: EC2.CreateRouteTableRequest, callback?: (err: any, data: EC2.CreateRouteTableResult|any) => void): Request;
+      createSecurityGroup(params: EC2.CreateSecurityGroupRequest, callback?: (err: any, data: EC2.CreateSecurityGroupResult|any) => void): Request;
+      createSnapshot(params: EC2.CreateSnapshotRequest, callback?: (err: any, data: EC2.Snapshot|any) => void): Request;
+      createSpotDatafeedSubscription(params: EC2.CreateSpotDatafeedSubscriptionRequest, callback?: (err: any, data: EC2.CreateSpotDatafeedSubscriptionResult|any) => void): Request;
+      createSubnet(params: EC2.CreateSubnetRequest, callback?: (err: any, data: EC2.CreateSubnetResult|any) => void): Request;
+      createTags(params: EC2.CreateTagsRequest, callback?: (err: any, data: any) => void): Request;
+      createVolume(params: EC2.CreateVolumeRequest, callback?: (err: any, data: EC2.Volume|any) => void): Request;
+      createVpc(params: EC2.CreateVpcRequest, callback?: (err: any, data: EC2.CreateVpcResult|any) => void): Request;
+      createVpcEndpoint(params: EC2.CreateVpcEndpointRequest, callback?: (err: any, data: EC2.CreateVpcEndpointResult|any) => void): Request;
+      createVpcPeeringConnection(params: EC2.CreateVpcPeeringConnectionRequest, callback?: (err: any, data: EC2.CreateVpcPeeringConnectionResult|any) => void): Request;
+      createVpnConnection(params: EC2.CreateVpnConnectionRequest, callback?: (err: any, data: EC2.CreateVpnConnectionResult|any) => void): Request;
+      createVpnConnectionRoute(params: EC2.CreateVpnConnectionRouteRequest, callback?: (err: any, data: any) => void): Request;
+      createVpnGateway(params: EC2.CreateVpnGatewayRequest, callback?: (err: any, data: EC2.CreateVpnGatewayResult|any) => void): Request;
+      deleteCustomerGateway(params: EC2.DeleteCustomerGatewayRequest, callback?: (err: any, data: any) => void): Request;
+      deleteDhcpOptions(params: EC2.DeleteDhcpOptionsRequest, callback?: (err: any, data: any) => void): Request;
+      deleteFlowLogs(params: EC2.DeleteFlowLogsRequest, callback?: (err: any, data: EC2.DeleteFlowLogsResult|any) => void): Request;
+      deleteInternetGateway(params: EC2.DeleteInternetGatewayRequest, callback?: (err: any, data: any) => void): Request;
+      deleteKeyPair(params: EC2.DeleteKeyPairRequest, callback?: (err: any, data: any) => void): Request;
+      deleteNetworkAcl(params: EC2.DeleteNetworkAclRequest, callback?: (err: any, data: any) => void): Request;
+      deleteNetworkAclEntry(params: EC2.DeleteNetworkAclEntryRequest, callback?: (err: any, data: any) => void): Request;
+      deleteNetworkInterface(params: EC2.DeleteNetworkInterfaceRequest, callback?: (err: any, data: any) => void): Request;
+      deletePlacementGroup(params: EC2.DeletePlacementGroupRequest, callback?: (err: any, data: any) => void): Request;
+      deleteRoute(params: EC2.DeleteRouteRequest, callback?: (err: any, data: any) => void): Request;
+      deleteRouteTable(params: EC2.DeleteRouteTableRequest, callback?: (err: any, data: any) => void): Request;
+      deleteSecurityGroup(params: EC2.DeleteSecurityGroupRequest, callback?: (err: any, data: any) => void): Request;
+      deleteSnapshot(params: EC2.DeleteSnapshotRequest, callback?: (err: any, data: any) => void): Request;
+      deleteSpotDatafeedSubscription(params: EC2.DeleteSpotDatafeedSubscriptionRequest, callback?: (err: any, data: any) => void): Request;
+      deleteSubnet(params: EC2.DeleteSubnetRequest, callback?: (err: any, data: any) => void): Request;
+      deleteTags(params: EC2.DeleteTagsRequest, callback?: (err: any, data: any) => void): Request;
+      deleteVolume(params: EC2.DeleteVolumeRequest, callback?: (err: any, data: any) => void): Request;
+      deleteVpc(params: EC2.DeleteVpcRequest, callback?: (err: any, data: any) => void): Request;
+      deleteVpcEndpoints(params: EC2.DeleteVpcEndpointsRequest, callback?: (err: any, data: EC2.DeleteVpcEndpointsResult|any) => void): Request;
+      deleteVpcPeeringConnection(params: EC2.DeleteVpcPeeringConnectionRequest, callback?: (err: any, data: EC2.DeleteVpcPeeringConnectionResult|any) => void): Request;
+      deleteVpnConnection(params: EC2.DeleteVpnConnectionRequest, callback?: (err: any, data: any) => void): Request;
+      deleteVpnConnectionRoute(params: EC2.DeleteVpnConnectionRouteRequest, callback?: (err: any, data: any) => void): Request;
+      deleteVpnGateway(params: EC2.DeleteVpnGatewayRequest, callback?: (err: any, data: any) => void): Request;
+      deregisterImage(params: EC2.DeregisterImageRequest, callback?: (err: any, data: any) => void): Request;
+      describeAccountAttributes(params: EC2.DescribeAccountAttributesRequest, callback?: (err: any, data: EC2.DescribeAccountAttributesResult|any) => void): Request;
+      describeAddresses(params: EC2.DescribeAddressesRequest, callback?: (err: any, data: EC2.DescribeAddressesResult|any) => void): Request;
+      describeAvailabilityZones(params: EC2.DescribeAvailabilityZonesRequest, callback?: (err: any, data: EC2.DescribeAvailabilityZonesResult|any) => void): Request;
+      describeBundleTasks(params: EC2.DescribeBundleTasksRequest, callback?: (err: any, data: EC2.DescribeBundleTasksResult|any) => void): Request;
+      describeClassicLinkInstances(params: EC2.DescribeClassicLinkInstancesRequest, callback?: (err: any, data: EC2.DescribeClassicLinkInstancesResult|any) => void): Request;
+      describeConversionTasks(params: EC2.DescribeConversionTasksRequest, callback?: (err: any, data: EC2.DescribeConversionTasksResult|any) => void): Request;
+      describeCustomerGateways(params: EC2.DescribeCustomerGatewaysRequest, callback?: (err: any, data: EC2.DescribeCustomerGatewaysResult|any) => void): Request;
+      describeDhcpOptions(params: EC2.DescribeDhcpOptionsRequest, callback?: (err: any, data: EC2.DescribeDhcpOptionsResult|any) => void): Request;
+      describeExportTasks(params: EC2.DescribeExportTasksRequest, callback?: (err: any, data: EC2.DescribeExportTasksResult|any) => void): Request;
+      describeFlowLogs(params: EC2.DescribeFlowLogsRequest, callback?: (err: any, data: EC2.DescribeFlowLogsResult|any) => void): Request;
+      describeHosts(params: EC2.DescribeHostsRequest, callback?: (err: any, data: EC2.DescribeHostsResult|any) => void): Request;
+      describeIdFormat(params: EC2.DescribeIdFormatRequest, callback?: (err: any, data: EC2.DescribeIdFormatResult|any) => void): Request;
+      describeImageAttribute(params: EC2.DescribeImageAttributeRequest, callback?: (err: any, data: EC2.ImageAttribute|any) => void): Request;
+      describeImages(params: EC2.DescribeImagesRequest, callback?: (err: any, data: EC2.DescribeImagesResult|any) => void): Request;
+      describeImportImageTasks(params: EC2.DescribeImportImageTasksRequest, callback?: (err: any, data: EC2.DescribeImportImageTasksResult|any) => void): Request;
+      describeImportSnapshotTasks(params: EC2.DescribeImportSnapshotTasksRequest, callback?: (err: any, data: EC2.DescribeImportSnapshotTasksResult|any) => void): Request;
+      describeInstanceAttribute(params: EC2.DescribeInstanceAttributeRequest, callback?: (err: any, data: EC2.InstanceAttribute|any) => void): Request;
+      describeInstanceStatus(params: EC2.DescribeInstanceStatusRequest, callback?: (err: any, data: EC2.DescribeInstanceStatusResult|any) => void): Request;
+      describeInstances(params: EC2.DescribeInstancesRequest, callback?: (err: any, data: EC2.DescribeInstancesResult|any) => void): Request;
+      describeInternetGateways(params: EC2.DescribeInternetGatewaysRequest, callback?: (err: any, data: EC2.DescribeInternetGatewaysResult|any) => void): Request;
+      describeKeyPairs(params: EC2.DescribeKeyPairsRequest, callback?: (err: any, data: EC2.DescribeKeyPairsResult|any) => void): Request;
+      describeMovingAddresses(params: EC2.DescribeMovingAddressesRequest, callback?: (err: any, data: EC2.DescribeMovingAddressesResult|any) => void): Request;
+      describeNetworkAcls(params: EC2.DescribeNetworkAclsRequest, callback?: (err: any, data: EC2.DescribeNetworkAclsResult|any) => void): Request;
+      describeNetworkInterfaceAttribute(params: EC2.DescribeNetworkInterfaceAttributeRequest, callback?: (err: any, data: EC2.DescribeNetworkInterfaceAttributeResult|any) => void): Request;
+      describeNetworkInterfaces(params: EC2.DescribeNetworkInterfacesRequest, callback?: (err: any, data: EC2.DescribeNetworkInterfacesResult|any) => void): Request;
+      describePlacementGroups(params: EC2.DescribePlacementGroupsRequest, callback?: (err: any, data: EC2.DescribePlacementGroupsResult|any) => void): Request;
+      describePrefixLists(params: EC2.DescribePrefixListsRequest, callback?: (err: any, data: EC2.DescribePrefixListsResult|any) => void): Request;
+      describeRegions(params: EC2.DescribeRegionsRequest, callback?: (err: any, data: EC2.DescribeRegionsResult|any) => void): Request;
+      describeReservedInstances(params: EC2.DescribeReservedInstancesRequest, callback?: (err: any, data: EC2.DescribeReservedInstancesResult|any) => void): Request;
+      describeReservedInstancesListings(params: EC2.DescribeReservedInstancesListingsRequest, callback?: (err: any, data: EC2.DescribeReservedInstancesListingsResult|any) => void): Request;
+      describeReservedInstancesModifications(params: EC2.DescribeReservedInstancesModificationsRequest, callback?: (err: any, data: EC2.DescribeReservedInstancesModificationsResult|any) => void): Request;
+      describeReservedInstancesOfferings(params: EC2.DescribeReservedInstancesOfferingsRequest, callback?: (err: any, data: EC2.DescribeReservedInstancesOfferingsResult|any) => void): Request;
+      describeRouteTables(params: EC2.DescribeRouteTablesRequest, callback?: (err: any, data: EC2.DescribeRouteTablesResult|any) => void): Request;
+      describeSecurityGroups(params: EC2.DescribeSecurityGroupsRequest, callback?: (err: any, data: EC2.DescribeSecurityGroupsResult|any) => void): Request;
+      describeSnapshotAttribute(params: EC2.DescribeSnapshotAttributeRequest, callback?: (err: any, data: EC2.DescribeSnapshotAttributeResult|any) => void): Request;
+      describeSnapshots(params: EC2.DescribeSnapshotsRequest, callback?: (err: any, data: EC2.DescribeSnapshotsResult|any) => void): Request;
+      describeSpotDatafeedSubscription(params: EC2.DescribeSpotDatafeedSubscriptionRequest, callback?: (err: any, data: EC2.DescribeSpotDatafeedSubscriptionResult|any) => void): Request;
+      describeSpotFleetInstances(params: EC2.DescribeSpotFleetInstancesRequest, callback?: (err: any, data: EC2.DescribeSpotFleetInstancesResponse|any) => void): Request;
+      describeSpotFleetRequestHistory(params: EC2.DescribeSpotFleetRequestHistoryRequest, callback?: (err: any, data: EC2.DescribeSpotFleetRequestHistoryResponse|any) => void): Request;
+      describeSpotFleetRequests(params: EC2.DescribeSpotFleetRequestsRequest, callback?: (err: any, data: EC2.DescribeSpotFleetRequestsResponse|any) => void): Request;
+      describeSpotInstanceRequests(params: EC2.DescribeSpotInstanceRequestsRequest, callback?: (err: any, data: EC2.DescribeSpotInstanceRequestsResult|any) => void): Request;
+      describeSpotPriceHistory(params: EC2.DescribeSpotPriceHistoryRequest, callback?: (err: any, data: EC2.DescribeSpotPriceHistoryResult|any) => void): Request;
+      describeSubnets(params: EC2.DescribeSubnetsRequest, callback?: (err: any, data: EC2.DescribeSubnetsResult|any) => void): Request;
+      describeTags(params: EC2.DescribeTagsRequest, callback?: (err: any, data: EC2.DescribeTagsResult|any) => void): Request;
+      describeVolumeAttribute(params: EC2.DescribeVolumeAttributeRequest, callback?: (err: any, data: EC2.DescribeVolumeAttributeResult|any) => void): Request;
+      describeVolumeStatus(params: EC2.DescribeVolumeStatusRequest, callback?: (err: any, data: EC2.DescribeVolumeStatusResult|any) => void): Request;
+      describeVolumes(params: EC2.DescribeVolumesRequest, callback?: (err: any, data: EC2.DescribeVolumesResult|any) => void): Request;
+      describeVpcAttribute(params: EC2.DescribeVpcAttributeRequest, callback?: (err: any, data: EC2.DescribeVpcAttributeResult|any) => void): Request;
+      describeVpcClassicLink(params: EC2.DescribeVpcClassicLinkRequest, callback?: (err: any, data: EC2.DescribeVpcClassicLinkResult|any) => void): Request;
+      describeVpcEndpointServices(params: EC2.DescribeVpcEndpointServicesRequest, callback?: (err: any, data: EC2.DescribeVpcEndpointServicesResult|any) => void): Request;
+      describeVpcEndpoints(params: EC2.DescribeVpcEndpointsRequest, callback?: (err: any, data: EC2.DescribeVpcEndpointsResult|any) => void): Request;
+      describeVpcPeeringConnections(params: EC2.DescribeVpcPeeringConnectionsRequest, callback?: (err: any, data: EC2.DescribeVpcPeeringConnectionsResult|any) => void): Request;
+      describeVpcs(params: EC2.DescribeVpcsRequest, callback?: (err: any, data: EC2.DescribeVpcsResult|any) => void): Request;
+      describeVpnConnections(params: EC2.DescribeVpnConnectionsRequest, callback?: (err: any, data: EC2.DescribeVpnConnectionsResult|any) => void): Request;
+      describeVpnGateways(params: EC2.DescribeVpnGatewaysRequest, callback?: (err: any, data: EC2.DescribeVpnGatewaysResult|any) => void): Request;
+      detachClassicLinkVpc(params: EC2.DetachClassicLinkVpcRequest, callback?: (err: any, data: EC2.DetachClassicLinkVpcResult|any) => void): Request;
+      detachInternetGateway(params: EC2.DetachInternetGatewayRequest, callback?: (err: any, data: any) => void): Request;
+      detachNetworkInterface(params: EC2.DetachNetworkInterfaceRequest, callback?: (err: any, data: any) => void): Request;
+      detachVolume(params: EC2.DetachVolumeRequest, callback?: (err: any, data: EC2.VolumeAttachment|any) => void): Request;
+      detachVpnGateway(params: EC2.DetachVpnGatewayRequest, callback?: (err: any, data: any) => void): Request;
+      disableVgwRoutePropagation(params: EC2.DisableVgwRoutePropagationRequest, callback?: (err: any, data: any) => void): Request;
+      disableVpcClassicLink(params: EC2.DisableVpcClassicLinkRequest, callback?: (err: any, data: EC2.DisableVpcClassicLinkResult|any) => void): Request;
+      disassociateAddress(params: EC2.DisassociateAddressRequest, callback?: (err: any, data: any) => void): Request;
+      disassociateRouteTable(params: EC2.DisassociateRouteTableRequest, callback?: (err: any, data: any) => void): Request;
+      enableVgwRoutePropagation(params: EC2.EnableVgwRoutePropagationRequest, callback?: (err: any, data: any) => void): Request;
+      enableVolumeIO(params: EC2.EnableVolumeIORequest, callback?: (err: any, data: any) => void): Request;
+      enableVpcClassicLink(params: EC2.EnableVpcClassicLinkRequest, callback?: (err: any, data: EC2.EnableVpcClassicLinkResult|any) => void): Request;
+      getConsoleOutput(params: EC2.GetConsoleOutputRequest, callback?: (err: any, data: EC2.GetConsoleOutputResult|any) => void): Request;
+      getPasswordData(params: EC2.GetPasswordDataRequest, callback?: (err: any, data: EC2.GetPasswordDataResult|any) => void): Request;
+      importImage(params: EC2.ImportImageRequest, callback?: (err: any, data: EC2.ImportImageResult|any) => void): Request;
+      importInstance(params: EC2.ImportInstanceRequest, callback?: (err: any, data: EC2.ImportInstanceResult|any) => void): Request;
+      importKeyPair(params: EC2.ImportKeyPairRequest, callback?: (err: any, data: EC2.ImportKeyPairResult|any) => void): Request;
+      importSnapshot(params: EC2.ImportSnapshotRequest, callback?: (err: any, data: EC2.ImportSnapshotResult|any) => void): Request;
+      importVolume(params: EC2.ImportVolumeRequest, callback?: (err: any, data: EC2.ImportVolumeResult|any) => void): Request;
+      modifyHosts(params: EC2.ModifyHostsRequest, callback?: (err: any, data: EC2.ModifyHostsResult|any) => void): Request;
+      modifyIdFormat(params: EC2.ModifyIdFormatRequest, callback?: (err: any, data: any) => void): Request;
+      modifyImageAttribute(params: EC2.ModifyImageAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifyInstanceAttribute(params: EC2.ModifyInstanceAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifyInstancePlacement(params: EC2.ModifyInstancePlacementRequest, callback?: (err: any, data: EC2.ModifyInstancePlacementResult|any) => void): Request;
+      modifyNetworkInterfaceAttribute(params: EC2.ModifyNetworkInterfaceAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifyReservedInstances(params: EC2.ModifyReservedInstancesRequest, callback?: (err: any, data: EC2.ModifyReservedInstancesResult|any) => void): Request;
+      modifySnapshotAttribute(params: EC2.ModifySnapshotAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifySpotFleetRequest(params: EC2.ModifySpotFleetRequestRequest, callback?: (err: any, data: EC2.ModifySpotFleetRequestResponse|any) => void): Request;
+      modifySubnetAttribute(params: EC2.ModifySubnetAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifyVolumeAttribute(params: EC2.ModifyVolumeAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifyVpcAttribute(params: EC2.ModifyVpcAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      modifyVpcEndpoint(params: EC2.ModifyVpcEndpointRequest, callback?: (err: any, data: EC2.ModifyVpcEndpointResult|any) => void): Request;
+      monitorInstances(params: EC2.MonitorInstancesRequest, callback?: (err: any, data: EC2.MonitorInstancesResult|any) => void): Request;
+      moveAddressToVpc(params: EC2.MoveAddressToVpcRequest, callback?: (err: any, data: EC2.MoveAddressToVpcResult|any) => void): Request;
+      purchaseReservedInstancesOffering(params: EC2.PurchaseReservedInstancesOfferingRequest, callback?: (err: any, data: EC2.PurchaseReservedInstancesOfferingResult|any) => void): Request;
+      rebootInstances(params: EC2.RebootInstancesRequest, callback?: (err: any, data: any) => void): Request;
+      registerImage(params: EC2.RegisterImageRequest, callback?: (err: any, data: EC2.RegisterImageResult|any) => void): Request;
+      rejectVpcPeeringConnection(params: EC2.RejectVpcPeeringConnectionRequest, callback?: (err: any, data: EC2.RejectVpcPeeringConnectionResult|any) => void): Request;
+      releaseAddress(params: EC2.ReleaseAddressRequest, callback?: (err: any, data: any) => void): Request;
+      releaseHosts(params: EC2.ReleaseHostsRequest, callback?: (err: any, data: EC2.ReleaseHostsResult|any) => void): Request;
+      replaceNetworkAclAssociation(params: EC2.ReplaceNetworkAclAssociationRequest, callback?: (err: any, data: EC2.ReplaceNetworkAclAssociationResult|any) => void): Request;
+      replaceNetworkAclEntry(params: EC2.ReplaceNetworkAclEntryRequest, callback?: (err: any, data: any) => void): Request;
+      replaceRoute(params: EC2.ReplaceRouteRequest, callback?: (err: any, data: any) => void): Request;
+      replaceRouteTableAssociation(params: EC2.ReplaceRouteTableAssociationRequest, callback?: (err: any, data: EC2.ReplaceRouteTableAssociationResult|any) => void): Request;
+      reportInstanceStatus(params: EC2.ReportInstanceStatusRequest, callback?: (err: any, data: any) => void): Request;
+      requestSpotFleet(params: EC2.RequestSpotFleetRequest, callback?: (err: any, data: EC2.RequestSpotFleetResponse|any) => void): Request;
+      requestSpotInstances(params: EC2.RequestSpotInstancesRequest, callback?: (err: any, data: EC2.RequestSpotInstancesResult|any) => void): Request;
+      resetImageAttribute(params: EC2.ResetImageAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      resetInstanceAttribute(params: EC2.ResetInstanceAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      resetNetworkInterfaceAttribute(params: EC2.ResetNetworkInterfaceAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      resetSnapshotAttribute(params: EC2.ResetSnapshotAttributeRequest, callback?: (err: any, data: any) => void): Request;
+      restoreAddressToClassic(params: EC2.RestoreAddressToClassicRequest, callback?: (err: any, data: EC2.RestoreAddressToClassicResult|any) => void): Request;
+      revokeSecurityGroupEgress(params: EC2.RevokeSecurityGroupEgressRequest, callback?: (err: any, data: any) => void): Request;
+      revokeSecurityGroupIngress(params: EC2.RevokeSecurityGroupIngressRequest, callback?: (err: any, data: any) => void): Request;
+      runInstances(params: EC2.RunInstancesRequest, callback?: (err: any, data: EC2.Reservation|any) => void): Request;
+      startInstances(params: EC2.StartInstancesRequest, callback?: (err: any, data: EC2.StartInstancesResult|any) => void): Request;
+      stopInstances(params: EC2.StopInstancesRequest, callback?: (err: any, data: EC2.StopInstancesResult|any) => void): Request;
+      terminateInstances(params: EC2.TerminateInstancesRequest, callback?: (err: any, data: EC2.TerminateInstancesResult|any) => void): Request;
+      unassignPrivateIpAddresses(params: EC2.UnassignPrivateIpAddressesRequest, callback?: (err: any, data: any) => void): Request;
+      unmonitorInstances(params: EC2.UnmonitorInstancesRequest, callback?: (err: any, data: EC2.UnmonitorInstancesResult|any) => void): Request;
+    }
+    
+    export module EC2 {
+        export type AccountAttributeList = AccountAttribute[];
+        export type AccountAttributeName = string;
+        export type AccountAttributeNameStringList = AccountAttributeName[];
+        export type AccountAttributeValueList = AccountAttributeValue[];
+        export type ActiveInstanceSet = ActiveInstance[];
+        export type AddressList = Address[];
+        export type Affinity = string;
+        export type AllocationIdList = String[];
+        export type AllocationState = string;
+        export type AllocationStrategy = string;
+        export type ArchitectureValues = string;
+        export type AttachmentStatus = string;
+        export type AutoPlacement = string;
+        export type AvailabilityZoneList = AvailabilityZone[];
+        export type AvailabilityZoneMessageList = AvailabilityZoneMessage[];
+        export type AvailabilityZoneState = string;
+        export type AvailableInstanceCapacityList = InstanceCapacity[];
+        export type BatchState = string;
+        export type Blob = any;    // type: blob
+        export type BlockDeviceMappingList = BlockDeviceMapping[];
+        export type BlockDeviceMappingRequestList = BlockDeviceMapping[];
+        export type Boolean = boolean;
+        export type BundleIdStringList = String[];
+        export type BundleTaskList = BundleTask[];
+        export type BundleTaskState = string;
+        export type CancelBatchErrorCode = string;
+        export type CancelSpotFleetRequestsErrorSet = CancelSpotFleetRequestsErrorItem[];
+        export type CancelSpotFleetRequestsSuccessSet = CancelSpotFleetRequestsSuccessItem[];
+        export type CancelSpotInstanceRequestState = string;
+        export type CancelledSpotInstanceRequestList = CancelledSpotInstanceRequest[];
+        export type ClassicLinkInstanceList = ClassicLinkInstance[];
+        export type ContainerFormat = string;
+        export type ConversionIdStringList = String[];
+        export type ConversionTaskState = string;
+        export type CreateVolumePermissionList = CreateVolumePermission[];
+        export type CurrencyCodeValues = string;
+        export type CustomerGatewayIdStringList = String[];
+        export type CustomerGatewayList = CustomerGateway[];
+        export type DatafeedSubscriptionState = string;
+        export type DateTime = number;
+        export type DescribeConversionTaskList = ConversionTask[];
+        export type DeviceType = string;
+        export type DhcpConfigurationList = DhcpConfiguration[];
+        export type DhcpConfigurationValueList = AttributeValue[];
+        export type DhcpOptionsIdStringList = String[];
+        export type DhcpOptionsList = DhcpOptions[];
+        export type DiskImageFormat = string;
+        export type DiskImageList = DiskImage[];
+        export type DomainType = string;
+        export type Double = number;
+        export type EventCode = string;
+        export type EventType = string;
+        export type ExcessCapacityTerminationPolicy = string;
+        export type ExecutableByStringList = String[];
+        export type ExportEnvironment = string;
+        export type ExportTaskIdStringList = String[];
+        export type ExportTaskList = ExportTask[];
+        export type ExportTaskState = string;
+        export type FilterList = Filter[];
+        export type Float = number;
+        export type FlowLogSet = FlowLog[];
+        export type FlowLogsResourceType = string;
+        export type GatewayType = string;
+        export type GroupIdStringList = String[];
+        export type GroupIdentifierList = GroupIdentifier[];
+        export type GroupNameStringList = String[];
+        export type HistoryRecords = HistoryRecord[];
+        export type HostInstanceList = HostInstance[];
+        export type HostList = Host[];
+        export type HostTenancy = string;
+        export type HypervisorType = string;
+        export type IdFormatList = IdFormat[];
+        export type ImageAttributeName = string;
+        export type ImageDiskContainerList = ImageDiskContainer[];
+        export type ImageIdStringList = String[];
+        export type ImageList = Image[];
+        export type ImageState = string;
+        export type ImageTypeValues = string;
+        export type ImportImageTaskList = ImportImageTask[];
+        export type ImportInstanceVolumeDetailSet = ImportInstanceVolumeDetailItem[];
+        export type ImportSnapshotTaskList = ImportSnapshotTask[];
+        export type ImportTaskIdList = String[];
+        export type InstanceAttributeName = string;
+        export type InstanceBlockDeviceMappingList = InstanceBlockDeviceMapping[];
+        export type InstanceBlockDeviceMappingSpecificationList = InstanceBlockDeviceMappingSpecification[];
+        export type InstanceCountList = InstanceCount[];
+        export type InstanceIdStringList = String[];
+        export type InstanceLifecycleType = string;
+        export type InstanceList = Instance[];
+        export type InstanceMonitoringList = InstanceMonitoring[];
+        export type InstanceNetworkInterfaceList = InstanceNetworkInterface[];
+        export type InstanceNetworkInterfaceSpecificationList = InstanceNetworkInterfaceSpecification[];
+        export type InstancePrivateIpAddressList = InstancePrivateIpAddress[];
+        export type InstanceStateChangeList = InstanceStateChange[];
+        export type InstanceStateName = string;
+        export type InstanceStatusDetailsList = InstanceStatusDetails[];
+        export type InstanceStatusEventList = InstanceStatusEvent[];
+        export type InstanceStatusList = InstanceStatus[];
+        export type InstanceType = string;
+        export type InstanceTypeList = InstanceType[];
+        export type Integer = number;
+        export type InternetGatewayAttachmentList = InternetGatewayAttachment[];
+        export type InternetGatewayList = InternetGateway[];
+        export type IpPermissionList = IpPermission[];
+        export type IpRangeList = IpRange[];
+        export type KeyNameStringList = String[];
+        export type KeyPairList = KeyPairInfo[];
+        export type LaunchPermissionList = LaunchPermission[];
+        export type LaunchSpecsList = SpotFleetLaunchSpecification[];    // min: 1
+        export type ListingState = string;
+        export type ListingStatus = string;
+        export type Long = number;
+        export type MonitoringState = string;
+        export type MoveStatus = string;
+        export type MovingAddressStatusSet = MovingAddressStatus[];
+        export type NetworkAclAssociationList = NetworkAclAssociation[];
+        export type NetworkAclEntryList = NetworkAclEntry[];
+        export type NetworkAclList = NetworkAcl[];
+        export type NetworkInterfaceAttribute = string;
+        export type NetworkInterfaceIdList = String[];
+        export type NetworkInterfaceList = NetworkInterface[];
+        export type NetworkInterfacePrivateIpAddressList = NetworkInterfacePrivateIpAddress[];
+        export type NetworkInterfaceStatus = string;
+        export type NewDhcpConfigurationList = NewDhcpConfiguration[];
+        export type OfferingTypeValues = string;
+        export type OperationType = string;
+        export type OwnerStringList = String[];
+        export type PermissionGroup = string;
+        export type PlacementGroupList = PlacementGroup[];
+        export type PlacementGroupState = string;
+        export type PlacementGroupStringList = String[];
+        export type PlacementStrategy = string;
+        export type PlatformValues = string;
+        export type PrefixListIdList = PrefixListId[];
+        export type PrefixListSet = PrefixList[];
+        export type PriceScheduleList = PriceSchedule[];
+        export type PriceScheduleSpecificationList = PriceScheduleSpecification[];
+        export type PricingDetailsList = PricingDetail[];
+        export type PrivateIpAddressSpecificationList = PrivateIpAddressSpecification[];
+        export type PrivateIpAddressStringList = String[];
+        export type ProductCodeList = ProductCode[];
+        export type ProductCodeStringList = String[];
+        export type ProductCodeValues = string;
+        export type ProductDescriptionList = String[];
+        export type PropagatingVgwList = PropagatingVgw[];
+        export type PublicIpStringList = String[];
+        export type RIProductDescription = string;
+        export type ReasonCodesList = ReportInstanceReasonCodes[];
+        export type RecurringChargeFrequency = string;
+        export type RecurringChargesList = RecurringCharge[];
+        export type RegionList = Region[];
+        export type RegionNameStringList = String[];
+        export type ReportInstanceReasonCodes = string;
+        export type ReportStatusType = string;
+        export type RequestHostIdList = String[];
+        export type ReservationList = Reservation[];
+        export type ReservedInstanceState = string;
+        export type ReservedInstancesConfigurationList = ReservedInstancesConfiguration[];
+        export type ReservedInstancesIdStringList = String[];
+        export type ReservedInstancesList = ReservedInstances[];
+        export type ReservedInstancesListingList = ReservedInstancesListing[];
+        export type ReservedInstancesModificationIdStringList = String[];
+        export type ReservedInstancesModificationList = ReservedInstancesModification[];
+        export type ReservedInstancesModificationResultList = ReservedInstancesModificationResult[];
+        export type ReservedInstancesOfferingIdStringList = String[];
+        export type ReservedInstancesOfferingList = ReservedInstancesOffering[];
+        export type ReservedIntancesIds = ReservedInstancesId[];
+        export type ResetImageAttributeName = string;
+        export type ResourceIdList = String[];
+        export type ResourceType = string;
+        export type ResponseHostIdList = String[];
+        export type RestorableByStringList = String[];
+        export type RouteList = Route[];
+        export type RouteOrigin = string;
+        export type RouteState = string;
+        export type RouteTableAssociationList = RouteTableAssociation[];
+        export type RouteTableList = RouteTable[];
+        export type RuleAction = string;
+        export type SecurityGroupIdStringList = String[];
+        export type SecurityGroupList = SecurityGroup[];
+        export type SecurityGroupStringList = String[];
+        export type ShutdownBehavior = string;
+        export type SnapshotAttributeName = string;
+        export type SnapshotDetailList = SnapshotDetail[];
+        export type SnapshotIdStringList = String[];
+        export type SnapshotList = Snapshot[];
+        export type SnapshotState = string;
+        export type SpotFleetRequestConfigSet = SpotFleetRequestConfig[];
+        export type SpotInstanceRequestIdList = String[];
+        export type SpotInstanceRequestList = SpotInstanceRequest[];
+        export type SpotInstanceState = string;
+        export type SpotInstanceType = string;
+        export type SpotPriceHistoryList = SpotPrice[];
+        export type State = string;
+        export type Status = string;
+        export type StatusName = string;
+        export type StatusType = string;
+        export type String = string;
+        export type SubnetIdStringList = String[];
+        export type SubnetList = Subnet[];
+        export type SubnetState = string;
+        export type SummaryStatus = string;
+        export type TagDescriptionList = TagDescription[];
+        export type TagList = Tag[];
+        export type TelemetryStatus = string;
+        export type Tenancy = string;
+        export type TrafficType = string;
+        export type UnsuccessfulItemList = UnsuccessfulItem[];
+        export type UnsuccessfulItemSet = UnsuccessfulItem[];
+        export type UserGroupStringList = String[];
+        export type UserIdGroupPairList = UserIdGroupPair[];
+        export type UserIdStringList = String[];
+        export type ValueStringList = String[];
+        export type VgwTelemetryList = VgwTelemetry[];
+        export type VirtualizationType = string;
+        export type VolumeAttachmentList = VolumeAttachment[];
+        export type VolumeAttachmentState = string;
+        export type VolumeAttributeName = string;
+        export type VolumeIdStringList = String[];
+        export type VolumeList = Volume[];
+        export type VolumeState = string;
+        export type VolumeStatusActionsList = VolumeStatusAction[];
+        export type VolumeStatusDetailsList = VolumeStatusDetails[];
+        export type VolumeStatusEventsList = VolumeStatusEvent[];
+        export type VolumeStatusInfoStatus = string;
+        export type VolumeStatusList = VolumeStatusItem[];
+        export type VolumeStatusName = string;
+        export type VolumeType = string;
+        export type VpcAttachmentList = VpcAttachment[];
+        export type VpcAttributeName = string;
+        export type VpcClassicLinkIdList = String[];
+        export type VpcClassicLinkList = VpcClassicLink[];
+        export type VpcEndpointSet = VpcEndpoint[];
+        export type VpcIdStringList = String[];
+        export type VpcList = Vpc[];
+        export type VpcPeeringConnectionList = VpcPeeringConnection[];
+        export type VpcPeeringConnectionStateReasonCode = string;
+        export type VpcState = string;
+        export type VpnConnectionIdStringList = String[];
+        export type VpnConnectionList = VpnConnection[];
+        export type VpnGatewayIdStringList = String[];
+        export type VpnGatewayList = VpnGateway[];
+        export type VpnState = string;
+        export type VpnStaticRouteList = VpnStaticRoute[];
+        export type VpnStaticRouteSource = string;
+        export type ZoneNameStringList = String[];
+
+        export interface AcceptVpcPeeringConnectionRequest {
+            DryRun?: Boolean;            
+            VpcPeeringConnectionId?: String;            
+        }
+        export interface AcceptVpcPeeringConnectionResult {
+            VpcPeeringConnection?: VpcPeeringConnection;            
+        }
+        export interface AccountAttribute {
+            AttributeName?: String;            
+            AttributeValues?: AccountAttributeValueList;            
+        }
+        export interface AccountAttributeValue {
+            AttributeValue?: String;            
+        }
+        export interface ActiveInstance {
+            InstanceType?: String;            
+            InstanceId?: String;            
+            SpotInstanceRequestId?: String;            
+        }
+        export interface Address {
+            InstanceId?: String;            
+            PublicIp?: String;            
+            AllocationId?: String;            
+            AssociationId?: String;            
+            Domain?: DomainType;            
+            NetworkInterfaceId?: String;            
+            NetworkInterfaceOwnerId?: String;            
+            PrivateIpAddress?: String;            
+        }
+        export interface AllocateAddressRequest {
+            DryRun?: Boolean;            
+            Domain?: DomainType;            
+        }
+        export interface AllocateAddressResult {
+            PublicIp?: String;            
+            Domain?: DomainType;            
+            AllocationId?: String;            
+        }
+        export interface AllocateHostsRequest {
+            AutoPlacement?: AutoPlacement;            
+            ClientToken?: String;            
+            InstanceType: String;            
+            Quantity: Integer;            
+            AvailabilityZone: String;            
+        }
+        export interface AllocateHostsResult {
+            HostIds?: ResponseHostIdList;            
+        }
+        export interface AssignPrivateIpAddressesRequest {
+            NetworkInterfaceId: String;            
+            PrivateIpAddresses?: PrivateIpAddressStringList;            
+            SecondaryPrivateIpAddressCount?: Integer;            
+            AllowReassignment?: Boolean;            
+        }
+        export interface AssociateAddressRequest {
+            DryRun?: Boolean;            
+            InstanceId?: String;            
+            PublicIp?: String;            
+            AllocationId?: String;            
+            NetworkInterfaceId?: String;            
+            PrivateIpAddress?: String;            
+            AllowReassociation?: Boolean;            
+        }
+        export interface AssociateAddressResult {
+            AssociationId?: String;            
+        }
+        export interface AssociateDhcpOptionsRequest {
+            DryRun?: Boolean;            
+            DhcpOptionsId: String;            
+            VpcId: String;            
+        }
+        export interface AssociateRouteTableRequest {
+            DryRun?: Boolean;            
+            SubnetId: String;            
+            RouteTableId: String;            
+        }
+        export interface AssociateRouteTableResult {
+            AssociationId?: String;            
+        }
+        export interface AttachClassicLinkVpcRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            VpcId: String;            
+            Groups: GroupIdStringList;            
+        }
+        export interface AttachClassicLinkVpcResult {
+            Return?: Boolean;            
+        }
+        export interface AttachInternetGatewayRequest {
+            DryRun?: Boolean;            
+            InternetGatewayId: String;            
+            VpcId: String;            
+        }
+        export interface AttachNetworkInterfaceRequest {
+            DryRun?: Boolean;            
+            NetworkInterfaceId: String;            
+            InstanceId: String;            
+            DeviceIndex: Integer;            
+        }
+        export interface AttachNetworkInterfaceResult {
+            AttachmentId?: String;            
+        }
+        export interface AttachVolumeRequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+            InstanceId: String;            
+            Device: String;            
+        }
+        export interface AttachVpnGatewayRequest {
+            DryRun?: Boolean;            
+            VpnGatewayId: String;            
+            VpcId: String;            
+        }
+        export interface AttachVpnGatewayResult {
+            VpcAttachment?: VpcAttachment;            
+        }
+        export interface AttributeBooleanValue {
+            Value?: Boolean;            
+        }
+        export interface AttributeValue {
+            Value?: String;            
+        }
+        export interface AuthorizeSecurityGroupEgressRequest {
+            DryRun?: Boolean;            
+            GroupId: String;            
+            SourceSecurityGroupName?: String;            
+            SourceSecurityGroupOwnerId?: String;            
+            IpProtocol?: String;            
+            FromPort?: Integer;            
+            ToPort?: Integer;            
+            CidrIp?: String;            
+            IpPermissions?: IpPermissionList;            
+        }
+        export interface AuthorizeSecurityGroupIngressRequest {
+            DryRun?: Boolean;            
+            GroupName?: String;            
+            GroupId?: String;            
+            SourceSecurityGroupName?: String;            
+            SourceSecurityGroupOwnerId?: String;            
+            IpProtocol?: String;            
+            FromPort?: Integer;            
+            ToPort?: Integer;            
+            CidrIp?: String;            
+            IpPermissions?: IpPermissionList;            
+        }
+        export interface AvailabilityZone {
+            ZoneName?: String;            
+            State?: AvailabilityZoneState;            
+            RegionName?: String;            
+            Messages?: AvailabilityZoneMessageList;            
+        }
+        export interface AvailabilityZoneMessage {
+            Message?: String;            
+        }
+        export interface AvailableCapacity {
+            AvailableInstanceCapacity?: AvailableInstanceCapacityList;            
+            AvailableVCpus?: Integer;            
+        }
+        export interface BlobAttributeValue {
+            Value?: Blob;            
+        }
+        export interface BlockDeviceMapping {
+            VirtualName?: String;            
+            DeviceName?: String;            
+            Ebs?: EbsBlockDevice;            
+            NoDevice?: String;            
+        }
+        export interface BundleInstanceRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            Storage: Storage;            
+        }
+        export interface BundleInstanceResult {
+            BundleTask?: BundleTask;            
+        }
+        export interface BundleTask {
+            InstanceId?: String;            
+            BundleId?: String;            
+            State?: BundleTaskState;            
+            StartTime?: DateTime;            
+            UpdateTime?: DateTime;            
+            Storage?: Storage;            
+            Progress?: String;            
+            BundleTaskError?: BundleTaskError;            
+        }
+        export interface BundleTaskError {
+            Code?: String;            
+            Message?: String;            
+        }
+        export interface CancelBundleTaskRequest {
+            DryRun?: Boolean;            
+            BundleId: String;            
+        }
+        export interface CancelBundleTaskResult {
+            BundleTask?: BundleTask;            
+        }
+        export interface CancelConversionRequest {
+            DryRun?: Boolean;            
+            ConversionTaskId: String;            
+            ReasonMessage?: String;            
+        }
+        export interface CancelExportTaskRequest {
+            ExportTaskId: String;            
+        }
+        export interface CancelImportTaskRequest {
+            DryRun?: Boolean;            
+            ImportTaskId?: String;            
+            CancelReason?: String;            
+        }
+        export interface CancelImportTaskResult {
+            ImportTaskId?: String;            
+            State?: String;            
+            PreviousState?: String;            
+        }
+        export interface CancelReservedInstancesListingRequest {
+            ReservedInstancesListingId: String;            
+        }
+        export interface CancelReservedInstancesListingResult {
+            ReservedInstancesListings?: ReservedInstancesListingList;            
+        }
+        export interface CancelSpotFleetRequestsError {
+            Code: CancelBatchErrorCode;            
+            Message: String;            
+        }
+        export interface CancelSpotFleetRequestsErrorItem {
+            SpotFleetRequestId: String;            
+            Error: CancelSpotFleetRequestsError;            
+        }
+        export interface CancelSpotFleetRequestsRequest {
+            DryRun?: Boolean;            
+            SpotFleetRequestIds: ValueStringList;            
+            TerminateInstances: Boolean;            
+        }
+        export interface CancelSpotFleetRequestsResponse {
+            UnsuccessfulFleetRequests?: CancelSpotFleetRequestsErrorSet;            
+            SuccessfulFleetRequests?: CancelSpotFleetRequestsSuccessSet;            
+        }
+        export interface CancelSpotFleetRequestsSuccessItem {
+            SpotFleetRequestId: String;            
+            CurrentSpotFleetRequestState: BatchState;            
+            PreviousSpotFleetRequestState: BatchState;            
+        }
+        export interface CancelSpotInstanceRequestsRequest {
+            DryRun?: Boolean;            
+            SpotInstanceRequestIds: SpotInstanceRequestIdList;            
+        }
+        export interface CancelSpotInstanceRequestsResult {
+            CancelledSpotInstanceRequests?: CancelledSpotInstanceRequestList;            
+        }
+        export interface CancelledSpotInstanceRequest {
+            SpotInstanceRequestId?: String;            
+            State?: CancelSpotInstanceRequestState;            
+        }
+        export interface ClassicLinkInstance {
+            InstanceId?: String;            
+            VpcId?: String;            
+            Groups?: GroupIdentifierList;            
+            Tags?: TagList;            
+        }
+        export interface ClientData {
+            UploadStart?: DateTime;            
+            UploadEnd?: DateTime;            
+            UploadSize?: Double;            
+            Comment?: String;            
+        }
+        export interface ConfirmProductInstanceRequest {
+            DryRun?: Boolean;            
+            ProductCode: String;            
+            InstanceId: String;            
+        }
+        export interface ConfirmProductInstanceResult {
+            OwnerId?: String;            
+            Return?: Boolean;            
+        }
+        export interface ConversionTask {
+            ConversionTaskId: String;            
+            ExpirationTime?: String;            
+            ImportInstance?: ImportInstanceTaskDetails;            
+            ImportVolume?: ImportVolumeTaskDetails;            
+            State: ConversionTaskState;            
+            StatusMessage?: String;            
+            Tags?: TagList;            
+        }
+        export interface CopyImageRequest {
+            DryRun?: Boolean;            
+            SourceRegion: String;            
+            SourceImageId: String;            
+            Name: String;            
+            Description?: String;            
+            ClientToken?: String;            
+        }
+        export interface CopyImageResult {
+            ImageId?: String;            
+        }
+        export interface CopySnapshotRequest {
+            DryRun?: Boolean;            
+            SourceRegion: String;            
+            SourceSnapshotId: String;            
+            Description?: String;            
+            DestinationRegion?: String;            
+            PresignedUrl?: String;            
+            Encrypted?: Boolean;            
+            KmsKeyId?: String;            
+        }
+        export interface CopySnapshotResult {
+            SnapshotId?: String;            
+        }
+        export interface CreateCustomerGatewayRequest {
+            DryRun?: Boolean;            
+            Type: GatewayType;            
+            PublicIp: String;            
+            BgpAsn: Integer;            
+        }
+        export interface CreateCustomerGatewayResult {
+            CustomerGateway?: CustomerGateway;            
+        }
+        export interface CreateDhcpOptionsRequest {
+            DryRun?: Boolean;            
+            DhcpConfigurations: NewDhcpConfigurationList;            
+        }
+        export interface CreateDhcpOptionsResult {
+            DhcpOptions?: DhcpOptions;            
+        }
+        export interface CreateFlowLogsRequest {
+            ResourceIds: ValueStringList;            
+            ResourceType: FlowLogsResourceType;            
+            TrafficType: TrafficType;            
+            LogGroupName: String;            
+            DeliverLogsPermissionArn: String;            
+            ClientToken?: String;            
+        }
+        export interface CreateFlowLogsResult {
+            FlowLogIds?: ValueStringList;            
+            ClientToken?: String;            
+            Unsuccessful?: UnsuccessfulItemSet;            
+        }
+        export interface CreateImageRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            Name: String;            
+            Description?: String;            
+            NoReboot?: Boolean;            
+            BlockDeviceMappings?: BlockDeviceMappingRequestList;            
+        }
+        export interface CreateImageResult {
+            ImageId?: String;            
+        }
+        export interface CreateInstanceExportTaskRequest {
+            Description?: String;            
+            InstanceId: String;            
+            TargetEnvironment?: ExportEnvironment;            
+            ExportToS3Task?: ExportToS3TaskSpecification;            
+        }
+        export interface CreateInstanceExportTaskResult {
+            ExportTask?: ExportTask;            
+        }
+        export interface CreateInternetGatewayRequest {
+            DryRun?: Boolean;            
+        }
+        export interface CreateInternetGatewayResult {
+            InternetGateway?: InternetGateway;            
+        }
+        export interface CreateKeyPairRequest {
+            DryRun?: Boolean;            
+            KeyName: String;            
+        }
+        export interface CreateNetworkAclEntryRequest {
+            DryRun?: Boolean;            
+            NetworkAclId: String;            
+            RuleNumber: Integer;            
+            Protocol: String;            
+            RuleAction: RuleAction;            
+            Egress: Boolean;            
+            CidrBlock: String;            
+            IcmpTypeCode?: IcmpTypeCode;            
+            PortRange?: PortRange;            
+        }
+        export interface CreateNetworkAclRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+        }
+        export interface CreateNetworkAclResult {
+            NetworkAcl?: NetworkAcl;            
+        }
+        export interface CreateNetworkInterfaceRequest {
+            SubnetId: String;            
+            Description?: String;            
+            PrivateIpAddress?: String;            
+            Groups?: SecurityGroupIdStringList;            
+            PrivateIpAddresses?: PrivateIpAddressSpecificationList;            
+            SecondaryPrivateIpAddressCount?: Integer;            
+            DryRun?: Boolean;            
+        }
+        export interface CreateNetworkInterfaceResult {
+            NetworkInterface?: NetworkInterface;            
+        }
+        export interface CreatePlacementGroupRequest {
+            DryRun?: Boolean;            
+            GroupName: String;            
+            Strategy: PlacementStrategy;            
+        }
+        export interface CreateReservedInstancesListingRequest {
+            ReservedInstancesId: String;            
+            InstanceCount: Integer;            
+            PriceSchedules: PriceScheduleSpecificationList;            
+            ClientToken: String;            
+        }
+        export interface CreateReservedInstancesListingResult {
+            ReservedInstancesListings?: ReservedInstancesListingList;            
+        }
+        export interface CreateRouteRequest {
+            DryRun?: Boolean;            
+            RouteTableId: String;            
+            DestinationCidrBlock: String;            
+            GatewayId?: String;            
+            InstanceId?: String;            
+            NetworkInterfaceId?: String;            
+            VpcPeeringConnectionId?: String;            
+        }
+        export interface CreateRouteResult {
+            Return?: Boolean;            
+        }
+        export interface CreateRouteTableRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+        }
+        export interface CreateRouteTableResult {
+            RouteTable?: RouteTable;            
+        }
+        export interface CreateSecurityGroupRequest {
+            DryRun?: Boolean;            
+            GroupName: String;            
+            Description: String;            
+            VpcId?: String;            
+        }
+        export interface CreateSecurityGroupResult {
+            GroupId?: String;            
+        }
+        export interface CreateSnapshotRequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+            Description?: String;            
+        }
+        export interface CreateSpotDatafeedSubscriptionRequest {
+            DryRun?: Boolean;            
+            Bucket: String;            
+            Prefix?: String;            
+        }
+        export interface CreateSpotDatafeedSubscriptionResult {
+            SpotDatafeedSubscription?: SpotDatafeedSubscription;            
+        }
+        export interface CreateSubnetRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+            CidrBlock: String;            
+            AvailabilityZone?: String;            
+        }
+        export interface CreateSubnetResult {
+            Subnet?: Subnet;            
+        }
+        export interface CreateTagsRequest {
+            DryRun?: Boolean;            
+            Resources: ResourceIdList;            
+            Tags: TagList;            
+        }
+        export interface CreateVolumePermission {
+            UserId?: String;            
+            Group?: PermissionGroup;            
+        }
+        export interface CreateVolumePermissionModifications {
+            Add?: CreateVolumePermissionList;            
+            Remove?: CreateVolumePermissionList;            
+        }
+        export interface CreateVolumeRequest {
+            DryRun?: Boolean;            
+            Size?: Integer;            
+            SnapshotId?: String;            
+            AvailabilityZone: String;            
+            VolumeType?: VolumeType;            
+            Iops?: Integer;            
+            Encrypted?: Boolean;            
+            KmsKeyId?: String;            
+        }
+        export interface CreateVpcEndpointRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+            ServiceName: String;            
+            PolicyDocument?: String;            
+            RouteTableIds?: ValueStringList;            
+            ClientToken?: String;            
+        }
+        export interface CreateVpcEndpointResult {
+            VpcEndpoint?: VpcEndpoint;            
+            ClientToken?: String;            
+        }
+        export interface CreateVpcPeeringConnectionRequest {
+            DryRun?: Boolean;            
+            VpcId?: String;            
+            PeerVpcId?: String;            
+            PeerOwnerId?: String;            
+        }
+        export interface CreateVpcPeeringConnectionResult {
+            VpcPeeringConnection?: VpcPeeringConnection;            
+        }
+        export interface CreateVpcRequest {
+            DryRun?: Boolean;            
+            CidrBlock: String;            
+            InstanceTenancy?: Tenancy;            
+        }
+        export interface CreateVpcResult {
+            Vpc?: Vpc;            
+        }
+        export interface CreateVpnConnectionRequest {
+            DryRun?: Boolean;            
+            Type: String;            
+            CustomerGatewayId: String;            
+            VpnGatewayId: String;            
+            Options?: VpnConnectionOptionsSpecification;            
+        }
+        export interface CreateVpnConnectionResult {
+            VpnConnection?: VpnConnection;            
+        }
+        export interface CreateVpnConnectionRouteRequest {
+            VpnConnectionId: String;            
+            DestinationCidrBlock: String;            
+        }
+        export interface CreateVpnGatewayRequest {
+            DryRun?: Boolean;            
+            Type: GatewayType;            
+            AvailabilityZone?: String;            
+        }
+        export interface CreateVpnGatewayResult {
+            VpnGateway?: VpnGateway;            
+        }
+        export interface CustomerGateway {
+            CustomerGatewayId?: String;            
+            State?: String;            
+            Type?: String;            
+            IpAddress?: String;            
+            BgpAsn?: String;            
+            Tags?: TagList;            
+        }
+        export interface DeleteCustomerGatewayRequest {
+            DryRun?: Boolean;            
+            CustomerGatewayId: String;            
+        }
+        export interface DeleteDhcpOptionsRequest {
+            DryRun?: Boolean;            
+            DhcpOptionsId: String;            
+        }
+        export interface DeleteFlowLogsRequest {
+            FlowLogIds: ValueStringList;            
+        }
+        export interface DeleteFlowLogsResult {
+            Unsuccessful?: UnsuccessfulItemSet;            
+        }
+        export interface DeleteInternetGatewayRequest {
+            DryRun?: Boolean;            
+            InternetGatewayId: String;            
+        }
+        export interface DeleteKeyPairRequest {
+            DryRun?: Boolean;            
+            KeyName: String;            
+        }
+        export interface DeleteNetworkAclEntryRequest {
+            DryRun?: Boolean;            
+            NetworkAclId: String;            
+            RuleNumber: Integer;            
+            Egress: Boolean;            
+        }
+        export interface DeleteNetworkAclRequest {
+            DryRun?: Boolean;            
+            NetworkAclId: String;            
+        }
+        export interface DeleteNetworkInterfaceRequest {
+            DryRun?: Boolean;            
+            NetworkInterfaceId: String;            
+        }
+        export interface DeletePlacementGroupRequest {
+            DryRun?: Boolean;            
+            GroupName: String;            
+        }
+        export interface DeleteRouteRequest {
+            DryRun?: Boolean;            
+            RouteTableId: String;            
+            DestinationCidrBlock: String;            
+        }
+        export interface DeleteRouteTableRequest {
+            DryRun?: Boolean;            
+            RouteTableId: String;            
+        }
+        export interface DeleteSecurityGroupRequest {
+            DryRun?: Boolean;            
+            GroupName?: String;            
+            GroupId?: String;            
+        }
+        export interface DeleteSnapshotRequest {
+            DryRun?: Boolean;            
+            SnapshotId: String;            
+        }
+        export interface DeleteSpotDatafeedSubscriptionRequest {
+            DryRun?: Boolean;            
+        }
+        export interface DeleteSubnetRequest {
+            DryRun?: Boolean;            
+            SubnetId: String;            
+        }
+        export interface DeleteTagsRequest {
+            DryRun?: Boolean;            
+            Resources: ResourceIdList;            
+            Tags?: TagList;            
+        }
+        export interface DeleteVolumeRequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+        }
+        export interface DeleteVpcEndpointsRequest {
+            DryRun?: Boolean;            
+            VpcEndpointIds: ValueStringList;            
+        }
+        export interface DeleteVpcEndpointsResult {
+            Unsuccessful?: UnsuccessfulItemSet;            
+        }
+        export interface DeleteVpcPeeringConnectionRequest {
+            DryRun?: Boolean;            
+            VpcPeeringConnectionId: String;            
+        }
+        export interface DeleteVpcPeeringConnectionResult {
+            Return?: Boolean;            
+        }
+        export interface DeleteVpcRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+        }
+        export interface DeleteVpnConnectionRequest {
+            DryRun?: Boolean;            
+            VpnConnectionId: String;            
+        }
+        export interface DeleteVpnConnectionRouteRequest {
+            VpnConnectionId: String;            
+            DestinationCidrBlock: String;            
+        }
+        export interface DeleteVpnGatewayRequest {
+            DryRun?: Boolean;            
+            VpnGatewayId: String;            
+        }
+        export interface DeregisterImageRequest {
+            DryRun?: Boolean;            
+            ImageId: String;            
+        }
+        export interface DescribeAccountAttributesRequest {
+            DryRun?: Boolean;            
+            AttributeNames?: AccountAttributeNameStringList;            
+        }
+        export interface DescribeAccountAttributesResult {
+            AccountAttributes?: AccountAttributeList;            
+        }
+        export interface DescribeAddressesRequest {
+            DryRun?: Boolean;            
+            PublicIps?: PublicIpStringList;            
+            Filters?: FilterList;            
+            AllocationIds?: AllocationIdList;            
+        }
+        export interface DescribeAddressesResult {
+            Addresses?: AddressList;            
+        }
+        export interface DescribeAvailabilityZonesRequest {
+            DryRun?: Boolean;            
+            ZoneNames?: ZoneNameStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeAvailabilityZonesResult {
+            AvailabilityZones?: AvailabilityZoneList;            
+        }
+        export interface DescribeBundleTasksRequest {
+            DryRun?: Boolean;            
+            BundleIds?: BundleIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeBundleTasksResult {
+            BundleTasks?: BundleTaskList;            
+        }
+        export interface DescribeClassicLinkInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds?: InstanceIdStringList;            
+            Filters?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeClassicLinkInstancesResult {
+            Instances?: ClassicLinkInstanceList;            
+            NextToken?: String;            
+        }
+        export interface DescribeConversionTasksRequest {
+            DryRun?: Boolean;            
+            Filters?: FilterList;            
+            ConversionTaskIds?: ConversionIdStringList;            
+        }
+        export interface DescribeConversionTasksResult {
+            ConversionTasks?: DescribeConversionTaskList;            
+        }
+        export interface DescribeCustomerGatewaysRequest {
+            DryRun?: Boolean;            
+            CustomerGatewayIds?: CustomerGatewayIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeCustomerGatewaysResult {
+            CustomerGateways?: CustomerGatewayList;            
+        }
+        export interface DescribeDhcpOptionsRequest {
+            DryRun?: Boolean;            
+            DhcpOptionsIds?: DhcpOptionsIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeDhcpOptionsResult {
+            DhcpOptions?: DhcpOptionsList;            
+        }
+        export interface DescribeExportTasksRequest {
+            ExportTaskIds?: ExportTaskIdStringList;            
+        }
+        export interface DescribeExportTasksResult {
+            ExportTasks?: ExportTaskList;            
+        }
+        export interface DescribeFlowLogsRequest {
+            FlowLogIds?: ValueStringList;            
+            Filter?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeFlowLogsResult {
+            FlowLogs?: FlowLogSet;            
+            NextToken?: String;            
+        }
+        export interface DescribeHostsRequest {
+            HostIds?: RequestHostIdList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+            Filter?: FilterList;            
+        }
+        export interface DescribeHostsResult {
+            Hosts?: HostList;            
+            NextToken?: String;            
+        }
+        export interface DescribeIdFormatRequest {
+            Resource?: String;            
+        }
+        export interface DescribeIdFormatResult {
+            Statuses?: IdFormatList;            
+        }
+        export interface DescribeImageAttributeRequest {
+            DryRun?: Boolean;            
+            ImageId: String;            
+            Attribute: ImageAttributeName;            
+        }
+        export interface DescribeImagesRequest {
+            DryRun?: Boolean;            
+            ImageIds?: ImageIdStringList;            
+            Owners?: OwnerStringList;            
+            ExecutableUsers?: ExecutableByStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeImagesResult {
+            Images?: ImageList;            
+        }
+        export interface DescribeImportImageTasksRequest {
+            DryRun?: Boolean;            
+            ImportTaskIds?: ImportTaskIdList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeImportImageTasksResult {
+            ImportImageTasks?: ImportImageTaskList;            
+            NextToken?: String;            
+        }
+        export interface DescribeImportSnapshotTasksRequest {
+            DryRun?: Boolean;            
+            ImportTaskIds?: ImportTaskIdList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeImportSnapshotTasksResult {
+            ImportSnapshotTasks?: ImportSnapshotTaskList;            
+            NextToken?: String;            
+        }
+        export interface DescribeInstanceAttributeRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            Attribute: InstanceAttributeName;            
+        }
+        export interface DescribeInstanceStatusRequest {
+            DryRun?: Boolean;            
+            InstanceIds?: InstanceIdStringList;            
+            Filters?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+            IncludeAllInstances?: Boolean;            
+        }
+        export interface DescribeInstanceStatusResult {
+            InstanceStatuses?: InstanceStatusList;            
+            NextToken?: String;            
+        }
+        export interface DescribeInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds?: InstanceIdStringList;            
+            Filters?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeInstancesResult {
+            Reservations?: ReservationList;            
+            NextToken?: String;            
+        }
+        export interface DescribeInternetGatewaysRequest {
+            DryRun?: Boolean;            
+            InternetGatewayIds?: ValueStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeInternetGatewaysResult {
+            InternetGateways?: InternetGatewayList;            
+        }
+        export interface DescribeKeyPairsRequest {
+            DryRun?: Boolean;            
+            KeyNames?: KeyNameStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeKeyPairsResult {
+            KeyPairs?: KeyPairList;            
+        }
+        export interface DescribeMovingAddressesRequest {
+            DryRun?: Boolean;            
+            PublicIps?: ValueStringList;            
+            NextToken?: String;            
+            Filters?: FilterList;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeMovingAddressesResult {
+            MovingAddressStatuses?: MovingAddressStatusSet;            
+            NextToken?: String;            
+        }
+        export interface DescribeNetworkAclsRequest {
+            DryRun?: Boolean;            
+            NetworkAclIds?: ValueStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeNetworkAclsResult {
+            NetworkAcls?: NetworkAclList;            
+        }
+        export interface DescribeNetworkInterfaceAttributeRequest {
+            DryRun?: Boolean;            
+            NetworkInterfaceId: String;            
+            Attribute?: NetworkInterfaceAttribute;            
+        }
+        export interface DescribeNetworkInterfaceAttributeResult {
+            NetworkInterfaceId?: String;            
+            Description?: AttributeValue;            
+            SourceDestCheck?: AttributeBooleanValue;            
+            Groups?: GroupIdentifierList;            
+            Attachment?: NetworkInterfaceAttachment;            
+        }
+        export interface DescribeNetworkInterfacesRequest {
+            DryRun?: Boolean;            
+            NetworkInterfaceIds?: NetworkInterfaceIdList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeNetworkInterfacesResult {
+            NetworkInterfaces?: NetworkInterfaceList;            
+        }
+        export interface DescribePlacementGroupsRequest {
+            DryRun?: Boolean;            
+            GroupNames?: PlacementGroupStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribePlacementGroupsResult {
+            PlacementGroups?: PlacementGroupList;            
+        }
+        export interface DescribePrefixListsRequest {
+            DryRun?: Boolean;            
+            PrefixListIds?: ValueStringList;            
+            Filters?: FilterList;            
+            MaxResults?: Integer;            
+            NextToken?: String;            
+        }
+        export interface DescribePrefixListsResult {
+            PrefixLists?: PrefixListSet;            
+            NextToken?: String;            
+        }
+        export interface DescribeRegionsRequest {
+            DryRun?: Boolean;            
+            RegionNames?: RegionNameStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeRegionsResult {
+            Regions?: RegionList;            
+        }
+        export interface DescribeReservedInstancesListingsRequest {
+            ReservedInstancesId?: String;            
+            ReservedInstancesListingId?: String;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeReservedInstancesListingsResult {
+            ReservedInstancesListings?: ReservedInstancesListingList;            
+        }
+        export interface DescribeReservedInstancesModificationsRequest {
+            ReservedInstancesModificationIds?: ReservedInstancesModificationIdStringList;            
+            NextToken?: String;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeReservedInstancesModificationsResult {
+            ReservedInstancesModifications?: ReservedInstancesModificationList;            
+            NextToken?: String;            
+        }
+        export interface DescribeReservedInstancesOfferingsRequest {
+            DryRun?: Boolean;            
+            ReservedInstancesOfferingIds?: ReservedInstancesOfferingIdStringList;            
+            InstanceType?: InstanceType;            
+            AvailabilityZone?: String;            
+            ProductDescription?: RIProductDescription;            
+            Filters?: FilterList;            
+            InstanceTenancy?: Tenancy;            
+            OfferingType?: OfferingTypeValues;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+            IncludeMarketplace?: Boolean;            
+            MinDuration?: Long;            
+            MaxDuration?: Long;            
+            MaxInstanceCount?: Integer;            
+        }
+        export interface DescribeReservedInstancesOfferingsResult {
+            ReservedInstancesOfferings?: ReservedInstancesOfferingList;            
+            NextToken?: String;            
+        }
+        export interface DescribeReservedInstancesRequest {
+            DryRun?: Boolean;            
+            ReservedInstancesIds?: ReservedInstancesIdStringList;            
+            Filters?: FilterList;            
+            OfferingType?: OfferingTypeValues;            
+        }
+        export interface DescribeReservedInstancesResult {
+            ReservedInstances?: ReservedInstancesList;            
+        }
+        export interface DescribeRouteTablesRequest {
+            DryRun?: Boolean;            
+            RouteTableIds?: ValueStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeRouteTablesResult {
+            RouteTables?: RouteTableList;            
+        }
+        export interface DescribeSecurityGroupsRequest {
+            DryRun?: Boolean;            
+            GroupNames?: GroupNameStringList;            
+            GroupIds?: GroupIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeSecurityGroupsResult {
+            SecurityGroups?: SecurityGroupList;            
+        }
+        export interface DescribeSnapshotAttributeRequest {
+            DryRun?: Boolean;            
+            SnapshotId: String;            
+            Attribute: SnapshotAttributeName;            
+        }
+        export interface DescribeSnapshotAttributeResult {
+            SnapshotId?: String;            
+            CreateVolumePermissions?: CreateVolumePermissionList;            
+            ProductCodes?: ProductCodeList;            
+        }
+        export interface DescribeSnapshotsRequest {
+            DryRun?: Boolean;            
+            SnapshotIds?: SnapshotIdStringList;            
+            OwnerIds?: OwnerStringList;            
+            RestorableByUserIds?: RestorableByStringList;            
+            Filters?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeSnapshotsResult {
+            Snapshots?: SnapshotList;            
+            NextToken?: String;            
+        }
+        export interface DescribeSpotDatafeedSubscriptionRequest {
+            DryRun?: Boolean;            
+        }
+        export interface DescribeSpotDatafeedSubscriptionResult {
+            SpotDatafeedSubscription?: SpotDatafeedSubscription;            
+        }
+        export interface DescribeSpotFleetInstancesRequest {
+            DryRun?: Boolean;            
+            SpotFleetRequestId: String;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeSpotFleetInstancesResponse {
+            SpotFleetRequestId: String;            
+            ActiveInstances: ActiveInstanceSet;            
+            NextToken?: String;            
+        }
+        export interface DescribeSpotFleetRequestHistoryRequest {
+            DryRun?: Boolean;            
+            SpotFleetRequestId: String;            
+            EventType?: EventType;            
+            StartTime: DateTime;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeSpotFleetRequestHistoryResponse {
+            SpotFleetRequestId: String;            
+            StartTime: DateTime;            
+            LastEvaluatedTime: DateTime;            
+            HistoryRecords: HistoryRecords;            
+            NextToken?: String;            
+        }
+        export interface DescribeSpotFleetRequestsRequest {
+            DryRun?: Boolean;            
+            SpotFleetRequestIds?: ValueStringList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeSpotFleetRequestsResponse {
+            SpotFleetRequestConfigs: SpotFleetRequestConfigSet;            
+            NextToken?: String;            
+        }
+        export interface DescribeSpotInstanceRequestsRequest {
+            DryRun?: Boolean;            
+            SpotInstanceRequestIds?: SpotInstanceRequestIdList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeSpotInstanceRequestsResult {
+            SpotInstanceRequests?: SpotInstanceRequestList;            
+        }
+        export interface DescribeSpotPriceHistoryRequest {
+            DryRun?: Boolean;            
+            StartTime?: DateTime;            
+            EndTime?: DateTime;            
+            InstanceTypes?: InstanceTypeList;            
+            ProductDescriptions?: ProductDescriptionList;            
+            Filters?: FilterList;            
+            AvailabilityZone?: String;            
+            MaxResults?: Integer;            
+            NextToken?: String;            
+        }
+        export interface DescribeSpotPriceHistoryResult {
+            SpotPriceHistory?: SpotPriceHistoryList;            
+            NextToken?: String;            
+        }
+        export interface DescribeSubnetsRequest {
+            DryRun?: Boolean;            
+            SubnetIds?: SubnetIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeSubnetsResult {
+            Subnets?: SubnetList;            
+        }
+        export interface DescribeTagsRequest {
+            DryRun?: Boolean;            
+            Filters?: FilterList;            
+            MaxResults?: Integer;            
+            NextToken?: String;            
+        }
+        export interface DescribeTagsResult {
+            Tags?: TagDescriptionList;            
+            NextToken?: String;            
+        }
+        export interface DescribeVolumeAttributeRequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+            Attribute?: VolumeAttributeName;            
+        }
+        export interface DescribeVolumeAttributeResult {
+            VolumeId?: String;            
+            AutoEnableIO?: AttributeBooleanValue;            
+            ProductCodes?: ProductCodeList;            
+        }
+        export interface DescribeVolumeStatusRequest {
+            DryRun?: Boolean;            
+            VolumeIds?: VolumeIdStringList;            
+            Filters?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeVolumeStatusResult {
+            VolumeStatuses?: VolumeStatusList;            
+            NextToken?: String;            
+        }
+        export interface DescribeVolumesRequest {
+            DryRun?: Boolean;            
+            VolumeIds?: VolumeIdStringList;            
+            Filters?: FilterList;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeVolumesResult {
+            Volumes?: VolumeList;            
+            NextToken?: String;            
+        }
+        export interface DescribeVpcAttributeRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+            Attribute?: VpcAttributeName;            
+        }
+        export interface DescribeVpcAttributeResult {
+            VpcId?: String;            
+            EnableDnsSupport?: AttributeBooleanValue;            
+            EnableDnsHostnames?: AttributeBooleanValue;            
+        }
+        export interface DescribeVpcClassicLinkRequest {
+            DryRun?: Boolean;            
+            VpcIds?: VpcClassicLinkIdList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeVpcClassicLinkResult {
+            Vpcs?: VpcClassicLinkList;            
+        }
+        export interface DescribeVpcEndpointServicesRequest {
+            DryRun?: Boolean;            
+            MaxResults?: Integer;            
+            NextToken?: String;            
+        }
+        export interface DescribeVpcEndpointServicesResult {
+            ServiceNames?: ValueStringList;            
+            NextToken?: String;            
+        }
+        export interface DescribeVpcEndpointsRequest {
+            DryRun?: Boolean;            
+            VpcEndpointIds?: ValueStringList;            
+            Filters?: FilterList;            
+            MaxResults?: Integer;            
+            NextToken?: String;            
+        }
+        export interface DescribeVpcEndpointsResult {
+            VpcEndpoints?: VpcEndpointSet;            
+            NextToken?: String;            
+        }
+        export interface DescribeVpcPeeringConnectionsRequest {
+            DryRun?: Boolean;            
+            VpcPeeringConnectionIds?: ValueStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeVpcPeeringConnectionsResult {
+            VpcPeeringConnections?: VpcPeeringConnectionList;            
+        }
+        export interface DescribeVpcsRequest {
+            DryRun?: Boolean;            
+            VpcIds?: VpcIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeVpcsResult {
+            Vpcs?: VpcList;            
+        }
+        export interface DescribeVpnConnectionsRequest {
+            DryRun?: Boolean;            
+            VpnConnectionIds?: VpnConnectionIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeVpnConnectionsResult {
+            VpnConnections?: VpnConnectionList;            
+        }
+        export interface DescribeVpnGatewaysRequest {
+            DryRun?: Boolean;            
+            VpnGatewayIds?: VpnGatewayIdStringList;            
+            Filters?: FilterList;            
+        }
+        export interface DescribeVpnGatewaysResult {
+            VpnGateways?: VpnGatewayList;            
+        }
+        export interface DetachClassicLinkVpcRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            VpcId: String;            
+        }
+        export interface DetachClassicLinkVpcResult {
+            Return?: Boolean;            
+        }
+        export interface DetachInternetGatewayRequest {
+            DryRun?: Boolean;            
+            InternetGatewayId: String;            
+            VpcId: String;            
+        }
+        export interface DetachNetworkInterfaceRequest {
+            DryRun?: Boolean;            
+            AttachmentId: String;            
+            Force?: Boolean;            
+        }
+        export interface DetachVolumeRequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+            InstanceId?: String;            
+            Device?: String;            
+            Force?: Boolean;            
+        }
+        export interface DetachVpnGatewayRequest {
+            DryRun?: Boolean;            
+            VpnGatewayId: String;            
+            VpcId: String;            
+        }
+        export interface DhcpConfiguration {
+            Key?: String;            
+            Values?: DhcpConfigurationValueList;            
+        }
+        export interface DhcpOptions {
+            DhcpOptionsId?: String;            
+            DhcpConfigurations?: DhcpConfigurationList;            
+            Tags?: TagList;            
+        }
+        export interface DisableVgwRoutePropagationRequest {
+            RouteTableId: String;            
+            GatewayId: String;            
+        }
+        export interface DisableVpcClassicLinkRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+        }
+        export interface DisableVpcClassicLinkResult {
+            Return?: Boolean;            
+        }
+        export interface DisassociateAddressRequest {
+            DryRun?: Boolean;            
+            PublicIp?: String;            
+            AssociationId?: String;            
+        }
+        export interface DisassociateRouteTableRequest {
+            DryRun?: Boolean;            
+            AssociationId: String;            
+        }
+        export interface DiskImage {
+            Image?: DiskImageDetail;            
+            Description?: String;            
+            Volume?: VolumeDetail;            
+        }
+        export interface DiskImageDescription {
+            Format: DiskImageFormat;            
+            Size: Long;            
+            ImportManifestUrl: String;            
+            Checksum?: String;            
+        }
+        export interface DiskImageDetail {
+            Format: DiskImageFormat;            
+            Bytes: Long;            
+            ImportManifestUrl: String;            
+        }
+        export interface DiskImageVolumeDescription {
+            Size?: Long;            
+            Id: String;            
+        }
+        export interface EbsBlockDevice {
+            SnapshotId?: String;            
+            VolumeSize?: Integer;            
+            DeleteOnTermination?: Boolean;            
+            VolumeType?: VolumeType;            
+            Iops?: Integer;            
+            Encrypted?: Boolean;            
+        }
+        export interface EbsInstanceBlockDevice {
+            VolumeId?: String;            
+            Status?: AttachmentStatus;            
+            AttachTime?: DateTime;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface EbsInstanceBlockDeviceSpecification {
+            VolumeId?: String;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface EnableVgwRoutePropagationRequest {
+            RouteTableId: String;            
+            GatewayId: String;            
+        }
+        export interface EnableVolumeIORequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+        }
+        export interface EnableVpcClassicLinkRequest {
+            DryRun?: Boolean;            
+            VpcId: String;            
+        }
+        export interface EnableVpcClassicLinkResult {
+            Return?: Boolean;            
+        }
+        export interface EventInformation {
+            InstanceId?: String;            
+            EventSubType?: String;            
+            EventDescription?: String;            
+        }
+        export interface ExportTask {
+            ExportTaskId?: String;            
+            Description?: String;            
+            State?: ExportTaskState;            
+            StatusMessage?: String;            
+            InstanceExportDetails?: InstanceExportDetails;            
+            ExportToS3Task?: ExportToS3Task;            
+        }
+        export interface ExportToS3Task {
+            DiskImageFormat?: DiskImageFormat;            
+            ContainerFormat?: ContainerFormat;            
+            S3Bucket?: String;            
+            S3Key?: String;            
+        }
+        export interface ExportToS3TaskSpecification {
+            DiskImageFormat?: DiskImageFormat;            
+            ContainerFormat?: ContainerFormat;            
+            S3Bucket?: String;            
+            S3Prefix?: String;            
+        }
+        export interface Filter {
+            Name?: String;            
+            Values?: ValueStringList;            
+        }
+        export interface FlowLog {
+            CreationTime?: DateTime;            
+            FlowLogId?: String;            
+            FlowLogStatus?: String;            
+            ResourceId?: String;            
+            TrafficType?: TrafficType;            
+            LogGroupName?: String;            
+            DeliverLogsStatus?: String;            
+            DeliverLogsErrorMessage?: String;            
+            DeliverLogsPermissionArn?: String;            
+        }
+        export interface GetConsoleOutputRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+        }
+        export interface GetConsoleOutputResult {
+            InstanceId?: String;            
+            Timestamp?: DateTime;            
+            Output?: String;            
+        }
+        export interface GetPasswordDataRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+        }
+        export interface GetPasswordDataResult {
+            InstanceId?: String;            
+            Timestamp?: DateTime;            
+            PasswordData?: String;            
+        }
+        export interface GroupIdentifier {
+            GroupName?: String;            
+            GroupId?: String;            
+        }
+        export interface HistoryRecord {
+            Timestamp: DateTime;            
+            EventType: EventType;            
+            EventInformation: EventInformation;            
+        }
+        export interface Host {
+            HostId?: String;            
+            AutoPlacement?: AutoPlacement;            
+            HostReservationId?: String;            
+            ClientToken?: String;            
+            HostProperties?: HostProperties;            
+            State?: AllocationState;            
+            AvailabilityZone?: String;            
+            Instances?: HostInstanceList;            
+            AvailableCapacity?: AvailableCapacity;            
+        }
+        export interface HostInstance {
+            InstanceId?: String;            
+            InstanceType?: String;            
+        }
+        export interface HostProperties {
+            Sockets?: Integer;            
+            Cores?: Integer;            
+            TotalVCpus?: Integer;            
+            InstanceType?: String;            
+        }
+        export interface IamInstanceProfile {
+            Arn?: String;            
+            Id?: String;            
+        }
+        export interface IamInstanceProfileSpecification {
+            Arn?: String;            
+            Name?: String;            
+        }
+        export interface IcmpTypeCode {
+            Type?: Integer;            
+            Code?: Integer;            
+        }
+        export interface IdFormat {
+            Resource?: String;            
+            UseLongIds?: Boolean;            
+            Deadline?: DateTime;            
+        }
+        export interface Image {
+            ImageId?: String;            
+            ImageLocation?: String;            
+            State?: ImageState;            
+            OwnerId?: String;            
+            CreationDate?: String;            
+            Public?: Boolean;            
+            ProductCodes?: ProductCodeList;            
+            Architecture?: ArchitectureValues;            
+            ImageType?: ImageTypeValues;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            Platform?: PlatformValues;            
+            SriovNetSupport?: String;            
+            StateReason?: StateReason;            
+            ImageOwnerAlias?: String;            
+            Name?: String;            
+            Description?: String;            
+            RootDeviceType?: DeviceType;            
+            RootDeviceName?: String;            
+            BlockDeviceMappings?: BlockDeviceMappingList;            
+            VirtualizationType?: VirtualizationType;            
+            Tags?: TagList;            
+            Hypervisor?: HypervisorType;            
+        }
+        export interface ImageAttribute {
+            ImageId?: String;            
+            LaunchPermissions?: LaunchPermissionList;            
+            ProductCodes?: ProductCodeList;            
+            KernelId?: AttributeValue;            
+            RamdiskId?: AttributeValue;            
+            Description?: AttributeValue;            
+            SriovNetSupport?: AttributeValue;            
+            BlockDeviceMappings?: BlockDeviceMappingList;            
+        }
+        export interface ImageDiskContainer {
+            Description?: String;            
+            Format?: String;            
+            Url?: String;            
+            UserBucket?: UserBucket;            
+            DeviceName?: String;            
+            SnapshotId?: String;            
+        }
+        export interface ImportImageRequest {
+            DryRun?: Boolean;            
+            Description?: String;            
+            DiskContainers?: ImageDiskContainerList;            
+            LicenseType?: String;            
+            Hypervisor?: String;            
+            Architecture?: String;            
+            Platform?: String;            
+            ClientData?: ClientData;            
+            ClientToken?: String;            
+            RoleName?: String;            
+        }
+        export interface ImportImageResult {
+            ImportTaskId?: String;            
+            Architecture?: String;            
+            LicenseType?: String;            
+            Platform?: String;            
+            Hypervisor?: String;            
+            Description?: String;            
+            SnapshotDetails?: SnapshotDetailList;            
+            ImageId?: String;            
+            Progress?: String;            
+            StatusMessage?: String;            
+            Status?: String;            
+        }
+        export interface ImportImageTask {
+            ImportTaskId?: String;            
+            Architecture?: String;            
+            LicenseType?: String;            
+            Platform?: String;            
+            Hypervisor?: String;            
+            Description?: String;            
+            SnapshotDetails?: SnapshotDetailList;            
+            ImageId?: String;            
+            Progress?: String;            
+            StatusMessage?: String;            
+            Status?: String;            
+        }
+        export interface ImportInstanceLaunchSpecification {
+            Architecture?: ArchitectureValues;            
+            GroupNames?: SecurityGroupStringList;            
+            GroupIds?: SecurityGroupIdStringList;            
+            AdditionalInfo?: String;            
+            UserData?: UserData;            
+            InstanceType?: InstanceType;            
+            Placement?: Placement;            
+            Monitoring?: Boolean;            
+            SubnetId?: String;            
+            InstanceInitiatedShutdownBehavior?: ShutdownBehavior;            
+            PrivateIpAddress?: String;            
+        }
+        export interface ImportInstanceRequest {
+            DryRun?: Boolean;            
+            Description?: String;            
+            LaunchSpecification?: ImportInstanceLaunchSpecification;            
+            DiskImages?: DiskImageList;            
+            Platform: PlatformValues;            
+        }
+        export interface ImportInstanceResult {
+            ConversionTask?: ConversionTask;            
+        }
+        export interface ImportInstanceTaskDetails {
+            Volumes: ImportInstanceVolumeDetailSet;            
+            InstanceId?: String;            
+            Platform?: PlatformValues;            
+            Description?: String;            
+        }
+        export interface ImportInstanceVolumeDetailItem {
+            BytesConverted: Long;            
+            AvailabilityZone: String;            
+            Image: DiskImageDescription;            
+            Volume: DiskImageVolumeDescription;            
+            Status: String;            
+            StatusMessage?: String;            
+            Description?: String;            
+        }
+        export interface ImportKeyPairRequest {
+            DryRun?: Boolean;            
+            KeyName: String;            
+            PublicKeyMaterial: Blob;            
+        }
+        export interface ImportKeyPairResult {
+            KeyName?: String;            
+            KeyFingerprint?: String;            
+        }
+        export interface ImportSnapshotRequest {
+            DryRun?: Boolean;            
+            Description?: String;            
+            DiskContainer?: SnapshotDiskContainer;            
+            ClientData?: ClientData;            
+            ClientToken?: String;            
+            RoleName?: String;            
+        }
+        export interface ImportSnapshotResult {
+            ImportTaskId?: String;            
+            SnapshotTaskDetail?: SnapshotTaskDetail;            
+            Description?: String;            
+        }
+        export interface ImportSnapshotTask {
+            ImportTaskId?: String;            
+            SnapshotTaskDetail?: SnapshotTaskDetail;            
+            Description?: String;            
+        }
+        export interface ImportVolumeRequest {
+            DryRun?: Boolean;            
+            AvailabilityZone: String;            
+            Image: DiskImageDetail;            
+            Description?: String;            
+            Volume: VolumeDetail;            
+        }
+        export interface ImportVolumeResult {
+            ConversionTask?: ConversionTask;            
+        }
+        export interface ImportVolumeTaskDetails {
+            BytesConverted: Long;            
+            AvailabilityZone: String;            
+            Description?: String;            
+            Image: DiskImageDescription;            
+            Volume: DiskImageVolumeDescription;            
+        }
+        export interface Instance {
+            InstanceId?: String;            
+            ImageId?: String;            
+            State?: InstanceState;            
+            PrivateDnsName?: String;            
+            PublicDnsName?: String;            
+            StateTransitionReason?: String;            
+            KeyName?: String;            
+            AmiLaunchIndex?: Integer;            
+            ProductCodes?: ProductCodeList;            
+            InstanceType?: InstanceType;            
+            LaunchTime?: DateTime;            
+            Placement?: Placement;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            Platform?: PlatformValues;            
+            Monitoring?: Monitoring;            
+            SubnetId?: String;            
+            VpcId?: String;            
+            PrivateIpAddress?: String;            
+            PublicIpAddress?: String;            
+            StateReason?: StateReason;            
+            Architecture?: ArchitectureValues;            
+            RootDeviceType?: DeviceType;            
+            RootDeviceName?: String;            
+            BlockDeviceMappings?: InstanceBlockDeviceMappingList;            
+            VirtualizationType?: VirtualizationType;            
+            InstanceLifecycle?: InstanceLifecycleType;            
+            SpotInstanceRequestId?: String;            
+            ClientToken?: String;            
+            Tags?: TagList;            
+            SecurityGroups?: GroupIdentifierList;            
+            SourceDestCheck?: Boolean;            
+            Hypervisor?: HypervisorType;            
+            NetworkInterfaces?: InstanceNetworkInterfaceList;            
+            IamInstanceProfile?: IamInstanceProfile;            
+            EbsOptimized?: Boolean;            
+            SriovNetSupport?: String;            
+        }
+        export interface InstanceAttribute {
+            InstanceId?: String;            
+            InstanceType?: AttributeValue;            
+            KernelId?: AttributeValue;            
+            RamdiskId?: AttributeValue;            
+            UserData?: AttributeValue;            
+            DisableApiTermination?: AttributeBooleanValue;            
+            InstanceInitiatedShutdownBehavior?: AttributeValue;            
+            RootDeviceName?: AttributeValue;            
+            BlockDeviceMappings?: InstanceBlockDeviceMappingList;            
+            ProductCodes?: ProductCodeList;            
+            EbsOptimized?: AttributeBooleanValue;            
+            SriovNetSupport?: AttributeValue;            
+            SourceDestCheck?: AttributeBooleanValue;            
+            Groups?: GroupIdentifierList;            
+        }
+        export interface InstanceBlockDeviceMapping {
+            DeviceName?: String;            
+            Ebs?: EbsInstanceBlockDevice;            
+        }
+        export interface InstanceBlockDeviceMappingSpecification {
+            DeviceName?: String;            
+            Ebs?: EbsInstanceBlockDeviceSpecification;            
+            VirtualName?: String;            
+            NoDevice?: String;            
+        }
+        export interface InstanceCapacity {
+            InstanceType?: String;            
+            AvailableCapacity?: Integer;            
+            TotalCapacity?: Integer;            
+        }
+        export interface InstanceCount {
+            State?: ListingState;            
+            InstanceCount?: Integer;            
+        }
+        export interface InstanceExportDetails {
+            InstanceId?: String;            
+            TargetEnvironment?: ExportEnvironment;            
+        }
+        export interface InstanceMonitoring {
+            InstanceId?: String;            
+            Monitoring?: Monitoring;            
+        }
+        export interface InstanceNetworkInterface {
+            NetworkInterfaceId?: String;            
+            SubnetId?: String;            
+            VpcId?: String;            
+            Description?: String;            
+            OwnerId?: String;            
+            Status?: NetworkInterfaceStatus;            
+            MacAddress?: String;            
+            PrivateIpAddress?: String;            
+            PrivateDnsName?: String;            
+            SourceDestCheck?: Boolean;            
+            Groups?: GroupIdentifierList;            
+            Attachment?: InstanceNetworkInterfaceAttachment;            
+            Association?: InstanceNetworkInterfaceAssociation;            
+            PrivateIpAddresses?: InstancePrivateIpAddressList;            
+        }
+        export interface InstanceNetworkInterfaceAssociation {
+            PublicIp?: String;            
+            PublicDnsName?: String;            
+            IpOwnerId?: String;            
+        }
+        export interface InstanceNetworkInterfaceAttachment {
+            AttachmentId?: String;            
+            DeviceIndex?: Integer;            
+            Status?: AttachmentStatus;            
+            AttachTime?: DateTime;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface InstanceNetworkInterfaceSpecification {
+            NetworkInterfaceId?: String;            
+            DeviceIndex?: Integer;            
+            SubnetId?: String;            
+            Description?: String;            
+            PrivateIpAddress?: String;            
+            Groups?: SecurityGroupIdStringList;            
+            DeleteOnTermination?: Boolean;            
+            PrivateIpAddresses?: PrivateIpAddressSpecificationList;            
+            SecondaryPrivateIpAddressCount?: Integer;            
+            AssociatePublicIpAddress?: Boolean;            
+        }
+        export interface InstancePrivateIpAddress {
+            PrivateIpAddress?: String;            
+            PrivateDnsName?: String;            
+            Primary?: Boolean;            
+            Association?: InstanceNetworkInterfaceAssociation;            
+        }
+        export interface InstanceState {
+            Code?: Integer;            
+            Name?: InstanceStateName;            
+        }
+        export interface InstanceStateChange {
+            InstanceId?: String;            
+            CurrentState?: InstanceState;            
+            PreviousState?: InstanceState;            
+        }
+        export interface InstanceStatus {
+            InstanceId?: String;            
+            AvailabilityZone?: String;            
+            Events?: InstanceStatusEventList;            
+            InstanceState?: InstanceState;            
+            SystemStatus?: InstanceStatusSummary;            
+            InstanceStatus?: InstanceStatusSummary;            
+        }
+        export interface InstanceStatusDetails {
+            Name?: StatusName;            
+            Status?: StatusType;            
+            ImpairedSince?: DateTime;            
+        }
+        export interface InstanceStatusEvent {
+            Code?: EventCode;            
+            Description?: String;            
+            NotBefore?: DateTime;            
+            NotAfter?: DateTime;            
+        }
+        export interface InstanceStatusSummary {
+            Status?: SummaryStatus;            
+            Details?: InstanceStatusDetailsList;            
+        }
+        export interface InternetGateway {
+            InternetGatewayId?: String;            
+            Attachments?: InternetGatewayAttachmentList;            
+            Tags?: TagList;            
+        }
+        export interface InternetGatewayAttachment {
+            VpcId?: String;            
+            State?: AttachmentStatus;            
+        }
+        export interface IpPermission {
+            IpProtocol?: String;            
+            FromPort?: Integer;            
+            ToPort?: Integer;            
+            UserIdGroupPairs?: UserIdGroupPairList;            
+            IpRanges?: IpRangeList;            
+            PrefixListIds?: PrefixListIdList;            
+        }
+        export interface IpRange {
+            CidrIp?: String;            
+        }
+        export interface KeyPair {
+            KeyName?: String;            
+            KeyFingerprint?: String;            
+            KeyMaterial?: String;            
+        }
+        export interface KeyPairInfo {
+            KeyName?: String;            
+            KeyFingerprint?: String;            
+        }
+        export interface LaunchPermission {
+            UserId?: String;            
+            Group?: PermissionGroup;            
+        }
+        export interface LaunchPermissionModifications {
+            Add?: LaunchPermissionList;            
+            Remove?: LaunchPermissionList;            
+        }
+        export interface LaunchSpecification {
+            ImageId?: String;            
+            KeyName?: String;            
+            SecurityGroups?: GroupIdentifierList;            
+            UserData?: String;            
+            AddressingType?: String;            
+            InstanceType?: InstanceType;            
+            Placement?: SpotPlacement;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            BlockDeviceMappings?: BlockDeviceMappingList;            
+            SubnetId?: String;            
+            NetworkInterfaces?: InstanceNetworkInterfaceSpecificationList;            
+            IamInstanceProfile?: IamInstanceProfileSpecification;            
+            EbsOptimized?: Boolean;            
+            Monitoring?: RunInstancesMonitoringEnabled;            
+        }
+        export interface ModifyHostsRequest {
+            HostIds: RequestHostIdList;            
+            AutoPlacement: AutoPlacement;            
+        }
+        export interface ModifyHostsResult {
+            Successful?: ResponseHostIdList;            
+            Unsuccessful?: UnsuccessfulItemList;            
+        }
+        export interface ModifyIdFormatRequest {
+            Resource: String;            
+            UseLongIds: Boolean;            
+        }
+        export interface ModifyImageAttributeRequest {
+            DryRun?: Boolean;            
+            ImageId: String;            
+            Attribute?: String;            
+            OperationType?: OperationType;            
+            UserIds?: UserIdStringList;            
+            UserGroups?: UserGroupStringList;            
+            ProductCodes?: ProductCodeStringList;            
+            Value?: String;            
+            LaunchPermission?: LaunchPermissionModifications;            
+            Description?: AttributeValue;            
+        }
+        export interface ModifyInstanceAttributeRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            Attribute?: InstanceAttributeName;            
+            Value?: String;            
+            BlockDeviceMappings?: InstanceBlockDeviceMappingSpecificationList;            
+            SourceDestCheck?: AttributeBooleanValue;            
+            DisableApiTermination?: AttributeBooleanValue;            
+            InstanceType?: AttributeValue;            
+            Kernel?: AttributeValue;            
+            Ramdisk?: AttributeValue;            
+            UserData?: BlobAttributeValue;            
+            InstanceInitiatedShutdownBehavior?: AttributeValue;            
+            Groups?: GroupIdStringList;            
+            EbsOptimized?: AttributeBooleanValue;            
+            SriovNetSupport?: AttributeValue;            
+        }
+        export interface ModifyInstancePlacementRequest {
+            InstanceId: String;            
+            Tenancy?: HostTenancy;            
+            Affinity?: Affinity;            
+            HostId?: String;            
+        }
+        export interface ModifyInstancePlacementResult {
+            Return?: Boolean;            
+        }
+        export interface ModifyNetworkInterfaceAttributeRequest {
+            DryRun?: Boolean;            
+            NetworkInterfaceId: String;            
+            Description?: AttributeValue;            
+            SourceDestCheck?: AttributeBooleanValue;            
+            Groups?: SecurityGroupIdStringList;            
+            Attachment?: NetworkInterfaceAttachmentChanges;            
+        }
+        export interface ModifyReservedInstancesRequest {
+            ClientToken?: String;            
+            ReservedInstancesIds: ReservedInstancesIdStringList;            
+            TargetConfigurations: ReservedInstancesConfigurationList;            
+        }
+        export interface ModifyReservedInstancesResult {
+            ReservedInstancesModificationId?: String;            
+        }
+        export interface ModifySnapshotAttributeRequest {
+            DryRun?: Boolean;            
+            SnapshotId: String;            
+            Attribute?: SnapshotAttributeName;            
+            OperationType?: OperationType;            
+            UserIds?: UserIdStringList;            
+            GroupNames?: GroupNameStringList;            
+            CreateVolumePermission?: CreateVolumePermissionModifications;            
+        }
+        export interface ModifySpotFleetRequestRequest {
+            SpotFleetRequestId: String;            
+            TargetCapacity?: Integer;            
+            ExcessCapacityTerminationPolicy?: ExcessCapacityTerminationPolicy;            
+        }
+        export interface ModifySpotFleetRequestResponse {
+            Return?: Boolean;            
+        }
+        export interface ModifySubnetAttributeRequest {
+            SubnetId: String;            
+            MapPublicIpOnLaunch?: AttributeBooleanValue;            
+        }
+        export interface ModifyVolumeAttributeRequest {
+            DryRun?: Boolean;            
+            VolumeId: String;            
+            AutoEnableIO?: AttributeBooleanValue;            
+        }
+        export interface ModifyVpcAttributeRequest {
+            VpcId: String;            
+            EnableDnsSupport?: AttributeBooleanValue;            
+            EnableDnsHostnames?: AttributeBooleanValue;            
+        }
+        export interface ModifyVpcEndpointRequest {
+            DryRun?: Boolean;            
+            VpcEndpointId: String;            
+            ResetPolicy?: Boolean;            
+            PolicyDocument?: String;            
+            AddRouteTableIds?: ValueStringList;            
+            RemoveRouteTableIds?: ValueStringList;            
+        }
+        export interface ModifyVpcEndpointResult {
+            Return?: Boolean;            
+        }
+        export interface MonitorInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds: InstanceIdStringList;            
+        }
+        export interface MonitorInstancesResult {
+            InstanceMonitorings?: InstanceMonitoringList;            
+        }
+        export interface Monitoring {
+            State?: MonitoringState;            
+        }
+        export interface MoveAddressToVpcRequest {
+            DryRun?: Boolean;            
+            PublicIp: String;            
+        }
+        export interface MoveAddressToVpcResult {
+            AllocationId?: String;            
+            Status?: Status;            
+        }
+        export interface MovingAddressStatus {
+            PublicIp?: String;            
+            MoveStatus?: MoveStatus;            
+        }
+        export interface NetworkAcl {
+            NetworkAclId?: String;            
+            VpcId?: String;            
+            IsDefault?: Boolean;            
+            Entries?: NetworkAclEntryList;            
+            Associations?: NetworkAclAssociationList;            
+            Tags?: TagList;            
+        }
+        export interface NetworkAclAssociation {
+            NetworkAclAssociationId?: String;            
+            NetworkAclId?: String;            
+            SubnetId?: String;            
+        }
+        export interface NetworkAclEntry {
+            RuleNumber?: Integer;            
+            Protocol?: String;            
+            RuleAction?: RuleAction;            
+            Egress?: Boolean;            
+            CidrBlock?: String;            
+            IcmpTypeCode?: IcmpTypeCode;            
+            PortRange?: PortRange;            
+        }
+        export interface NetworkInterface {
+            NetworkInterfaceId?: String;            
+            SubnetId?: String;            
+            VpcId?: String;            
+            AvailabilityZone?: String;            
+            Description?: String;            
+            OwnerId?: String;            
+            RequesterId?: String;            
+            RequesterManaged?: Boolean;            
+            Status?: NetworkInterfaceStatus;            
+            MacAddress?: String;            
+            PrivateIpAddress?: String;            
+            PrivateDnsName?: String;            
+            SourceDestCheck?: Boolean;            
+            Groups?: GroupIdentifierList;            
+            Attachment?: NetworkInterfaceAttachment;            
+            Association?: NetworkInterfaceAssociation;            
+            TagSet?: TagList;            
+            PrivateIpAddresses?: NetworkInterfacePrivateIpAddressList;            
+        }
+        export interface NetworkInterfaceAssociation {
+            PublicIp?: String;            
+            PublicDnsName?: String;            
+            IpOwnerId?: String;            
+            AllocationId?: String;            
+            AssociationId?: String;            
+        }
+        export interface NetworkInterfaceAttachment {
+            AttachmentId?: String;            
+            InstanceId?: String;            
+            InstanceOwnerId?: String;            
+            DeviceIndex?: Integer;            
+            Status?: AttachmentStatus;            
+            AttachTime?: DateTime;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface NetworkInterfaceAttachmentChanges {
+            AttachmentId?: String;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface NetworkInterfacePrivateIpAddress {
+            PrivateIpAddress?: String;            
+            PrivateDnsName?: String;            
+            Primary?: Boolean;            
+            Association?: NetworkInterfaceAssociation;            
+        }
+        export interface NewDhcpConfiguration {
+            Key?: String;            
+            Values?: ValueStringList;            
+        }
+        export interface Placement {
+            AvailabilityZone?: String;            
+            GroupName?: String;            
+            Tenancy?: Tenancy;            
+            HostId?: String;            
+            Affinity?: String;            
+        }
+        export interface PlacementGroup {
+            GroupName?: String;            
+            Strategy?: PlacementStrategy;            
+            State?: PlacementGroupState;            
+        }
+        export interface PortRange {
+            From?: Integer;            
+            To?: Integer;            
+        }
+        export interface PrefixList {
+            PrefixListId?: String;            
+            PrefixListName?: String;            
+            Cidrs?: ValueStringList;            
+        }
+        export interface PrefixListId {
+            PrefixListId?: String;            
+        }
+        export interface PriceSchedule {
+            Term?: Long;            
+            Price?: Double;            
+            CurrencyCode?: CurrencyCodeValues;            
+            Active?: Boolean;            
+        }
+        export interface PriceScheduleSpecification {
+            Term?: Long;            
+            Price?: Double;            
+            CurrencyCode?: CurrencyCodeValues;            
+        }
+        export interface PricingDetail {
+            Price?: Double;            
+            Count?: Integer;            
+        }
+        export interface PrivateIpAddressSpecification {
+            PrivateIpAddress: String;            
+            Primary?: Boolean;            
+        }
+        export interface ProductCode {
+            ProductCodeId?: String;            
+            ProductCodeType?: ProductCodeValues;            
+        }
+        export interface PropagatingVgw {
+            GatewayId?: String;            
+        }
+        export interface PurchaseReservedInstancesOfferingRequest {
+            DryRun?: Boolean;            
+            ReservedInstancesOfferingId: String;            
+            InstanceCount: Integer;            
+            LimitPrice?: ReservedInstanceLimitPrice;            
+        }
+        export interface PurchaseReservedInstancesOfferingResult {
+            ReservedInstancesId?: String;            
+        }
+        export interface RebootInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds: InstanceIdStringList;            
+        }
+        export interface RecurringCharge {
+            Frequency?: RecurringChargeFrequency;            
+            Amount?: Double;            
+        }
+        export interface Region {
+            RegionName?: String;            
+            Endpoint?: String;            
+        }
+        export interface RegisterImageRequest {
+            DryRun?: Boolean;            
+            ImageLocation?: String;            
+            Name: String;            
+            Description?: String;            
+            Architecture?: ArchitectureValues;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            RootDeviceName?: String;            
+            BlockDeviceMappings?: BlockDeviceMappingRequestList;            
+            VirtualizationType?: String;            
+            SriovNetSupport?: String;            
+        }
+        export interface RegisterImageResult {
+            ImageId?: String;            
+        }
+        export interface RejectVpcPeeringConnectionRequest {
+            DryRun?: Boolean;            
+            VpcPeeringConnectionId: String;            
+        }
+        export interface RejectVpcPeeringConnectionResult {
+            Return?: Boolean;            
+        }
+        export interface ReleaseAddressRequest {
+            DryRun?: Boolean;            
+            PublicIp?: String;            
+            AllocationId?: String;            
+        }
+        export interface ReleaseHostsRequest {
+            HostIds: RequestHostIdList;            
+        }
+        export interface ReleaseHostsResult {
+            Successful?: ResponseHostIdList;            
+            Unsuccessful?: UnsuccessfulItemList;            
+        }
+        export interface ReplaceNetworkAclAssociationRequest {
+            DryRun?: Boolean;            
+            AssociationId: String;            
+            NetworkAclId: String;            
+        }
+        export interface ReplaceNetworkAclAssociationResult {
+            NewAssociationId?: String;            
+        }
+        export interface ReplaceNetworkAclEntryRequest {
+            DryRun?: Boolean;            
+            NetworkAclId: String;            
+            RuleNumber: Integer;            
+            Protocol: String;            
+            RuleAction: RuleAction;            
+            Egress: Boolean;            
+            CidrBlock: String;            
+            IcmpTypeCode?: IcmpTypeCode;            
+            PortRange?: PortRange;            
+        }
+        export interface ReplaceRouteRequest {
+            DryRun?: Boolean;            
+            RouteTableId: String;            
+            DestinationCidrBlock: String;            
+            GatewayId?: String;            
+            InstanceId?: String;            
+            NetworkInterfaceId?: String;            
+            VpcPeeringConnectionId?: String;            
+        }
+        export interface ReplaceRouteTableAssociationRequest {
+            DryRun?: Boolean;            
+            AssociationId: String;            
+            RouteTableId: String;            
+        }
+        export interface ReplaceRouteTableAssociationResult {
+            NewAssociationId?: String;            
+        }
+        export interface ReportInstanceStatusRequest {
+            DryRun?: Boolean;            
+            Instances: InstanceIdStringList;            
+            Status: ReportStatusType;            
+            StartTime?: DateTime;            
+            EndTime?: DateTime;            
+            ReasonCodes: ReasonCodesList;            
+            Description?: String;            
+        }
+        export interface RequestSpotFleetRequest {
+            DryRun?: Boolean;            
+            SpotFleetRequestConfig: SpotFleetRequestConfigData;            
+        }
+        export interface RequestSpotFleetResponse {
+            SpotFleetRequestId: String;            
+        }
+        export interface RequestSpotInstancesRequest {
+            DryRun?: Boolean;            
+            SpotPrice: String;            
+            ClientToken?: String;            
+            InstanceCount?: Integer;            
+            Type?: SpotInstanceType;            
+            ValidFrom?: DateTime;            
+            ValidUntil?: DateTime;            
+            LaunchGroup?: String;            
+            AvailabilityZoneGroup?: String;            
+            BlockDurationMinutes?: Integer;            
+            LaunchSpecification?: RequestSpotLaunchSpecification;            
+        }
+        export interface RequestSpotInstancesResult {
+            SpotInstanceRequests?: SpotInstanceRequestList;            
+        }
+        export interface RequestSpotLaunchSpecification {
+            ImageId?: String;            
+            KeyName?: String;            
+            SecurityGroups?: ValueStringList;            
+            UserData?: String;            
+            AddressingType?: String;            
+            InstanceType?: InstanceType;            
+            Placement?: SpotPlacement;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            BlockDeviceMappings?: BlockDeviceMappingList;            
+            SubnetId?: String;            
+            NetworkInterfaces?: InstanceNetworkInterfaceSpecificationList;            
+            IamInstanceProfile?: IamInstanceProfileSpecification;            
+            EbsOptimized?: Boolean;            
+            Monitoring?: RunInstancesMonitoringEnabled;            
+            SecurityGroupIds?: ValueStringList;            
+        }
+        export interface Reservation {
+            ReservationId?: String;            
+            OwnerId?: String;            
+            RequesterId?: String;            
+            Groups?: GroupIdentifierList;            
+            Instances?: InstanceList;            
+        }
+        export interface ReservedInstanceLimitPrice {
+            Amount?: Double;            
+            CurrencyCode?: CurrencyCodeValues;            
+        }
+        export interface ReservedInstances {
+            ReservedInstancesId?: String;            
+            InstanceType?: InstanceType;            
+            AvailabilityZone?: String;            
+            Start?: DateTime;            
+            End?: DateTime;            
+            Duration?: Long;            
+            UsagePrice?: Float;            
+            FixedPrice?: Float;            
+            InstanceCount?: Integer;            
+            ProductDescription?: RIProductDescription;            
+            State?: ReservedInstanceState;            
+            Tags?: TagList;            
+            InstanceTenancy?: Tenancy;            
+            CurrencyCode?: CurrencyCodeValues;            
+            OfferingType?: OfferingTypeValues;            
+            RecurringCharges?: RecurringChargesList;            
+        }
+        export interface ReservedInstancesConfiguration {
+            AvailabilityZone?: String;            
+            Platform?: String;            
+            InstanceCount?: Integer;            
+            InstanceType?: InstanceType;            
+        }
+        export interface ReservedInstancesId {
+            ReservedInstancesId?: String;            
+        }
+        export interface ReservedInstancesListing {
+            ReservedInstancesListingId?: String;            
+            ReservedInstancesId?: String;            
+            CreateDate?: DateTime;            
+            UpdateDate?: DateTime;            
+            Status?: ListingStatus;            
+            StatusMessage?: String;            
+            InstanceCounts?: InstanceCountList;            
+            PriceSchedules?: PriceScheduleList;            
+            Tags?: TagList;            
+            ClientToken?: String;            
+        }
+        export interface ReservedInstancesModification {
+            ReservedInstancesModificationId?: String;            
+            ReservedInstancesIds?: ReservedIntancesIds;            
+            ModificationResults?: ReservedInstancesModificationResultList;            
+            CreateDate?: DateTime;            
+            UpdateDate?: DateTime;            
+            EffectiveDate?: DateTime;            
+            Status?: String;            
+            StatusMessage?: String;            
+            ClientToken?: String;            
+        }
+        export interface ReservedInstancesModificationResult {
+            ReservedInstancesId?: String;            
+            TargetConfiguration?: ReservedInstancesConfiguration;            
+        }
+        export interface ReservedInstancesOffering {
+            ReservedInstancesOfferingId?: String;            
+            InstanceType?: InstanceType;            
+            AvailabilityZone?: String;            
+            Duration?: Long;            
+            UsagePrice?: Float;            
+            FixedPrice?: Float;            
+            ProductDescription?: RIProductDescription;            
+            InstanceTenancy?: Tenancy;            
+            CurrencyCode?: CurrencyCodeValues;            
+            OfferingType?: OfferingTypeValues;            
+            RecurringCharges?: RecurringChargesList;            
+            Marketplace?: Boolean;            
+            PricingDetails?: PricingDetailsList;            
+        }
+        export interface ResetImageAttributeRequest {
+            DryRun?: Boolean;            
+            ImageId: String;            
+            Attribute: ResetImageAttributeName;            
+        }
+        export interface ResetInstanceAttributeRequest {
+            DryRun?: Boolean;            
+            InstanceId: String;            
+            Attribute: InstanceAttributeName;            
+        }
+        export interface ResetNetworkInterfaceAttributeRequest {
+            DryRun?: Boolean;            
+            NetworkInterfaceId: String;            
+            SourceDestCheck?: String;            
+        }
+        export interface ResetSnapshotAttributeRequest {
+            DryRun?: Boolean;            
+            SnapshotId: String;            
+            Attribute: SnapshotAttributeName;            
+        }
+        export interface RestoreAddressToClassicRequest {
+            DryRun?: Boolean;            
+            PublicIp: String;            
+        }
+        export interface RestoreAddressToClassicResult {
+            Status?: Status;            
+            PublicIp?: String;            
+        }
+        export interface RevokeSecurityGroupEgressRequest {
+            DryRun?: Boolean;            
+            GroupId: String;            
+            SourceSecurityGroupName?: String;            
+            SourceSecurityGroupOwnerId?: String;            
+            IpProtocol?: String;            
+            FromPort?: Integer;            
+            ToPort?: Integer;            
+            CidrIp?: String;            
+            IpPermissions?: IpPermissionList;            
+        }
+        export interface RevokeSecurityGroupIngressRequest {
+            DryRun?: Boolean;            
+            GroupName?: String;            
+            GroupId?: String;            
+            SourceSecurityGroupName?: String;            
+            SourceSecurityGroupOwnerId?: String;            
+            IpProtocol?: String;            
+            FromPort?: Integer;            
+            ToPort?: Integer;            
+            CidrIp?: String;            
+            IpPermissions?: IpPermissionList;            
+        }
+        export interface Route {
+            DestinationCidrBlock?: String;            
+            DestinationPrefixListId?: String;            
+            GatewayId?: String;            
+            InstanceId?: String;            
+            InstanceOwnerId?: String;            
+            NetworkInterfaceId?: String;            
+            VpcPeeringConnectionId?: String;            
+            State?: RouteState;            
+            Origin?: RouteOrigin;            
+        }
+        export interface RouteTable {
+            RouteTableId?: String;            
+            VpcId?: String;            
+            Routes?: RouteList;            
+            Associations?: RouteTableAssociationList;            
+            Tags?: TagList;            
+            PropagatingVgws?: PropagatingVgwList;            
+        }
+        export interface RouteTableAssociation {
+            RouteTableAssociationId?: String;            
+            RouteTableId?: String;            
+            SubnetId?: String;            
+            Main?: Boolean;            
+        }
+        export interface RunInstancesMonitoringEnabled {
+            Enabled: Boolean;            
+        }
+        export interface RunInstancesRequest {
+            DryRun?: Boolean;            
+            ImageId: String;            
+            MinCount: Integer;            
+            MaxCount: Integer;            
+            KeyName?: String;            
+            SecurityGroups?: SecurityGroupStringList;            
+            SecurityGroupIds?: SecurityGroupIdStringList;            
+            UserData?: String;            
+            InstanceType?: InstanceType;            
+            Placement?: Placement;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            BlockDeviceMappings?: BlockDeviceMappingRequestList;            
+            Monitoring?: RunInstancesMonitoringEnabled;            
+            SubnetId?: String;            
+            DisableApiTermination?: Boolean;            
+            InstanceInitiatedShutdownBehavior?: ShutdownBehavior;            
+            PrivateIpAddress?: String;            
+            ClientToken?: String;            
+            AdditionalInfo?: String;            
+            NetworkInterfaces?: InstanceNetworkInterfaceSpecificationList;            
+            IamInstanceProfile?: IamInstanceProfileSpecification;            
+            EbsOptimized?: Boolean;            
+        }
+        export interface S3Storage {
+            Bucket?: String;            
+            Prefix?: String;            
+            AWSAccessKeyId?: String;            
+            UploadPolicy?: Blob;            
+            UploadPolicySignature?: String;            
+        }
+        export interface SecurityGroup {
+            OwnerId?: String;            
+            GroupName?: String;            
+            GroupId?: String;            
+            Description?: String;            
+            IpPermissions?: IpPermissionList;            
+            IpPermissionsEgress?: IpPermissionList;            
+            VpcId?: String;            
+            Tags?: TagList;            
+        }
+        export interface Snapshot {
+            SnapshotId?: String;            
+            VolumeId?: String;            
+            State?: SnapshotState;            
+            StateMessage?: String;            
+            StartTime?: DateTime;            
+            Progress?: String;            
+            OwnerId?: String;            
+            Description?: String;            
+            VolumeSize?: Integer;            
+            OwnerAlias?: String;            
+            Tags?: TagList;            
+            Encrypted?: Boolean;            
+            KmsKeyId?: String;            
+            DataEncryptionKeyId?: String;            
+        }
+        export interface SnapshotDetail {
+            DiskImageSize?: Double;            
+            Description?: String;            
+            Format?: String;            
+            Url?: String;            
+            UserBucket?: UserBucketDetails;            
+            DeviceName?: String;            
+            SnapshotId?: String;            
+            Progress?: String;            
+            StatusMessage?: String;            
+            Status?: String;            
+        }
+        export interface SnapshotDiskContainer {
+            Description?: String;            
+            Format?: String;            
+            Url?: String;            
+            UserBucket?: UserBucket;            
+        }
+        export interface SnapshotTaskDetail {
+            DiskImageSize?: Double;            
+            Description?: String;            
+            Format?: String;            
+            Url?: String;            
+            UserBucket?: UserBucketDetails;            
+            SnapshotId?: String;            
+            Progress?: String;            
+            StatusMessage?: String;            
+            Status?: String;            
+        }
+        export interface SpotDatafeedSubscription {
+            OwnerId?: String;            
+            Bucket?: String;            
+            Prefix?: String;            
+            State?: DatafeedSubscriptionState;            
+            Fault?: SpotInstanceStateFault;            
+        }
+        export interface SpotFleetLaunchSpecification {
+            ImageId?: String;            
+            KeyName?: String;            
+            SecurityGroups?: GroupIdentifierList;            
+            UserData?: String;            
+            AddressingType?: String;            
+            InstanceType?: InstanceType;            
+            Placement?: SpotPlacement;            
+            KernelId?: String;            
+            RamdiskId?: String;            
+            BlockDeviceMappings?: BlockDeviceMappingList;            
+            Monitoring?: SpotFleetMonitoring;            
+            SubnetId?: String;            
+            NetworkInterfaces?: InstanceNetworkInterfaceSpecificationList;            
+            IamInstanceProfile?: IamInstanceProfileSpecification;            
+            EbsOptimized?: Boolean;            
+            WeightedCapacity?: Double;            
+            SpotPrice?: String;            
+        }
+        export interface SpotFleetMonitoring {
+            Enabled?: Boolean;            
+        }
+        export interface SpotFleetRequestConfig {
+            SpotFleetRequestId: String;            
+            SpotFleetRequestState: BatchState;            
+            SpotFleetRequestConfig: SpotFleetRequestConfigData;            
+            CreateTime: DateTime;            
+        }
+        export interface SpotFleetRequestConfigData {
+            ClientToken?: String;            
+            SpotPrice: String;            
+            TargetCapacity: Integer;            
+            ValidFrom?: DateTime;            
+            ValidUntil?: DateTime;            
+            TerminateInstancesWithExpiration?: Boolean;            
+            IamFleetRole: String;            
+            LaunchSpecifications: LaunchSpecsList;            
+            ExcessCapacityTerminationPolicy?: ExcessCapacityTerminationPolicy;            
+            AllocationStrategy?: AllocationStrategy;            
+        }
+        export interface SpotInstanceRequest {
+            SpotInstanceRequestId?: String;            
+            SpotPrice?: String;            
+            Type?: SpotInstanceType;            
+            State?: SpotInstanceState;            
+            Fault?: SpotInstanceStateFault;            
+            Status?: SpotInstanceStatus;            
+            ValidFrom?: DateTime;            
+            ValidUntil?: DateTime;            
+            LaunchGroup?: String;            
+            AvailabilityZoneGroup?: String;            
+            LaunchSpecification?: LaunchSpecification;            
+            InstanceId?: String;            
+            CreateTime?: DateTime;            
+            ProductDescription?: RIProductDescription;            
+            BlockDurationMinutes?: Integer;            
+            ActualBlockHourlyPrice?: String;            
+            Tags?: TagList;            
+            LaunchedAvailabilityZone?: String;            
+        }
+        export interface SpotInstanceStateFault {
+            Code?: String;            
+            Message?: String;            
+        }
+        export interface SpotInstanceStatus {
+            Code?: String;            
+            UpdateTime?: DateTime;            
+            Message?: String;            
+        }
+        export interface SpotPlacement {
+            AvailabilityZone?: String;            
+            GroupName?: String;            
+        }
+        export interface SpotPrice {
+            InstanceType?: InstanceType;            
+            ProductDescription?: RIProductDescription;            
+            SpotPrice?: String;            
+            Timestamp?: DateTime;            
+            AvailabilityZone?: String;            
+        }
+        export interface StartInstancesRequest {
+            InstanceIds: InstanceIdStringList;            
+            AdditionalInfo?: String;            
+            DryRun?: Boolean;            
+        }
+        export interface StartInstancesResult {
+            StartingInstances?: InstanceStateChangeList;            
+        }
+        export interface StateReason {
+            Code?: String;            
+            Message?: String;            
+        }
+        export interface StopInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds: InstanceIdStringList;            
+            Force?: Boolean;            
+        }
+        export interface StopInstancesResult {
+            StoppingInstances?: InstanceStateChangeList;            
+        }
+        export interface Storage {
+            S3?: S3Storage;            
+        }
+        export interface Subnet {
+            SubnetId?: String;            
+            State?: SubnetState;            
+            VpcId?: String;            
+            CidrBlock?: String;            
+            AvailableIpAddressCount?: Integer;            
+            AvailabilityZone?: String;            
+            DefaultForAz?: Boolean;            
+            MapPublicIpOnLaunch?: Boolean;            
+            Tags?: TagList;            
+        }
+        export interface Tag {
+            Key?: String;            
+            Value?: String;            
+        }
+        export interface TagDescription {
+            ResourceId?: String;            
+            ResourceType?: ResourceType;            
+            Key?: String;            
+            Value?: String;            
+        }
+        export interface TerminateInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds: InstanceIdStringList;            
+        }
+        export interface TerminateInstancesResult {
+            TerminatingInstances?: InstanceStateChangeList;            
+        }
+        export interface UnassignPrivateIpAddressesRequest {
+            NetworkInterfaceId: String;            
+            PrivateIpAddresses: PrivateIpAddressStringList;            
+        }
+        export interface UnmonitorInstancesRequest {
+            DryRun?: Boolean;            
+            InstanceIds: InstanceIdStringList;            
+        }
+        export interface UnmonitorInstancesResult {
+            InstanceMonitorings?: InstanceMonitoringList;            
+        }
+        export interface UnsuccessfulItem {
+            Error: UnsuccessfulItemError;            
+            ResourceId?: String;            
+        }
+        export interface UnsuccessfulItemError {
+            Code: String;            
+            Message: String;            
+        }
+        export interface UserBucket {
+            S3Bucket?: String;            
+            S3Key?: String;            
+        }
+        export interface UserBucketDetails {
+            S3Bucket?: String;            
+            S3Key?: String;            
+        }
+        export interface UserData {
+            Data?: String;            
+        }
+        export interface UserIdGroupPair {
+            UserId?: String;            
+            GroupName?: String;            
+            GroupId?: String;            
+        }
+        export interface VgwTelemetry {
+            OutsideIpAddress?: String;            
+            Status?: TelemetryStatus;            
+            LastStatusChange?: DateTime;            
+            StatusMessage?: String;            
+            AcceptedRouteCount?: Integer;            
+        }
+        export interface Volume {
+            VolumeId?: String;            
+            Size?: Integer;            
+            SnapshotId?: String;            
+            AvailabilityZone?: String;            
+            State?: VolumeState;            
+            CreateTime?: DateTime;            
+            Attachments?: VolumeAttachmentList;            
+            Tags?: TagList;            
+            VolumeType?: VolumeType;            
+            Iops?: Integer;            
+            Encrypted?: Boolean;            
+            KmsKeyId?: String;            
+        }
+        export interface VolumeAttachment {
+            VolumeId?: String;            
+            InstanceId?: String;            
+            Device?: String;            
+            State?: VolumeAttachmentState;            
+            AttachTime?: DateTime;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface VolumeDetail {
+            Size: Long;            
+        }
+        export interface VolumeStatusAction {
+            Code?: String;            
+            Description?: String;            
+            EventType?: String;            
+            EventId?: String;            
+        }
+        export interface VolumeStatusDetails {
+            Name?: VolumeStatusName;            
+            Status?: String;            
+        }
+        export interface VolumeStatusEvent {
+            EventType?: String;            
+            Description?: String;            
+            NotBefore?: DateTime;            
+            NotAfter?: DateTime;            
+            EventId?: String;            
+        }
+        export interface VolumeStatusInfo {
+            Status?: VolumeStatusInfoStatus;            
+            Details?: VolumeStatusDetailsList;            
+        }
+        export interface VolumeStatusItem {
+            VolumeId?: String;            
+            AvailabilityZone?: String;            
+            VolumeStatus?: VolumeStatusInfo;            
+            Events?: VolumeStatusEventsList;            
+            Actions?: VolumeStatusActionsList;            
+        }
+        export interface Vpc {
+            VpcId?: String;            
+            State?: VpcState;            
+            CidrBlock?: String;            
+            DhcpOptionsId?: String;            
+            Tags?: TagList;            
+            InstanceTenancy?: Tenancy;            
+            IsDefault?: Boolean;            
+        }
+        export interface VpcAttachment {
+            VpcId?: String;            
+            State?: AttachmentStatus;            
+        }
+        export interface VpcClassicLink {
+            VpcId?: String;            
+            ClassicLinkEnabled?: Boolean;            
+            Tags?: TagList;            
+        }
+        export interface VpcEndpoint {
+            VpcEndpointId?: String;            
+            VpcId?: String;            
+            ServiceName?: String;            
+            State?: State;            
+            PolicyDocument?: String;            
+            RouteTableIds?: ValueStringList;            
+            CreationTimestamp?: DateTime;            
+        }
+        export interface VpcPeeringConnection {
+            AccepterVpcInfo?: VpcPeeringConnectionVpcInfo;            
+            ExpirationTime?: DateTime;            
+            RequesterVpcInfo?: VpcPeeringConnectionVpcInfo;            
+            Status?: VpcPeeringConnectionStateReason;            
+            Tags?: TagList;            
+            VpcPeeringConnectionId?: String;            
+        }
+        export interface VpcPeeringConnectionStateReason {
+            Code?: VpcPeeringConnectionStateReasonCode;            
+            Message?: String;            
+        }
+        export interface VpcPeeringConnectionVpcInfo {
+            CidrBlock?: String;            
+            OwnerId?: String;            
+            VpcId?: String;            
+        }
+        export interface VpnConnection {
+            VpnConnectionId?: String;            
+            State?: VpnState;            
+            CustomerGatewayConfiguration?: String;            
+            Type?: GatewayType;            
+            CustomerGatewayId?: String;            
+            VpnGatewayId?: String;            
+            Tags?: TagList;            
+            VgwTelemetry?: VgwTelemetryList;            
+            Options?: VpnConnectionOptions;            
+            Routes?: VpnStaticRouteList;            
+        }
+        export interface VpnConnectionOptions {
+            StaticRoutesOnly?: Boolean;            
+        }
+        export interface VpnConnectionOptionsSpecification {
+            StaticRoutesOnly?: Boolean;            
+        }
+        export interface VpnGateway {
+            VpnGatewayId?: String;            
+            State?: VpnState;            
+            Type?: GatewayType;            
+            AvailabilityZone?: String;            
+            VpcAttachments?: VpcAttachmentList;            
+            Tags?: TagList;            
+        }
+        export interface VpnStaticRoute {
+            DestinationCidrBlock?: String;            
+            Source?: VpnStaticRouteSource;            
+            State?: VpnState;            
+        }
 
-    export interface EC2MonitorInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds: EC2InstanceIdStringList;
     }
-
-    export interface EC2MonitorInstancesResult {
-        InstanceMonitorings?: EC2InstanceMonitoringList;
-    }
-
-    export interface EC2Monitoring {
-        State?: EC2MonitoringState;
-    }
-
-    export type EC2MonitoringState = string;
-    export interface EC2MoveAddressToVpcRequest {
-        DryRun?: EC2Boolean;
-        PublicIp: EC2String;
-    }
-
-    export interface EC2MoveAddressToVpcResult {
-        AllocationId?: EC2String;
-        Status?: EC2Status;
-    }
-
-    export type EC2MoveStatus = string;
-    export interface EC2MovingAddressStatus {
-        PublicIp?: EC2String;
-        MoveStatus?: EC2MoveStatus;
-    }
-
-    export type EC2MovingAddressStatusSet = Array<EC2MovingAddressStatus>;
-    export interface EC2NetworkAcl {
-        NetworkAclId?: EC2String;
-        VpcId?: EC2String;
-        IsDefault?: EC2Boolean;
-        Entries?: EC2NetworkAclEntryList;
-        Associations?: EC2NetworkAclAssociationList;
-        Tags?: EC2TagList;
-    }
-
-    export interface EC2NetworkAclAssociation {
-        NetworkAclAssociationId?: EC2String;
-        NetworkAclId?: EC2String;
-        SubnetId?: EC2String;
-    }
-
-    export type EC2NetworkAclAssociationList = Array<EC2NetworkAclAssociation>;
-    export interface EC2NetworkAclEntry {
-        RuleNumber?: EC2Integer;
-        Protocol?: EC2String;
-        RuleAction?: EC2RuleAction;
-        Egress?: EC2Boolean;
-        CidrBlock?: EC2String;
-        IcmpTypeCode?: EC2IcmpTypeCode;
-        PortRange?: EC2PortRange;
-    }
-
-    export type EC2NetworkAclEntryList = Array<EC2NetworkAclEntry>;
-    export type EC2NetworkAclList = Array<EC2NetworkAcl>;
-    export interface EC2NetworkInterface {
-        NetworkInterfaceId?: EC2String;
-        SubnetId?: EC2String;
-        VpcId?: EC2String;
-        AvailabilityZone?: EC2String;
-        Description?: EC2String;
-        OwnerId?: EC2String;
-        RequesterId?: EC2String;
-        RequesterManaged?: EC2Boolean;
-        Status?: EC2NetworkInterfaceStatus;
-        MacAddress?: EC2String;
-        PrivateIpAddress?: EC2String;
-        PrivateDnsName?: EC2String;
-        SourceDestCheck?: EC2Boolean;
-        Groups?: EC2GroupIdentifierList;
-        Attachment?: EC2NetworkInterfaceAttachment;
-        Association?: EC2NetworkInterfaceAssociation;
-        TagSet?: EC2TagList;
-        PrivateIpAddresses?: EC2NetworkInterfacePrivateIpAddressList;
-    }
-
-    export interface EC2NetworkInterfaceAssociation {
-        PublicIp?: EC2String;
-        PublicDnsName?: EC2String;
-        IpOwnerId?: EC2String;
-        AllocationId?: EC2String;
-        AssociationId?: EC2String;
-    }
-
-    export interface EC2NetworkInterfaceAttachment {
-        AttachmentId?: EC2String;
-        InstanceId?: EC2String;
-        InstanceOwnerId?: EC2String;
-        DeviceIndex?: EC2Integer;
-        Status?: EC2AttachmentStatus;
-        AttachTime?: EC2DateTime;
-        DeleteOnTermination?: EC2Boolean;
-    }
-
-    export interface EC2NetworkInterfaceAttachmentChanges {
-        AttachmentId?: EC2String;
-        DeleteOnTermination?: EC2Boolean;
-    }
-
-    export type EC2NetworkInterfaceAttribute = string;
-    export type EC2NetworkInterfaceIdList = Array<EC2String>;
-    export type EC2NetworkInterfaceList = Array<EC2NetworkInterface>;
-    export interface EC2NetworkInterfacePrivateIpAddress {
-        PrivateIpAddress?: EC2String;
-        PrivateDnsName?: EC2String;
-        Primary?: EC2Boolean;
-        Association?: EC2NetworkInterfaceAssociation;
-    }
-
-    export type EC2NetworkInterfacePrivateIpAddressList = Array<EC2NetworkInterfacePrivateIpAddress>;
-    export type EC2NetworkInterfaceStatus = string;
-    export interface EC2NewDhcpConfiguration {
-        Key?: EC2String;
-        Values?: EC2ValueStringList;
-    }
-
-    export type EC2NewDhcpConfigurationList = Array<EC2NewDhcpConfiguration>;
-    export type EC2OfferingTypeValues = string;
-    export type EC2OperationType = string;
-    export type EC2OwnerStringList = Array<EC2String>;
-    export type EC2PermissionGroup = string;
-    export interface EC2Placement {
-        AvailabilityZone?: EC2String;
-        GroupName?: EC2String;
-        Tenancy?: EC2Tenancy;
-        HostId?: EC2String;
-        Affinity?: EC2String;
-    }
-
-    export interface EC2PlacementGroup {
-        GroupName?: EC2String;
-        Strategy?: EC2PlacementStrategy;
-        State?: EC2PlacementGroupState;
-    }
-
-    export type EC2PlacementGroupList = Array<EC2PlacementGroup>;
-    export type EC2PlacementGroupState = string;
-    export type EC2PlacementGroupStringList = Array<EC2String>;
-    export type EC2PlacementStrategy = string;
-    export type EC2PlatformValues = string;
-    export interface EC2PortRange {
-        From?: EC2Integer;
-        To?: EC2Integer;
-    }
-
-    export interface EC2PrefixList {
-        PrefixListId?: EC2String;
-        PrefixListName?: EC2String;
-        Cidrs?: EC2ValueStringList;
-    }
-
-    export interface EC2PrefixListId {
-        PrefixListId?: EC2String;
-    }
-
-    export type EC2PrefixListIdList = Array<EC2PrefixListId>;
-    export type EC2PrefixListSet = Array<EC2PrefixList>;
-    export interface EC2PriceSchedule {
-        Term?: EC2Long;
-        Price?: EC2Double;
-        CurrencyCode?: EC2CurrencyCodeValues;
-        Active?: EC2Boolean;
-    }
-
-    export type EC2PriceScheduleList = Array<EC2PriceSchedule>;
-    export interface EC2PriceScheduleSpecification {
-        Term?: EC2Long;
-        Price?: EC2Double;
-        CurrencyCode?: EC2CurrencyCodeValues;
-    }
-
-    export type EC2PriceScheduleSpecificationList = Array<EC2PriceScheduleSpecification>;
-    export interface EC2PricingDetail {
-        Price?: EC2Double;
-        Count?: EC2Integer;
-    }
-
-    export type EC2PricingDetailsList = Array<EC2PricingDetail>;
-    export interface EC2PrivateIpAddressSpecification {
-        PrivateIpAddress: EC2String;
-        Primary?: EC2Boolean;
-    }
-
-    export type EC2PrivateIpAddressSpecificationList = Array<EC2PrivateIpAddressSpecification>;
-    export type EC2PrivateIpAddressStringList = Array<EC2String>;
-    export interface EC2ProductCode {
-        ProductCodeId?: EC2String;
-        ProductCodeType?: EC2ProductCodeValues;
-    }
-
-    export type EC2ProductCodeList = Array<EC2ProductCode>;
-    export type EC2ProductCodeStringList = Array<EC2String>;
-    export type EC2ProductCodeValues = string;
-    export type EC2ProductDescriptionList = Array<EC2String>;
-    export interface EC2PropagatingVgw {
-        GatewayId?: EC2String;
-    }
-
-    export type EC2PropagatingVgwList = Array<EC2PropagatingVgw>;
-    export type EC2PublicIpStringList = Array<EC2String>;
-    export interface EC2PurchaseReservedInstancesOfferingRequest {
-        DryRun?: EC2Boolean;
-        ReservedInstancesOfferingId: EC2String;
-        InstanceCount: EC2Integer;
-        LimitPrice?: EC2ReservedInstanceLimitPrice;
-    }
-
-    export interface EC2PurchaseReservedInstancesOfferingResult {
-        ReservedInstancesId?: EC2String;
-    }
-
-    export type EC2RIProductDescription = string;
-    export type EC2ReasonCodesList = Array<EC2ReportInstanceReasonCodes>;
-    export interface EC2RebootInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds: EC2InstanceIdStringList;
-    }
-
-    export interface EC2RecurringCharge {
-        Frequency?: EC2RecurringChargeFrequency;
-        Amount?: EC2Double;
-    }
-
-    export type EC2RecurringChargeFrequency = string;
-    export type EC2RecurringChargesList = Array<EC2RecurringCharge>;
-    export interface EC2Region {
-        RegionName?: EC2String;
-        Endpoint?: EC2String;
-    }
-
-    export type EC2RegionList = Array<EC2Region>;
-    export type EC2RegionNameStringList = Array<EC2String>;
-    export interface EC2RegisterImageRequest {
-        DryRun?: EC2Boolean;
-        ImageLocation?: EC2String;
-        Name: EC2String;
-        Description?: EC2String;
-        Architecture?: EC2ArchitectureValues;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        RootDeviceName?: EC2String;
-        BlockDeviceMappings?: EC2BlockDeviceMappingRequestList;
-        VirtualizationType?: EC2String;
-        SriovNetSupport?: EC2String;
-    }
-
-    export interface EC2RegisterImageResult {
-        ImageId?: EC2String;
-    }
-
-    export interface EC2RejectVpcPeeringConnectionRequest {
-        DryRun?: EC2Boolean;
-        VpcPeeringConnectionId: EC2String;
-    }
-
-    export interface EC2RejectVpcPeeringConnectionResult {
-        Return?: EC2Boolean;
-    }
-
-    export interface EC2ReleaseAddressRequest {
-        DryRun?: EC2Boolean;
-        PublicIp?: EC2String;
-        AllocationId?: EC2String;
-    }
-
-    export interface EC2ReleaseHostsRequest {
-        HostIds: EC2RequestHostIdList;
-    }
-
-    export interface EC2ReleaseHostsResult {
-        Successful?: EC2ResponseHostIdList;
-        Unsuccessful?: EC2UnsuccessfulItemList;
-    }
-
-    export interface EC2ReplaceNetworkAclAssociationRequest {
-        DryRun?: EC2Boolean;
-        AssociationId: EC2String;
-        NetworkAclId: EC2String;
-    }
-
-    export interface EC2ReplaceNetworkAclAssociationResult {
-        NewAssociationId?: EC2String;
-    }
-
-    export interface EC2ReplaceNetworkAclEntryRequest {
-        DryRun?: EC2Boolean;
-        NetworkAclId: EC2String;
-        RuleNumber: EC2Integer;
-        Protocol: EC2String;
-        RuleAction: EC2RuleAction;
-        Egress: EC2Boolean;
-        CidrBlock: EC2String;
-        IcmpTypeCode?: EC2IcmpTypeCode;
-        PortRange?: EC2PortRange;
-    }
-
-    export interface EC2ReplaceRouteRequest {
-        DryRun?: EC2Boolean;
-        RouteTableId: EC2String;
-        DestinationCidrBlock: EC2String;
-        GatewayId?: EC2String;
-        InstanceId?: EC2String;
-        NetworkInterfaceId?: EC2String;
-        VpcPeeringConnectionId?: EC2String;
-    }
-
-    export interface EC2ReplaceRouteTableAssociationRequest {
-        DryRun?: EC2Boolean;
-        AssociationId: EC2String;
-        RouteTableId: EC2String;
-    }
-
-    export interface EC2ReplaceRouteTableAssociationResult {
-        NewAssociationId?: EC2String;
-    }
-
-    export type EC2ReportInstanceReasonCodes = string;
-    export interface EC2ReportInstanceStatusRequest {
-        DryRun?: EC2Boolean;
-        Instances: EC2InstanceIdStringList;
-        Status: EC2ReportStatusType;
-        StartTime?: EC2DateTime;
-        EndTime?: EC2DateTime;
-        ReasonCodes: EC2ReasonCodesList;
-        Description?: EC2String;
-    }
-
-    export type EC2ReportStatusType = string;
-    export type EC2RequestHostIdList = Array<EC2String>;
-    export interface EC2RequestSpotFleetRequest {
-        DryRun?: EC2Boolean;
-        SpotFleetRequestConfig: EC2SpotFleetRequestConfigData;
-    }
-
-    export interface EC2RequestSpotFleetResponse {
-        SpotFleetRequestId: EC2String;
-    }
-
-    export interface EC2RequestSpotInstancesRequest {
-        DryRun?: EC2Boolean;
-        SpotPrice: EC2String;
-        ClientToken?: EC2String;
-        InstanceCount?: EC2Integer;
-        Type?: EC2SpotInstanceType;
-        ValidFrom?: EC2DateTime;
-        ValidUntil?: EC2DateTime;
-        LaunchGroup?: EC2String;
-        AvailabilityZoneGroup?: EC2String;
-        BlockDurationMinutes?: EC2Integer;
-        LaunchSpecification?: EC2RequestSpotLaunchSpecification;
-    }
-
-    export interface EC2RequestSpotInstancesResult {
-        SpotInstanceRequests?: EC2SpotInstanceRequestList;
-    }
-
-    export interface EC2RequestSpotLaunchSpecification {
-        ImageId?: EC2String;
-        KeyName?: EC2String;
-        SecurityGroups?: EC2ValueStringList;
-        UserData?: EC2String;
-        AddressingType?: EC2String;
-        InstanceType?: EC2InstanceType;
-        Placement?: EC2SpotPlacement;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        BlockDeviceMappings?: EC2BlockDeviceMappingList;
-        SubnetId?: EC2String;
-        NetworkInterfaces?: EC2InstanceNetworkInterfaceSpecificationList;
-        IamInstanceProfile?: EC2IamInstanceProfileSpecification;
-        EbsOptimized?: EC2Boolean;
-        Monitoring?: EC2RunInstancesMonitoringEnabled;
-        SecurityGroupIds?: EC2ValueStringList;
-    }
-
-    export interface EC2Reservation {
-        ReservationId?: EC2String;
-        OwnerId?: EC2String;
-        RequesterId?: EC2String;
-        Groups?: EC2GroupIdentifierList;
-        Instances?: EC2InstanceList;
-    }
-
-    export type EC2ReservationList = Array<EC2Reservation>;
-    export interface EC2ReservedInstanceLimitPrice {
-        Amount?: EC2Double;
-        CurrencyCode?: EC2CurrencyCodeValues;
-    }
-
-    export type EC2ReservedInstanceState = string;
-    export interface EC2ReservedInstances {
-        ReservedInstancesId?: EC2String;
-        InstanceType?: EC2InstanceType;
-        AvailabilityZone?: EC2String;
-        Start?: EC2DateTime;
-        End?: EC2DateTime;
-        Duration?: EC2Long;
-        UsagePrice?: EC2Float;
-        FixedPrice?: EC2Float;
-        InstanceCount?: EC2Integer;
-        ProductDescription?: EC2RIProductDescription;
-        State?: EC2ReservedInstanceState;
-        Tags?: EC2TagList;
-        InstanceTenancy?: EC2Tenancy;
-        CurrencyCode?: EC2CurrencyCodeValues;
-        OfferingType?: EC2OfferingTypeValues;
-        RecurringCharges?: EC2RecurringChargesList;
-    }
-
-    export interface EC2ReservedInstancesConfiguration {
-        AvailabilityZone?: EC2String;
-        Platform?: EC2String;
-        InstanceCount?: EC2Integer;
-        InstanceType?: EC2InstanceType;
-    }
-
-    export type EC2ReservedInstancesConfigurationList = Array<EC2ReservedInstancesConfiguration>;
-    export interface EC2ReservedInstancesId {
-        ReservedInstancesId?: EC2String;
-    }
-
-    export type EC2ReservedInstancesIdStringList = Array<EC2String>;
-    export type EC2ReservedInstancesList = Array<EC2ReservedInstances>;
-    export interface EC2ReservedInstancesListing {
-        ReservedInstancesListingId?: EC2String;
-        ReservedInstancesId?: EC2String;
-        CreateDate?: EC2DateTime;
-        UpdateDate?: EC2DateTime;
-        Status?: EC2ListingStatus;
-        StatusMessage?: EC2String;
-        InstanceCounts?: EC2InstanceCountList;
-        PriceSchedules?: EC2PriceScheduleList;
-        Tags?: EC2TagList;
-        ClientToken?: EC2String;
-    }
-
-    export type EC2ReservedInstancesListingList = Array<EC2ReservedInstancesListing>;
-    export interface EC2ReservedInstancesModification {
-        ReservedInstancesModificationId?: EC2String;
-        ReservedInstancesIds?: EC2ReservedIntancesIds;
-        ModificationResults?: EC2ReservedInstancesModificationResultList;
-        CreateDate?: EC2DateTime;
-        UpdateDate?: EC2DateTime;
-        EffectiveDate?: EC2DateTime;
-        Status?: EC2String;
-        StatusMessage?: EC2String;
-        ClientToken?: EC2String;
-    }
-
-    export type EC2ReservedInstancesModificationIdStringList = Array<EC2String>;
-    export type EC2ReservedInstancesModificationList = Array<EC2ReservedInstancesModification>;
-    export interface EC2ReservedInstancesModificationResult {
-        ReservedInstancesId?: EC2String;
-        TargetConfiguration?: EC2ReservedInstancesConfiguration;
-    }
-
-    export type EC2ReservedInstancesModificationResultList = Array<EC2ReservedInstancesModificationResult>;
-    export interface EC2ReservedInstancesOffering {
-        ReservedInstancesOfferingId?: EC2String;
-        InstanceType?: EC2InstanceType;
-        AvailabilityZone?: EC2String;
-        Duration?: EC2Long;
-        UsagePrice?: EC2Float;
-        FixedPrice?: EC2Float;
-        ProductDescription?: EC2RIProductDescription;
-        InstanceTenancy?: EC2Tenancy;
-        CurrencyCode?: EC2CurrencyCodeValues;
-        OfferingType?: EC2OfferingTypeValues;
-        RecurringCharges?: EC2RecurringChargesList;
-        Marketplace?: EC2Boolean;
-        PricingDetails?: EC2PricingDetailsList;
-    }
-
-    export type EC2ReservedInstancesOfferingIdStringList = Array<EC2String>;
-    export type EC2ReservedInstancesOfferingList = Array<EC2ReservedInstancesOffering>;
-    export type EC2ReservedIntancesIds = Array<EC2ReservedInstancesId>;
-    export type EC2ResetImageAttributeName = string;
-    export interface EC2ResetImageAttributeRequest {
-        DryRun?: EC2Boolean;
-        ImageId: EC2String;
-        Attribute: EC2ResetImageAttributeName;
-    }
-
-    export interface EC2ResetInstanceAttributeRequest {
-        DryRun?: EC2Boolean;
-        InstanceId: EC2String;
-        Attribute: EC2InstanceAttributeName;
-    }
-
-    export interface EC2ResetNetworkInterfaceAttributeRequest {
-        DryRun?: EC2Boolean;
-        NetworkInterfaceId: EC2String;
-        SourceDestCheck?: EC2String;
-    }
-
-    export interface EC2ResetSnapshotAttributeRequest {
-        DryRun?: EC2Boolean;
-        SnapshotId: EC2String;
-        Attribute: EC2SnapshotAttributeName;
-    }
-
-    export type EC2ResourceIdList = Array<EC2String>;
-    export type EC2ResourceType = string;
-    export type EC2ResponseHostIdList = Array<EC2String>;
-    export type EC2RestorableByStringList = Array<EC2String>;
-    export interface EC2RestoreAddressToClassicRequest {
-        DryRun?: EC2Boolean;
-        PublicIp: EC2String;
-    }
-
-    export interface EC2RestoreAddressToClassicResult {
-        Status?: EC2Status;
-        PublicIp?: EC2String;
-    }
-
-    export interface EC2RevokeSecurityGroupEgressRequest {
-        DryRun?: EC2Boolean;
-        GroupId: EC2String;
-        SourceSecurityGroupName?: EC2String;
-        SourceSecurityGroupOwnerId?: EC2String;
-        IpProtocol?: EC2String;
-        FromPort?: EC2Integer;
-        ToPort?: EC2Integer;
-        CidrIp?: EC2String;
-        IpPermissions?: EC2IpPermissionList;
-    }
-
-    export interface EC2RevokeSecurityGroupIngressRequest {
-        DryRun?: EC2Boolean;
-        GroupName?: EC2String;
-        GroupId?: EC2String;
-        SourceSecurityGroupName?: EC2String;
-        SourceSecurityGroupOwnerId?: EC2String;
-        IpProtocol?: EC2String;
-        FromPort?: EC2Integer;
-        ToPort?: EC2Integer;
-        CidrIp?: EC2String;
-        IpPermissions?: EC2IpPermissionList;
-    }
-
-    export interface EC2Route {
-        DestinationCidrBlock?: EC2String;
-        DestinationPrefixListId?: EC2String;
-        GatewayId?: EC2String;
-        InstanceId?: EC2String;
-        InstanceOwnerId?: EC2String;
-        NetworkInterfaceId?: EC2String;
-        VpcPeeringConnectionId?: EC2String;
-        State?: EC2RouteState;
-        Origin?: EC2RouteOrigin;
-    }
-
-    export type EC2RouteList = Array<EC2Route>;
-    export type EC2RouteOrigin = string;
-    export type EC2RouteState = string;
-    export interface EC2RouteTable {
-        RouteTableId?: EC2String;
-        VpcId?: EC2String;
-        Routes?: EC2RouteList;
-        Associations?: EC2RouteTableAssociationList;
-        Tags?: EC2TagList;
-        PropagatingVgws?: EC2PropagatingVgwList;
-    }
-
-    export interface EC2RouteTableAssociation {
-        RouteTableAssociationId?: EC2String;
-        RouteTableId?: EC2String;
-        SubnetId?: EC2String;
-        Main?: EC2Boolean;
-    }
-
-    export type EC2RouteTableAssociationList = Array<EC2RouteTableAssociation>;
-    export type EC2RouteTableList = Array<EC2RouteTable>;
-    export type EC2RuleAction = string;
-    export interface EC2RunInstancesMonitoringEnabled {
-        Enabled: EC2Boolean;
-    }
-
-    export interface EC2RunInstancesRequest {
-        DryRun?: EC2Boolean;
-        ImageId: EC2String;
-        MinCount: EC2Integer;
-        MaxCount: EC2Integer;
-        KeyName?: EC2String;
-        SecurityGroups?: EC2SecurityGroupStringList;
-        SecurityGroupIds?: EC2SecurityGroupIdStringList;
-        UserData?: EC2String;
-        InstanceType?: EC2InstanceType;
-        Placement?: EC2Placement;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        BlockDeviceMappings?: EC2BlockDeviceMappingRequestList;
-        Monitoring?: EC2RunInstancesMonitoringEnabled;
-        SubnetId?: EC2String;
-        DisableApiTermination?: EC2Boolean;
-        InstanceInitiatedShutdownBehavior?: EC2ShutdownBehavior;
-        PrivateIpAddress?: EC2String;
-        ClientToken?: EC2String;
-        AdditionalInfo?: EC2String;
-        NetworkInterfaces?: EC2InstanceNetworkInterfaceSpecificationList;
-        IamInstanceProfile?: EC2IamInstanceProfileSpecification;
-        EbsOptimized?: EC2Boolean;
-    }
-
-    export interface EC2S3Storage {
-        Bucket?: EC2String;
-        Prefix?: EC2String;
-        AWSAccessKeyId?: EC2String;
-        UploadPolicy?: EC2Blob;
-        UploadPolicySignature?: EC2String;
-    }
-
-    export interface EC2SecurityGroup {
-        OwnerId?: EC2String;
-        GroupName?: EC2String;
-        GroupId?: EC2String;
-        Description?: EC2String;
-        IpPermissions?: EC2IpPermissionList;
-        IpPermissionsEgress?: EC2IpPermissionList;
-        VpcId?: EC2String;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2SecurityGroupIdStringList = Array<EC2String>;
-    export type EC2SecurityGroupList = Array<EC2SecurityGroup>;
-    export type EC2SecurityGroupStringList = Array<EC2String>;
-    export type EC2ShutdownBehavior = string;
-    export interface EC2Snapshot {
-        SnapshotId?: EC2String;
-        VolumeId?: EC2String;
-        State?: EC2SnapshotState;
-        StateMessage?: EC2String;
-        StartTime?: EC2DateTime;
-        Progress?: EC2String;
-        OwnerId?: EC2String;
-        Description?: EC2String;
-        VolumeSize?: EC2Integer;
-        OwnerAlias?: EC2String;
-        Tags?: EC2TagList;
-        Encrypted?: EC2Boolean;
-        KmsKeyId?: EC2String;
-        DataEncryptionKeyId?: EC2String;
-    }
-
-    export type EC2SnapshotAttributeName = string;
-    export interface EC2SnapshotDetail {
-        DiskImageSize?: EC2Double;
-        Description?: EC2String;
-        Format?: EC2String;
-        Url?: EC2String;
-        UserBucket?: EC2UserBucketDetails;
-        DeviceName?: EC2String;
-        SnapshotId?: EC2String;
-        Progress?: EC2String;
-        StatusMessage?: EC2String;
-        Status?: EC2String;
-    }
-
-    export type EC2SnapshotDetailList = Array<EC2SnapshotDetail>;
-    export interface EC2SnapshotDiskContainer {
-        Description?: EC2String;
-        Format?: EC2String;
-        Url?: EC2String;
-        UserBucket?: EC2UserBucket;
-    }
-
-    export type EC2SnapshotIdStringList = Array<EC2String>;
-    export type EC2SnapshotList = Array<EC2Snapshot>;
-    export type EC2SnapshotState = string;
-    export interface EC2SnapshotTaskDetail {
-        DiskImageSize?: EC2Double;
-        Description?: EC2String;
-        Format?: EC2String;
-        Url?: EC2String;
-        UserBucket?: EC2UserBucketDetails;
-        SnapshotId?: EC2String;
-        Progress?: EC2String;
-        StatusMessage?: EC2String;
-        Status?: EC2String;
-    }
-
-    export interface EC2SpotDatafeedSubscription {
-        OwnerId?: EC2String;
-        Bucket?: EC2String;
-        Prefix?: EC2String;
-        State?: EC2DatafeedSubscriptionState;
-        Fault?: EC2SpotInstanceStateFault;
-    }
-
-    export interface EC2SpotFleetLaunchSpecification {
-        ImageId?: EC2String;
-        KeyName?: EC2String;
-        SecurityGroups?: EC2GroupIdentifierList;
-        UserData?: EC2String;
-        AddressingType?: EC2String;
-        InstanceType?: EC2InstanceType;
-        Placement?: EC2SpotPlacement;
-        KernelId?: EC2String;
-        RamdiskId?: EC2String;
-        BlockDeviceMappings?: EC2BlockDeviceMappingList;
-        Monitoring?: EC2SpotFleetMonitoring;
-        SubnetId?: EC2String;
-        NetworkInterfaces?: EC2InstanceNetworkInterfaceSpecificationList;
-        IamInstanceProfile?: EC2IamInstanceProfileSpecification;
-        EbsOptimized?: EC2Boolean;
-        WeightedCapacity?: EC2Double;
-        SpotPrice?: EC2String;
-    }
-
-    export interface EC2SpotFleetMonitoring {
-        Enabled?: EC2Boolean;
-    }
-
-    export interface EC2SpotFleetRequestConfig {
-        SpotFleetRequestId: EC2String;
-        SpotFleetRequestState: EC2BatchState;
-        SpotFleetRequestConfig: EC2SpotFleetRequestConfigData;
-        CreateTime: EC2DateTime;
-    }
-
-    export interface EC2SpotFleetRequestConfigData {
-        ClientToken?: EC2String;
-        SpotPrice: EC2String;
-        TargetCapacity: EC2Integer;
-        ValidFrom?: EC2DateTime;
-        ValidUntil?: EC2DateTime;
-        TerminateInstancesWithExpiration?: EC2Boolean;
-        IamFleetRole: EC2String;
-        LaunchSpecifications: EC2LaunchSpecsList;
-        ExcessCapacityTerminationPolicy?: EC2ExcessCapacityTerminationPolicy;
-        AllocationStrategy?: EC2AllocationStrategy;
-    }
-
-    export type EC2SpotFleetRequestConfigSet = Array<EC2SpotFleetRequestConfig>;
-    export interface EC2SpotInstanceRequest {
-        SpotInstanceRequestId?: EC2String;
-        SpotPrice?: EC2String;
-        Type?: EC2SpotInstanceType;
-        State?: EC2SpotInstanceState;
-        Fault?: EC2SpotInstanceStateFault;
-        Status?: EC2SpotInstanceStatus;
-        ValidFrom?: EC2DateTime;
-        ValidUntil?: EC2DateTime;
-        LaunchGroup?: EC2String;
-        AvailabilityZoneGroup?: EC2String;
-        LaunchSpecification?: EC2LaunchSpecification;
-        InstanceId?: EC2String;
-        CreateTime?: EC2DateTime;
-        ProductDescription?: EC2RIProductDescription;
-        BlockDurationMinutes?: EC2Integer;
-        ActualBlockHourlyPrice?: EC2String;
-        Tags?: EC2TagList;
-        LaunchedAvailabilityZone?: EC2String;
-    }
-
-    export type EC2SpotInstanceRequestIdList = Array<EC2String>;
-    export type EC2SpotInstanceRequestList = Array<EC2SpotInstanceRequest>;
-    export type EC2SpotInstanceState = string;
-    export interface EC2SpotInstanceStateFault {
-        Code?: EC2String;
-        Message?: EC2String;
-    }
-
-    export interface EC2SpotInstanceStatus {
-        Code?: EC2String;
-        UpdateTime?: EC2DateTime;
-        Message?: EC2String;
-    }
-
-    export type EC2SpotInstanceType = string;
-    export interface EC2SpotPlacement {
-        AvailabilityZone?: EC2String;
-        GroupName?: EC2String;
-    }
-
-    export interface EC2SpotPrice {
-        InstanceType?: EC2InstanceType;
-        ProductDescription?: EC2RIProductDescription;
-        SpotPrice?: EC2String;
-        Timestamp?: EC2DateTime;
-        AvailabilityZone?: EC2String;
-    }
-
-    export type EC2SpotPriceHistoryList = Array<EC2SpotPrice>;
-    export interface EC2StartInstancesRequest {
-        InstanceIds: EC2InstanceIdStringList;
-        AdditionalInfo?: EC2String;
-        DryRun?: EC2Boolean;
-    }
-
-    export interface EC2StartInstancesResult {
-        StartingInstances?: EC2InstanceStateChangeList;
-    }
-
-    export type EC2State = string;
-    export interface EC2StateReason {
-        Code?: EC2String;
-        Message?: EC2String;
-    }
-
-    export type EC2Status = string;
-    export type EC2StatusName = string;
-    export type EC2StatusType = string;
-    export interface EC2StopInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds: EC2InstanceIdStringList;
-        Force?: EC2Boolean;
-    }
-
-    export interface EC2StopInstancesResult {
-        StoppingInstances?: EC2InstanceStateChangeList;
-    }
-
-    export interface EC2Storage {
-        S3?: EC2S3Storage;
-    }
-
-    export type EC2String = string;
-    export interface EC2Subnet {
-        SubnetId?: EC2String;
-        State?: EC2SubnetState;
-        VpcId?: EC2String;
-        CidrBlock?: EC2String;
-        AvailableIpAddressCount?: EC2Integer;
-        AvailabilityZone?: EC2String;
-        DefaultForAz?: EC2Boolean;
-        MapPublicIpOnLaunch?: EC2Boolean;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2SubnetIdStringList = Array<EC2String>;
-    export type EC2SubnetList = Array<EC2Subnet>;
-    export type EC2SubnetState = string;
-    export type EC2SummaryStatus = string;
-    export interface EC2Tag {
-        Key?: EC2String;
-        Value?: EC2String;
-    }
-
-    export interface EC2TagDescription {
-        ResourceId?: EC2String;
-        ResourceType?: EC2ResourceType;
-        Key?: EC2String;
-        Value?: EC2String;
-    }
-
-    export type EC2TagDescriptionList = Array<EC2TagDescription>;
-    export type EC2TagList = Array<EC2Tag>;
-    export type EC2TelemetryStatus = string;
-    export type EC2Tenancy = string;
-    export interface EC2TerminateInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds: EC2InstanceIdStringList;
-    }
-
-    export interface EC2TerminateInstancesResult {
-        TerminatingInstances?: EC2InstanceStateChangeList;
-    }
-
-    export type EC2TrafficType = string;
-    export interface EC2UnassignPrivateIpAddressesRequest {
-        NetworkInterfaceId: EC2String;
-        PrivateIpAddresses: EC2PrivateIpAddressStringList;
-    }
-
-    export interface EC2UnmonitorInstancesRequest {
-        DryRun?: EC2Boolean;
-        InstanceIds: EC2InstanceIdStringList;
-    }
-
-    export interface EC2UnmonitorInstancesResult {
-        InstanceMonitorings?: EC2InstanceMonitoringList;
-    }
-
-    export interface EC2UnsuccessfulItem {
-        Error: EC2UnsuccessfulItemError;
-        ResourceId?: EC2String;
-    }
-
-    export interface EC2UnsuccessfulItemError {
-        Code: EC2String;
-        Message: EC2String;
-    }
-
-    export type EC2UnsuccessfulItemList = Array<EC2UnsuccessfulItem>;
-    export type EC2UnsuccessfulItemSet = Array<EC2UnsuccessfulItem>;
-    export interface EC2UserBucket {
-        S3Bucket?: EC2String;
-        S3Key?: EC2String;
-    }
-
-    export interface EC2UserBucketDetails {
-        S3Bucket?: EC2String;
-        S3Key?: EC2String;
-    }
-
-    export interface EC2UserData {
-        Data?: EC2String;
-    }
-
-    export type EC2UserGroupStringList = Array<EC2String>;
-    export interface EC2UserIdGroupPair {
-        UserId?: EC2String;
-        GroupName?: EC2String;
-        GroupId?: EC2String;
-    }
-
-    export type EC2UserIdGroupPairList = Array<EC2UserIdGroupPair>;
-    export type EC2UserIdStringList = Array<EC2String>;
-    export type EC2ValueStringList = Array<EC2String>;
-    export interface EC2VgwTelemetry {
-        OutsideIpAddress?: EC2String;
-        Status?: EC2TelemetryStatus;
-        LastStatusChange?: EC2DateTime;
-        StatusMessage?: EC2String;
-        AcceptedRouteCount?: EC2Integer;
-    }
-
-    export type EC2VgwTelemetryList = Array<EC2VgwTelemetry>;
-    export type EC2VirtualizationType = string;
-    export interface EC2Volume {
-        VolumeId?: EC2String;
-        Size?: EC2Integer;
-        SnapshotId?: EC2String;
-        AvailabilityZone?: EC2String;
-        State?: EC2VolumeState;
-        CreateTime?: EC2DateTime;
-        Attachments?: EC2VolumeAttachmentList;
-        Tags?: EC2TagList;
-        VolumeType?: EC2VolumeType;
-        Iops?: EC2Integer;
-        Encrypted?: EC2Boolean;
-        KmsKeyId?: EC2String;
-    }
-
-    export interface EC2VolumeAttachment {
-        VolumeId?: EC2String;
-        InstanceId?: EC2String;
-        Device?: EC2String;
-        State?: EC2VolumeAttachmentState;
-        AttachTime?: EC2DateTime;
-        DeleteOnTermination?: EC2Boolean;
-    }
-
-    export type EC2VolumeAttachmentList = Array<EC2VolumeAttachment>;
-    export type EC2VolumeAttachmentState = string;
-    export type EC2VolumeAttributeName = string;
-    export interface EC2VolumeDetail {
-        Size: EC2Long;
-    }
-
-    export type EC2VolumeIdStringList = Array<EC2String>;
-    export type EC2VolumeList = Array<EC2Volume>;
-    export type EC2VolumeState = string;
-    export interface EC2VolumeStatusAction {
-        Code?: EC2String;
-        Description?: EC2String;
-        EventType?: EC2String;
-        EventId?: EC2String;
-    }
-
-    export type EC2VolumeStatusActionsList = Array<EC2VolumeStatusAction>;
-    export interface EC2VolumeStatusDetails {
-        Name?: EC2VolumeStatusName;
-        Status?: EC2String;
-    }
-
-    export type EC2VolumeStatusDetailsList = Array<EC2VolumeStatusDetails>;
-    export interface EC2VolumeStatusEvent {
-        EventType?: EC2String;
-        Description?: EC2String;
-        NotBefore?: EC2DateTime;
-        NotAfter?: EC2DateTime;
-        EventId?: EC2String;
-    }
-
-    export type EC2VolumeStatusEventsList = Array<EC2VolumeStatusEvent>;
-    export interface EC2VolumeStatusInfo {
-        Status?: EC2VolumeStatusInfoStatus;
-        Details?: EC2VolumeStatusDetailsList;
-    }
-
-    export type EC2VolumeStatusInfoStatus = string;
-    export interface EC2VolumeStatusItem {
-        VolumeId?: EC2String;
-        AvailabilityZone?: EC2String;
-        VolumeStatus?: EC2VolumeStatusInfo;
-        Events?: EC2VolumeStatusEventsList;
-        Actions?: EC2VolumeStatusActionsList;
-    }
-
-    export type EC2VolumeStatusList = Array<EC2VolumeStatusItem>;
-    export type EC2VolumeStatusName = string;
-    export type EC2VolumeType = string;
-    export interface EC2Vpc {
-        VpcId?: EC2String;
-        State?: EC2VpcState;
-        CidrBlock?: EC2String;
-        DhcpOptionsId?: EC2String;
-        Tags?: EC2TagList;
-        InstanceTenancy?: EC2Tenancy;
-        IsDefault?: EC2Boolean;
-    }
-
-    export interface EC2VpcAttachment {
-        VpcId?: EC2String;
-        State?: EC2AttachmentStatus;
-    }
-
-    export type EC2VpcAttachmentList = Array<EC2VpcAttachment>;
-    export type EC2VpcAttributeName = string;
-    export interface EC2VpcClassicLink {
-        VpcId?: EC2String;
-        ClassicLinkEnabled?: EC2Boolean;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2VpcClassicLinkIdList = Array<EC2String>;
-    export type EC2VpcClassicLinkList = Array<EC2VpcClassicLink>;
-    export interface EC2VpcEndpoint {
-        VpcEndpointId?: EC2String;
-        VpcId?: EC2String;
-        ServiceName?: EC2String;
-        State?: EC2State;
-        PolicyDocument?: EC2String;
-        RouteTableIds?: EC2ValueStringList;
-        CreationTimestamp?: EC2DateTime;
-    }
-
-    export type EC2VpcEndpointSet = Array<EC2VpcEndpoint>;
-    export type EC2VpcIdStringList = Array<EC2String>;
-    export type EC2VpcList = Array<EC2Vpc>;
-    export interface EC2VpcPeeringConnection {
-        AccepterVpcInfo?: EC2VpcPeeringConnectionVpcInfo;
-        ExpirationTime?: EC2DateTime;
-        RequesterVpcInfo?: EC2VpcPeeringConnectionVpcInfo;
-        Status?: EC2VpcPeeringConnectionStateReason;
-        Tags?: EC2TagList;
-        VpcPeeringConnectionId?: EC2String;
-    }
-
-    export type EC2VpcPeeringConnectionList = Array<EC2VpcPeeringConnection>;
-    export interface EC2VpcPeeringConnectionStateReason {
-        Code?: EC2VpcPeeringConnectionStateReasonCode;
-        Message?: EC2String;
-    }
-
-    export type EC2VpcPeeringConnectionStateReasonCode = string;
-    export interface EC2VpcPeeringConnectionVpcInfo {
-        CidrBlock?: EC2String;
-        OwnerId?: EC2String;
-        VpcId?: EC2String;
-    }
-
-    export type EC2VpcState = string;
-    export interface EC2VpnConnection {
-        VpnConnectionId?: EC2String;
-        State?: EC2VpnState;
-        CustomerGatewayConfiguration?: EC2String;
-        Type?: EC2GatewayType;
-        CustomerGatewayId?: EC2String;
-        VpnGatewayId?: EC2String;
-        Tags?: EC2TagList;
-        VgwTelemetry?: EC2VgwTelemetryList;
-        Options?: EC2VpnConnectionOptions;
-        Routes?: EC2VpnStaticRouteList;
-    }
-
-    export type EC2VpnConnectionIdStringList = Array<EC2String>;
-    export type EC2VpnConnectionList = Array<EC2VpnConnection>;
-    export interface EC2VpnConnectionOptions {
-        StaticRoutesOnly?: EC2Boolean;
-    }
-
-    export interface EC2VpnConnectionOptionsSpecification {
-        StaticRoutesOnly?: EC2Boolean;
-    }
-
-    export interface EC2VpnGateway {
-        VpnGatewayId?: EC2String;
-        State?: EC2VpnState;
-        Type?: EC2GatewayType;
-        AvailabilityZone?: EC2String;
-        VpcAttachments?: EC2VpcAttachmentList;
-        Tags?: EC2TagList;
-    }
-
-    export type EC2VpnGatewayIdStringList = Array<EC2String>;
-    export type EC2VpnGatewayList = Array<EC2VpnGateway>;
-    export type EC2VpnState = string;
-    export interface EC2VpnStaticRoute {
-        DestinationCidrBlock?: EC2String;
-        Source?: EC2VpnStaticRouteSource;
-        State?: EC2VpnState;
-    }
-
-    export type EC2VpnStaticRouteList = Array<EC2VpnStaticRoute>;
-    export type EC2VpnStaticRouteSource = string;
-    export type EC2ZoneNameStringList = Array<EC2String>;
 }

--- a/output/aws-ecs.d.ts
+++ b/output/aws-ecs.d.ts
@@ -6,614 +6,527 @@ declare module "aws-sdk" {
 
     export class ECS extends Service {
       constructor(options?: any);
-      createCluster(params: ECSCreateClusterRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSCreateClusterResponse|any) => void): Request;
-      createService(params: ECSCreateServiceRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSCreateServiceResponse|any) => void): Request;
-      deleteCluster(params: ECSDeleteClusterRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|ECSClusterContainsContainerInstancesException|ECSClusterContainsServicesException|any, data: ECSDeleteClusterResponse|any) => void): Request;
-      deleteService(params: ECSDeleteServiceRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|ECSServiceNotFoundException|any, data: ECSDeleteServiceResponse|any) => void): Request;
-      deregisterContainerInstance(params: ECSDeregisterContainerInstanceRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSDeregisterContainerInstanceResponse|any) => void): Request;
-      deregisterTaskDefinition(params: ECSDeregisterTaskDefinitionRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSDeregisterTaskDefinitionResponse|any) => void): Request;
-      describeClusters(params: ECSDescribeClustersRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSDescribeClustersResponse|any) => void): Request;
-      describeContainerInstances(params: ECSDescribeContainerInstancesRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSDescribeContainerInstancesResponse|any) => void): Request;
-      describeServices(params: ECSDescribeServicesRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSDescribeServicesResponse|any) => void): Request;
-      describeTaskDefinition(params: ECSDescribeTaskDefinitionRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSDescribeTaskDefinitionResponse|any) => void): Request;
-      describeTasks(params: ECSDescribeTasksRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSDescribeTasksResponse|any) => void): Request;
-      discoverPollEndpoint(params: ECSDiscoverPollEndpointRequest, callback?: (err: ECSServerException|ECSClientException|any, data: ECSDiscoverPollEndpointResponse|any) => void): Request;
-      listClusters(params: ECSListClustersRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSListClustersResponse|any) => void): Request;
-      listContainerInstances(params: ECSListContainerInstancesRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSListContainerInstancesResponse|any) => void): Request;
-      listServices(params: ECSListServicesRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSListServicesResponse|any) => void): Request;
-      listTaskDefinitionFamilies(params: ECSListTaskDefinitionFamiliesRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSListTaskDefinitionFamiliesResponse|any) => void): Request;
-      listTaskDefinitions(params: ECSListTaskDefinitionsRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSListTaskDefinitionsResponse|any) => void): Request;
-      listTasks(params: ECSListTasksRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|ECSServiceNotFoundException|any, data: ECSListTasksResponse|any) => void): Request;
-      registerContainerInstance(params: ECSRegisterContainerInstanceRequest, callback?: (err: ECSServerException|ECSClientException|any, data: ECSRegisterContainerInstanceResponse|any) => void): Request;
-      registerTaskDefinition(params: ECSRegisterTaskDefinitionRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|any, data: ECSRegisterTaskDefinitionResponse|any) => void): Request;
-      runTask(params: ECSRunTaskRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSRunTaskResponse|any) => void): Request;
-      startTask(params: ECSStartTaskRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSStartTaskResponse|any) => void): Request;
-      stopTask(params: ECSStopTaskRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|any, data: ECSStopTaskResponse|any) => void): Request;
-      submitContainerStateChange(params: ECSSubmitContainerStateChangeRequest, callback?: (err: ECSServerException|ECSClientException|any, data: ECSSubmitContainerStateChangeResponse|any) => void): Request;
-      submitTaskStateChange(params: ECSSubmitTaskStateChangeRequest, callback?: (err: ECSServerException|ECSClientException|any, data: ECSSubmitTaskStateChangeResponse|any) => void): Request;
-      updateContainerAgent(params: ECSUpdateContainerAgentRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|ECSUpdateInProgressException|ECSNoUpdateAvailableException|ECSMissingVersionException|any, data: ECSUpdateContainerAgentResponse|any) => void): Request;
-      updateService(params: ECSUpdateServiceRequest, callback?: (err: ECSServerException|ECSClientException|ECSInvalidParameterException|ECSClusterNotFoundException|ECSServiceNotFoundException|ECSServiceNotActiveException|any, data: ECSUpdateServiceResponse|any) => void): Request;
-    }
-
-    export type ECSAgentUpdateStatus = string;
-    export interface ECSAttribute {
-        name: ECSString;
-        value?: ECSString;
-    }
-
-    export type ECSAttributes = Array<ECSAttribute>;
-    export type ECSBoolean = boolean;
-    export type ECSBoxedBoolean = boolean;
-    export type ECSBoxedInteger = number;
-    export interface ECSClientException {
-        message?: ECSString;
-    }
-
-    export interface ECSCluster {
-        clusterArn?: ECSString;
-        clusterName?: ECSString;
-        status?: ECSString;
-        registeredContainerInstancesCount?: ECSInteger;
-        runningTasksCount?: ECSInteger;
-        pendingTasksCount?: ECSInteger;
-        activeServicesCount?: ECSInteger;
-    }
-
-    export interface ECSClusterContainsContainerInstancesException {
-    }
-
-    export interface ECSClusterContainsServicesException {
-    }
-
-    export interface ECSClusterNotFoundException {
-    }
-
-    export type ECSClusters = Array<ECSCluster>;
-    export interface ECSContainer {
-        containerArn?: ECSString;
-        taskArn?: ECSString;
-        name?: ECSString;
-        lastStatus?: ECSString;
-        exitCode?: ECSBoxedInteger;
-        reason?: ECSString;
-        networkBindings?: ECSNetworkBindings;
-    }
-
-    export interface ECSContainerDefinition {
-        name?: ECSString;
-        image?: ECSString;
-        cpu?: ECSInteger;
-        memory?: ECSInteger;
-        links?: ECSStringList;
-        portMappings?: ECSPortMappingList;
-        essential?: ECSBoxedBoolean;
-        entryPoint?: ECSStringList;
-        command?: ECSStringList;
-        environment?: ECSEnvironmentVariables;
-        mountPoints?: ECSMountPointList;
-        volumesFrom?: ECSVolumeFromList;
-        hostname?: ECSString;
-        user?: ECSString;
-        workingDirectory?: ECSString;
-        disableNetworking?: ECSBoxedBoolean;
-        privileged?: ECSBoxedBoolean;
-        readonlyRootFilesystem?: ECSBoxedBoolean;
-        dnsServers?: ECSStringList;
-        dnsSearchDomains?: ECSStringList;
-        extraHosts?: ECSHostEntryList;
-        dockerSecurityOptions?: ECSStringList;
-        dockerLabels?: ECSDockerLabelsMap;
-        ulimits?: ECSUlimitList;
-        logConfiguration?: ECSLogConfiguration;
-    }
-
-    export type ECSContainerDefinitions = Array<ECSContainerDefinition>;
-    export interface ECSContainerInstance {
-        containerInstanceArn?: ECSString;
-        ec2InstanceId?: ECSString;
-        versionInfo?: ECSVersionInfo;
-        remainingResources?: ECSResources;
-        registeredResources?: ECSResources;
-        status?: ECSString;
-        agentConnected?: ECSBoolean;
-        runningTasksCount?: ECSInteger;
-        pendingTasksCount?: ECSInteger;
-        agentUpdateStatus?: ECSAgentUpdateStatus;
-        attributes?: ECSAttributes;
-    }
-
-    export type ECSContainerInstances = Array<ECSContainerInstance>;
-    export interface ECSContainerOverride {
-        name?: ECSString;
-        command?: ECSStringList;
-        environment?: ECSEnvironmentVariables;
-    }
-
-    export type ECSContainerOverrides = Array<ECSContainerOverride>;
-    export type ECSContainers = Array<ECSContainer>;
-    export interface ECSCreateClusterRequest {
-        clusterName?: ECSString;
-    }
-
-    export interface ECSCreateClusterResponse {
-        cluster?: ECSCluster;
-    }
-
-    export interface ECSCreateServiceRequest {
-        cluster?: ECSString;
-        serviceName: ECSString;
-        taskDefinition: ECSString;
-        loadBalancers?: ECSLoadBalancers;
-        desiredCount: ECSBoxedInteger;
-        clientToken?: ECSString;
-        role?: ECSString;
-    }
-
-    export interface ECSCreateServiceResponse {
-        service?: ECSService;
-    }
-
-    export interface ECSDeleteClusterRequest {
-        cluster: ECSString;
-    }
-
-    export interface ECSDeleteClusterResponse {
-        cluster?: ECSCluster;
-    }
-
-    export interface ECSDeleteServiceRequest {
-        cluster?: ECSString;
-        service: ECSString;
-    }
-
-    export interface ECSDeleteServiceResponse {
-        service?: ECSService;
-    }
-
-    export interface ECSDeployment {
-        id?: ECSString;
-        status?: ECSString;
-        taskDefinition?: ECSString;
-        desiredCount?: ECSInteger;
-        pendingCount?: ECSInteger;
-        runningCount?: ECSInteger;
-        createdAt?: ECSTimestamp;
-        updatedAt?: ECSTimestamp;
-    }
-
-    export type ECSDeployments = Array<ECSDeployment>;
-    export interface ECSDeregisterContainerInstanceRequest {
-        cluster?: ECSString;
-        containerInstance: ECSString;
-        force?: ECSBoxedBoolean;
-    }
-
-    export interface ECSDeregisterContainerInstanceResponse {
-        containerInstance?: ECSContainerInstance;
-    }
-
-    export interface ECSDeregisterTaskDefinitionRequest {
-        taskDefinition: ECSString;
-    }
-
-    export interface ECSDeregisterTaskDefinitionResponse {
-        taskDefinition?: ECSTaskDefinition;
-    }
-
-    export interface ECSDescribeClustersRequest {
-        clusters?: ECSStringList;
-    }
-
-    export interface ECSDescribeClustersResponse {
-        clusters?: ECSClusters;
-        failures?: ECSFailures;
-    }
-
-    export interface ECSDescribeContainerInstancesRequest {
-        cluster?: ECSString;
-        containerInstances: ECSStringList;
-    }
-
-    export interface ECSDescribeContainerInstancesResponse {
-        containerInstances?: ECSContainerInstances;
-        failures?: ECSFailures;
-    }
-
-    export interface ECSDescribeServicesRequest {
-        cluster?: ECSString;
-        services: ECSStringList;
-    }
-
-    export interface ECSDescribeServicesResponse {
-        services?: ECSServices;
-        failures?: ECSFailures;
-    }
-
-    export interface ECSDescribeTaskDefinitionRequest {
-        taskDefinition: ECSString;
-    }
-
-    export interface ECSDescribeTaskDefinitionResponse {
-        taskDefinition?: ECSTaskDefinition;
-    }
-
-    export interface ECSDescribeTasksRequest {
-        cluster?: ECSString;
-        tasks: ECSStringList;
-    }
-
-    export interface ECSDescribeTasksResponse {
-        tasks?: ECSTasks;
-        failures?: ECSFailures;
-    }
-
-    export type ECSDesiredStatus = string;
-    export interface ECSDiscoverPollEndpointRequest {
-        containerInstance?: ECSString;
-        cluster?: ECSString;
-    }
-
-    export interface ECSDiscoverPollEndpointResponse {
-        endpoint?: ECSString;
-        telemetryEndpoint?: ECSString;
-    }
-
-    export type ECSDockerLabelsMap = any; // not really - it was 'map' instead - must fix this one
-    export type ECSDouble = number;
-    export type ECSEnvironmentVariables = Array<ECSKeyValuePair>;
-    export interface ECSFailure {
-        arn?: ECSString;
-        reason?: ECSString;
-    }
-
-    export type ECSFailures = Array<ECSFailure>;
-    export interface ECSHostEntry {
-        hostname: ECSString;
-        ipAddress: ECSString;
-    }
-
-    export type ECSHostEntryList = Array<ECSHostEntry>;
-    export interface ECSHostVolumeProperties {
-        sourcePath?: ECSString;
-    }
-
-    export type ECSInteger = number;
-    export interface ECSInvalidParameterException {
-    }
-
-    export interface ECSKeyValuePair {
-        name?: ECSString;
-        value?: ECSString;
-    }
-
-    export interface ECSListClustersRequest {
-        nextToken?: ECSString;
-        maxResults?: ECSBoxedInteger;
-    }
-
-    export interface ECSListClustersResponse {
-        clusterArns?: ECSStringList;
-        nextToken?: ECSString;
-    }
-
-    export interface ECSListContainerInstancesRequest {
-        cluster?: ECSString;
-        nextToken?: ECSString;
-        maxResults?: ECSBoxedInteger;
-    }
-
-    export interface ECSListContainerInstancesResponse {
-        containerInstanceArns?: ECSStringList;
-        nextToken?: ECSString;
-    }
-
-    export interface ECSListServicesRequest {
-        cluster?: ECSString;
-        nextToken?: ECSString;
-        maxResults?: ECSBoxedInteger;
-    }
+      createCluster(params: ECS.CreateClusterRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.CreateClusterResponse|any) => void): Request;
+      createService(params: ECS.CreateServiceRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.CreateServiceResponse|any) => void): Request;
+      deleteCluster(params: ECS.DeleteClusterRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|ECS.ClusterContainsContainerInstancesException|ECS.ClusterContainsServicesException|any, data: ECS.DeleteClusterResponse|any) => void): Request;
+      deleteService(params: ECS.DeleteServiceRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|ECS.ServiceNotFoundException|any, data: ECS.DeleteServiceResponse|any) => void): Request;
+      deregisterContainerInstance(params: ECS.DeregisterContainerInstanceRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.DeregisterContainerInstanceResponse|any) => void): Request;
+      deregisterTaskDefinition(params: ECS.DeregisterTaskDefinitionRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.DeregisterTaskDefinitionResponse|any) => void): Request;
+      describeClusters(params: ECS.DescribeClustersRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.DescribeClustersResponse|any) => void): Request;
+      describeContainerInstances(params: ECS.DescribeContainerInstancesRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.DescribeContainerInstancesResponse|any) => void): Request;
+      describeServices(params: ECS.DescribeServicesRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.DescribeServicesResponse|any) => void): Request;
+      describeTaskDefinition(params: ECS.DescribeTaskDefinitionRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.DescribeTaskDefinitionResponse|any) => void): Request;
+      describeTasks(params: ECS.DescribeTasksRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.DescribeTasksResponse|any) => void): Request;
+      discoverPollEndpoint(params: ECS.DiscoverPollEndpointRequest, callback?: (err: ECS.ServerException|ECS.ClientException|any, data: ECS.DiscoverPollEndpointResponse|any) => void): Request;
+      listClusters(params: ECS.ListClustersRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.ListClustersResponse|any) => void): Request;
+      listContainerInstances(params: ECS.ListContainerInstancesRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.ListContainerInstancesResponse|any) => void): Request;
+      listServices(params: ECS.ListServicesRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.ListServicesResponse|any) => void): Request;
+      listTaskDefinitionFamilies(params: ECS.ListTaskDefinitionFamiliesRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.ListTaskDefinitionFamiliesResponse|any) => void): Request;
+      listTaskDefinitions(params: ECS.ListTaskDefinitionsRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.ListTaskDefinitionsResponse|any) => void): Request;
+      listTasks(params: ECS.ListTasksRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|ECS.ServiceNotFoundException|any, data: ECS.ListTasksResponse|any) => void): Request;
+      registerContainerInstance(params: ECS.RegisterContainerInstanceRequest, callback?: (err: ECS.ServerException|ECS.ClientException|any, data: ECS.RegisterContainerInstanceResponse|any) => void): Request;
+      registerTaskDefinition(params: ECS.RegisterTaskDefinitionRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|any, data: ECS.RegisterTaskDefinitionResponse|any) => void): Request;
+      runTask(params: ECS.RunTaskRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.RunTaskResponse|any) => void): Request;
+      startTask(params: ECS.StartTaskRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.StartTaskResponse|any) => void): Request;
+      stopTask(params: ECS.StopTaskRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|any, data: ECS.StopTaskResponse|any) => void): Request;
+      submitContainerStateChange(params: ECS.SubmitContainerStateChangeRequest, callback?: (err: ECS.ServerException|ECS.ClientException|any, data: ECS.SubmitContainerStateChangeResponse|any) => void): Request;
+      submitTaskStateChange(params: ECS.SubmitTaskStateChangeRequest, callback?: (err: ECS.ServerException|ECS.ClientException|any, data: ECS.SubmitTaskStateChangeResponse|any) => void): Request;
+      updateContainerAgent(params: ECS.UpdateContainerAgentRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|ECS.UpdateInProgressException|ECS.NoUpdateAvailableException|ECS.MissingVersionException|any, data: ECS.UpdateContainerAgentResponse|any) => void): Request;
+      updateService(params: ECS.UpdateServiceRequest, callback?: (err: ECS.ServerException|ECS.ClientException|ECS.InvalidParameterException|ECS.ClusterNotFoundException|ECS.ServiceNotFoundException|ECS.ServiceNotActiveException|any, data: ECS.UpdateServiceResponse|any) => void): Request;
+    }
+    
+    export module ECS {
+        export type AgentUpdateStatus = string;
+        export type Attributes = Attribute[];
+        export type Boolean = boolean;
+        export type BoxedBoolean = boolean;
+        export type BoxedInteger = number;
+        export type Clusters = Cluster[];
+        export type ContainerDefinitions = ContainerDefinition[];
+        export type ContainerInstances = ContainerInstance[];
+        export type ContainerOverrides = ContainerOverride[];
+        export type Containers = Container[];
+        export type Deployments = Deployment[];
+        export type DesiredStatus = string;
+        export type DockerLabelsMap = {[key:string]: String};
+        export type Double = number;
+        export type EnvironmentVariables = KeyValuePair[];
+        export type Failures = Failure[];
+        export type HostEntryList = HostEntry[];
+        export type Integer = number;
+        export type LoadBalancers = LoadBalancer[];
+        export type LogConfigurationOptionsMap = {[key:string]: String};
+        export type LogDriver = string;
+        export type Long = number;
+        export type MountPointList = MountPoint[];
+        export type NetworkBindings = NetworkBinding[];
+        export type PortMappingList = PortMapping[];
+        export type RequiresAttributes = Attribute[];
+        export type Resources = Resource[];
+        export type ServiceEvents = ServiceEvent[];
+        export type Services = Service[];
+        export type SortOrder = string;
+        export type String = string;
+        export type StringList = String[];
+        export type TaskDefinitionStatus = string;
+        export type Tasks = Task[];
+        export type Timestamp = number;
+        export type TransportProtocol = string;
+        export type UlimitList = Ulimit[];
+        export type UlimitName = string;
+        export type VolumeFromList = VolumeFrom[];
+        export type VolumeList = Volume[];
+
+        export interface Attribute {
+            name: String;            
+            value?: String;            
+        }
+        export interface ClientException {
+            message?: String;            
+        }
+        export interface Cluster {
+            clusterArn?: String;            
+            clusterName?: String;            
+            status?: String;            
+            registeredContainerInstancesCount?: Integer;            
+            runningTasksCount?: Integer;            
+            pendingTasksCount?: Integer;            
+            activeServicesCount?: Integer;            
+        }
+        export interface ClusterContainsContainerInstancesException {
+        }
+        export interface ClusterContainsServicesException {
+        }
+        export interface ClusterNotFoundException {
+        }
+        export interface Container {
+            containerArn?: String;            
+            taskArn?: String;            
+            name?: String;            
+            lastStatus?: String;            
+            exitCode?: BoxedInteger;            
+            reason?: String;            
+            networkBindings?: NetworkBindings;            
+        }
+        export interface ContainerDefinition {
+            name?: String;            
+            image?: String;            
+            cpu?: Integer;            
+            memory?: Integer;            
+            links?: StringList;            
+            portMappings?: PortMappingList;            
+            essential?: BoxedBoolean;            
+            entryPoint?: StringList;            
+            command?: StringList;            
+            environment?: EnvironmentVariables;            
+            mountPoints?: MountPointList;            
+            volumesFrom?: VolumeFromList;            
+            hostname?: String;            
+            user?: String;            
+            workingDirectory?: String;            
+            disableNetworking?: BoxedBoolean;            
+            privileged?: BoxedBoolean;            
+            readonlyRootFilesystem?: BoxedBoolean;            
+            dnsServers?: StringList;            
+            dnsSearchDomains?: StringList;            
+            extraHosts?: HostEntryList;            
+            dockerSecurityOptions?: StringList;            
+            dockerLabels?: DockerLabelsMap;            
+            ulimits?: UlimitList;            
+            logConfiguration?: LogConfiguration;            
+        }
+        export interface ContainerInstance {
+            containerInstanceArn?: String;            
+            ec2InstanceId?: String;            
+            versionInfo?: VersionInfo;            
+            remainingResources?: Resources;            
+            registeredResources?: Resources;            
+            status?: String;            
+            agentConnected?: Boolean;            
+            runningTasksCount?: Integer;            
+            pendingTasksCount?: Integer;            
+            agentUpdateStatus?: AgentUpdateStatus;            
+            attributes?: Attributes;            
+        }
+        export interface ContainerOverride {
+            name?: String;            
+            command?: StringList;            
+            environment?: EnvironmentVariables;            
+        }
+        export interface CreateClusterRequest {
+            clusterName?: String;            
+        }
+        export interface CreateClusterResponse {
+            cluster?: Cluster;            
+        }
+        export interface CreateServiceRequest {
+            cluster?: String;            
+            serviceName: String;            
+            taskDefinition: String;            
+            loadBalancers?: LoadBalancers;            
+            desiredCount: BoxedInteger;            
+            clientToken?: String;            
+            role?: String;            
+        }
+        export interface CreateServiceResponse {
+            service?: Service;            
+        }
+        export interface DeleteClusterRequest {
+            cluster: String;            
+        }
+        export interface DeleteClusterResponse {
+            cluster?: Cluster;            
+        }
+        export interface DeleteServiceRequest {
+            cluster?: String;            
+            service: String;            
+        }
+        export interface DeleteServiceResponse {
+            service?: Service;            
+        }
+        export interface Deployment {
+            id?: String;            
+            status?: String;            
+            taskDefinition?: String;            
+            desiredCount?: Integer;            
+            pendingCount?: Integer;            
+            runningCount?: Integer;            
+            createdAt?: Timestamp;            
+            updatedAt?: Timestamp;            
+        }
+        export interface DeregisterContainerInstanceRequest {
+            cluster?: String;            
+            containerInstance: String;            
+            force?: BoxedBoolean;            
+        }
+        export interface DeregisterContainerInstanceResponse {
+            containerInstance?: ContainerInstance;            
+        }
+        export interface DeregisterTaskDefinitionRequest {
+            taskDefinition: String;            
+        }
+        export interface DeregisterTaskDefinitionResponse {
+            taskDefinition?: TaskDefinition;            
+        }
+        export interface DescribeClustersRequest {
+            clusters?: StringList;            
+        }
+        export interface DescribeClustersResponse {
+            clusters?: Clusters;            
+            failures?: Failures;            
+        }
+        export interface DescribeContainerInstancesRequest {
+            cluster?: String;            
+            containerInstances: StringList;            
+        }
+        export interface DescribeContainerInstancesResponse {
+            containerInstances?: ContainerInstances;            
+            failures?: Failures;            
+        }
+        export interface DescribeServicesRequest {
+            cluster?: String;            
+            services: StringList;            
+        }
+        export interface DescribeServicesResponse {
+            services?: Services;            
+            failures?: Failures;            
+        }
+        export interface DescribeTaskDefinitionRequest {
+            taskDefinition: String;            
+        }
+        export interface DescribeTaskDefinitionResponse {
+            taskDefinition?: TaskDefinition;            
+        }
+        export interface DescribeTasksRequest {
+            cluster?: String;            
+            tasks: StringList;            
+        }
+        export interface DescribeTasksResponse {
+            tasks?: Tasks;            
+            failures?: Failures;            
+        }
+        export interface DiscoverPollEndpointRequest {
+            containerInstance?: String;            
+            cluster?: String;            
+        }
+        export interface DiscoverPollEndpointResponse {
+            endpoint?: String;            
+            telemetryEndpoint?: String;            
+        }
+        export interface Failure {
+            arn?: String;            
+            reason?: String;            
+        }
+        export interface HostEntry {
+            hostname: String;            
+            ipAddress: String;            
+        }
+        export interface HostVolumeProperties {
+            sourcePath?: String;            
+        }
+        export interface InvalidParameterException {
+        }
+        export interface KeyValuePair {
+            name?: String;            
+            value?: String;            
+        }
+        export interface ListClustersRequest {
+            nextToken?: String;            
+            maxResults?: BoxedInteger;            
+        }
+        export interface ListClustersResponse {
+            clusterArns?: StringList;            
+            nextToken?: String;            
+        }
+        export interface ListContainerInstancesRequest {
+            cluster?: String;            
+            nextToken?: String;            
+            maxResults?: BoxedInteger;            
+        }
+        export interface ListContainerInstancesResponse {
+            containerInstanceArns?: StringList;            
+            nextToken?: String;            
+        }
+        export interface ListServicesRequest {
+            cluster?: String;            
+            nextToken?: String;            
+            maxResults?: BoxedInteger;            
+        }
+        export interface ListServicesResponse {
+            serviceArns?: StringList;            
+            nextToken?: String;            
+        }
+        export interface ListTaskDefinitionFamiliesRequest {
+            familyPrefix?: String;            
+            nextToken?: String;            
+            maxResults?: BoxedInteger;            
+        }
+        export interface ListTaskDefinitionFamiliesResponse {
+            families?: StringList;            
+            nextToken?: String;            
+        }
+        export interface ListTaskDefinitionsRequest {
+            familyPrefix?: String;            
+            status?: TaskDefinitionStatus;            
+            sort?: SortOrder;            
+            nextToken?: String;            
+            maxResults?: BoxedInteger;            
+        }
+        export interface ListTaskDefinitionsResponse {
+            taskDefinitionArns?: StringList;            
+            nextToken?: String;            
+        }
+        export interface ListTasksRequest {
+            cluster?: String;            
+            containerInstance?: String;            
+            family?: String;            
+            nextToken?: String;            
+            maxResults?: BoxedInteger;            
+            startedBy?: String;            
+            serviceName?: String;            
+            desiredStatus?: DesiredStatus;            
+        }
+        export interface ListTasksResponse {
+            taskArns?: StringList;            
+            nextToken?: String;            
+        }
+        export interface LoadBalancer {
+            loadBalancerName?: String;            
+            containerName?: String;            
+            containerPort?: BoxedInteger;            
+        }
+        export interface LogConfiguration {
+            logDriver: LogDriver;            
+            options?: LogConfigurationOptionsMap;            
+        }
+        export interface MissingVersionException {
+        }
+        export interface MountPoint {
+            sourceVolume?: String;            
+            containerPath?: String;            
+            readOnly?: BoxedBoolean;            
+        }
+        export interface NetworkBinding {
+            bindIP?: String;            
+            containerPort?: BoxedInteger;            
+            hostPort?: BoxedInteger;            
+            protocol?: TransportProtocol;            
+        }
+        export interface NoUpdateAvailableException {
+        }
+        export interface PortMapping {
+            containerPort?: Integer;            
+            hostPort?: Integer;            
+            protocol?: TransportProtocol;            
+        }
+        export interface RegisterContainerInstanceRequest {
+            cluster?: String;            
+            instanceIdentityDocument?: String;            
+            instanceIdentityDocumentSignature?: String;            
+            totalResources?: Resources;            
+            versionInfo?: VersionInfo;            
+            containerInstanceArn?: String;            
+            attributes?: Attributes;            
+        }
+        export interface RegisterContainerInstanceResponse {
+            containerInstance?: ContainerInstance;            
+        }
+        export interface RegisterTaskDefinitionRequest {
+            family: String;            
+            containerDefinitions: ContainerDefinitions;            
+            volumes?: VolumeList;            
+        }
+        export interface RegisterTaskDefinitionResponse {
+            taskDefinition?: TaskDefinition;            
+        }
+        export interface Resource {
+            name?: String;            
+            type?: String;            
+            doubleValue?: Double;            
+            longValue?: Long;            
+            integerValue?: Integer;            
+            stringSetValue?: StringList;            
+        }
+        export interface RunTaskRequest {
+            cluster?: String;            
+            taskDefinition: String;            
+            overrides?: TaskOverride;            
+            count?: BoxedInteger;            
+            startedBy?: String;            
+        }
+        export interface RunTaskResponse {
+            tasks?: Tasks;            
+            failures?: Failures;            
+        }
+        export interface ServerException {
+            message?: String;            
+        }
+        export interface Service {
+            serviceArn?: String;            
+            serviceName?: String;            
+            clusterArn?: String;            
+            loadBalancers?: LoadBalancers;            
+            status?: String;            
+            desiredCount?: Integer;            
+            runningCount?: Integer;            
+            pendingCount?: Integer;            
+            taskDefinition?: String;            
+            deployments?: Deployments;            
+            roleArn?: String;            
+            events?: ServiceEvents;            
+        }
+        export interface ServiceEvent {
+            id?: String;            
+            createdAt?: Timestamp;            
+            message?: String;            
+        }
+        export interface ServiceNotActiveException {
+        }
+        export interface ServiceNotFoundException {
+        }
+        export interface StartTaskRequest {
+            cluster?: String;            
+            taskDefinition: String;            
+            overrides?: TaskOverride;            
+            containerInstances: StringList;            
+            startedBy?: String;            
+        }
+        export interface StartTaskResponse {
+            tasks?: Tasks;            
+            failures?: Failures;            
+        }
+        export interface StopTaskRequest {
+            cluster?: String;            
+            task: String;            
+            reason?: String;            
+        }
+        export interface StopTaskResponse {
+            task?: Task;            
+        }
+        export interface SubmitContainerStateChangeRequest {
+            cluster?: String;            
+            task?: String;            
+            containerName?: String;            
+            status?: String;            
+            exitCode?: BoxedInteger;            
+            reason?: String;            
+            networkBindings?: NetworkBindings;            
+        }
+        export interface SubmitContainerStateChangeResponse {
+            acknowledgment?: String;            
+        }
+        export interface SubmitTaskStateChangeRequest {
+            cluster?: String;            
+            task?: String;            
+            status?: String;            
+            reason?: String;            
+        }
+        export interface SubmitTaskStateChangeResponse {
+            acknowledgment?: String;            
+        }
+        export interface Task {
+            taskArn?: String;            
+            clusterArn?: String;            
+            taskDefinitionArn?: String;            
+            containerInstanceArn?: String;            
+            overrides?: TaskOverride;            
+            lastStatus?: String;            
+            desiredStatus?: String;            
+            containers?: Containers;            
+            startedBy?: String;            
+            stoppedReason?: String;            
+            createdAt?: Timestamp;            
+            startedAt?: Timestamp;            
+            stoppedAt?: Timestamp;            
+        }
+        export interface TaskDefinition {
+            taskDefinitionArn?: String;            
+            containerDefinitions?: ContainerDefinitions;            
+            family?: String;            
+            revision?: Integer;            
+            volumes?: VolumeList;            
+            status?: TaskDefinitionStatus;            
+            requiresAttributes?: RequiresAttributes;            
+        }
+        export interface TaskOverride {
+            containerOverrides?: ContainerOverrides;            
+        }
+        export interface Ulimit {
+            name: UlimitName;            
+            softLimit: Integer;            
+            hardLimit: Integer;            
+        }
+        export interface UpdateContainerAgentRequest {
+            cluster?: String;            
+            containerInstance: String;            
+        }
+        export interface UpdateContainerAgentResponse {
+            containerInstance?: ContainerInstance;            
+        }
+        export interface UpdateInProgressException {
+        }
+        export interface UpdateServiceRequest {
+            cluster?: String;            
+            service: String;            
+            desiredCount?: BoxedInteger;            
+            taskDefinition?: String;            
+        }
+        export interface UpdateServiceResponse {
+            service?: Service;            
+        }
+        export interface VersionInfo {
+            agentVersion?: String;            
+            agentHash?: String;            
+            dockerVersion?: String;            
+        }
+        export interface Volume {
+            name?: String;            
+            host?: HostVolumeProperties;            
+        }
+        export interface VolumeFrom {
+            sourceContainer?: String;            
+            readOnly?: BoxedBoolean;            
+        }
 
-    export interface ECSListServicesResponse {
-        serviceArns?: ECSStringList;
-        nextToken?: ECSString;
     }
-
-    export interface ECSListTaskDefinitionFamiliesRequest {
-        familyPrefix?: ECSString;
-        nextToken?: ECSString;
-        maxResults?: ECSBoxedInteger;
-    }
-
-    export interface ECSListTaskDefinitionFamiliesResponse {
-        families?: ECSStringList;
-        nextToken?: ECSString;
-    }
-
-    export interface ECSListTaskDefinitionsRequest {
-        familyPrefix?: ECSString;
-        status?: ECSTaskDefinitionStatus;
-        sort?: ECSSortOrder;
-        nextToken?: ECSString;
-        maxResults?: ECSBoxedInteger;
-    }
-
-    export interface ECSListTaskDefinitionsResponse {
-        taskDefinitionArns?: ECSStringList;
-        nextToken?: ECSString;
-    }
-
-    export interface ECSListTasksRequest {
-        cluster?: ECSString;
-        containerInstance?: ECSString;
-        family?: ECSString;
-        nextToken?: ECSString;
-        maxResults?: ECSBoxedInteger;
-        startedBy?: ECSString;
-        serviceName?: ECSString;
-        desiredStatus?: ECSDesiredStatus;
-    }
-
-    export interface ECSListTasksResponse {
-        taskArns?: ECSStringList;
-        nextToken?: ECSString;
-    }
-
-    export interface ECSLoadBalancer {
-        loadBalancerName?: ECSString;
-        containerName?: ECSString;
-        containerPort?: ECSBoxedInteger;
-    }
-
-    export type ECSLoadBalancers = Array<ECSLoadBalancer>;
-    export interface ECSLogConfiguration {
-        logDriver: ECSLogDriver;
-        options?: ECSLogConfigurationOptionsMap;
-    }
-
-    export type ECSLogConfigurationOptionsMap = any; // not really - it was 'map' instead - must fix this one
-    export type ECSLogDriver = string;
-    export type ECSLong = number;
-    export interface ECSMissingVersionException {
-    }
-
-    export interface ECSMountPoint {
-        sourceVolume?: ECSString;
-        containerPath?: ECSString;
-        readOnly?: ECSBoxedBoolean;
-    }
-
-    export type ECSMountPointList = Array<ECSMountPoint>;
-    export interface ECSNetworkBinding {
-        bindIP?: ECSString;
-        containerPort?: ECSBoxedInteger;
-        hostPort?: ECSBoxedInteger;
-        protocol?: ECSTransportProtocol;
-    }
-
-    export type ECSNetworkBindings = Array<ECSNetworkBinding>;
-    export interface ECSNoUpdateAvailableException {
-    }
-
-    export interface ECSPortMapping {
-        containerPort?: ECSInteger;
-        hostPort?: ECSInteger;
-        protocol?: ECSTransportProtocol;
-    }
-
-    export type ECSPortMappingList = Array<ECSPortMapping>;
-    export interface ECSRegisterContainerInstanceRequest {
-        cluster?: ECSString;
-        instanceIdentityDocument?: ECSString;
-        instanceIdentityDocumentSignature?: ECSString;
-        totalResources?: ECSResources;
-        versionInfo?: ECSVersionInfo;
-        containerInstanceArn?: ECSString;
-        attributes?: ECSAttributes;
-    }
-
-    export interface ECSRegisterContainerInstanceResponse {
-        containerInstance?: ECSContainerInstance;
-    }
-
-    export interface ECSRegisterTaskDefinitionRequest {
-        family: ECSString;
-        containerDefinitions: ECSContainerDefinitions;
-        volumes?: ECSVolumeList;
-    }
-
-    export interface ECSRegisterTaskDefinitionResponse {
-        taskDefinition?: ECSTaskDefinition;
-    }
-
-    export type ECSRequiresAttributes = Array<ECSAttribute>;
-    export interface ECSResource {
-        name?: ECSString;
-        type?: ECSString;
-        doubleValue?: ECSDouble;
-        longValue?: ECSLong;
-        integerValue?: ECSInteger;
-        stringSetValue?: ECSStringList;
-    }
-
-    export type ECSResources = Array<ECSResource>;
-    export interface ECSRunTaskRequest {
-        cluster?: ECSString;
-        taskDefinition: ECSString;
-        overrides?: ECSTaskOverride;
-        count?: ECSBoxedInteger;
-        startedBy?: ECSString;
-    }
-
-    export interface ECSRunTaskResponse {
-        tasks?: ECSTasks;
-        failures?: ECSFailures;
-    }
-
-    export interface ECSServerException {
-        message?: ECSString;
-    }
-
-    export interface ECSService {
-        serviceArn?: ECSString;
-        serviceName?: ECSString;
-        clusterArn?: ECSString;
-        loadBalancers?: ECSLoadBalancers;
-        status?: ECSString;
-        desiredCount?: ECSInteger;
-        runningCount?: ECSInteger;
-        pendingCount?: ECSInteger;
-        taskDefinition?: ECSString;
-        deployments?: ECSDeployments;
-        roleArn?: ECSString;
-        events?: ECSServiceEvents;
-    }
-
-    export interface ECSServiceEvent {
-        id?: ECSString;
-        createdAt?: ECSTimestamp;
-        message?: ECSString;
-    }
-
-    export type ECSServiceEvents = Array<ECSServiceEvent>;
-    export interface ECSServiceNotActiveException {
-    }
-
-    export interface ECSServiceNotFoundException {
-    }
-
-    export type ECSServices = Array<ECSService>;
-    export type ECSSortOrder = string;
-    export interface ECSStartTaskRequest {
-        cluster?: ECSString;
-        taskDefinition: ECSString;
-        overrides?: ECSTaskOverride;
-        containerInstances: ECSStringList;
-        startedBy?: ECSString;
-    }
-
-    export interface ECSStartTaskResponse {
-        tasks?: ECSTasks;
-        failures?: ECSFailures;
-    }
-
-    export interface ECSStopTaskRequest {
-        cluster?: ECSString;
-        task: ECSString;
-        reason?: ECSString;
-    }
-
-    export interface ECSStopTaskResponse {
-        task?: ECSTask;
-    }
-
-    export type ECSString = string;
-    export type ECSStringList = Array<ECSString>;
-    export interface ECSSubmitContainerStateChangeRequest {
-        cluster?: ECSString;
-        task?: ECSString;
-        containerName?: ECSString;
-        status?: ECSString;
-        exitCode?: ECSBoxedInteger;
-        reason?: ECSString;
-        networkBindings?: ECSNetworkBindings;
-    }
-
-    export interface ECSSubmitContainerStateChangeResponse {
-        acknowledgment?: ECSString;
-    }
-
-    export interface ECSSubmitTaskStateChangeRequest {
-        cluster?: ECSString;
-        task?: ECSString;
-        status?: ECSString;
-        reason?: ECSString;
-    }
-
-    export interface ECSSubmitTaskStateChangeResponse {
-        acknowledgment?: ECSString;
-    }
-
-    export interface ECSTask {
-        taskArn?: ECSString;
-        clusterArn?: ECSString;
-        taskDefinitionArn?: ECSString;
-        containerInstanceArn?: ECSString;
-        overrides?: ECSTaskOverride;
-        lastStatus?: ECSString;
-        desiredStatus?: ECSString;
-        containers?: ECSContainers;
-        startedBy?: ECSString;
-        stoppedReason?: ECSString;
-        createdAt?: ECSTimestamp;
-        startedAt?: ECSTimestamp;
-        stoppedAt?: ECSTimestamp;
-    }
-
-    export interface ECSTaskDefinition {
-        taskDefinitionArn?: ECSString;
-        containerDefinitions?: ECSContainerDefinitions;
-        family?: ECSString;
-        revision?: ECSInteger;
-        volumes?: ECSVolumeList;
-        status?: ECSTaskDefinitionStatus;
-        requiresAttributes?: ECSRequiresAttributes;
-    }
-
-    export type ECSTaskDefinitionStatus = string;
-    export interface ECSTaskOverride {
-        containerOverrides?: ECSContainerOverrides;
-    }
-
-    export type ECSTasks = Array<ECSTask>;
-    export type ECSTimestamp = number;
-    export type ECSTransportProtocol = string;
-    export interface ECSUlimit {
-        name: ECSUlimitName;
-        softLimit: ECSInteger;
-        hardLimit: ECSInteger;
-    }
-
-    export type ECSUlimitList = Array<ECSUlimit>;
-    export type ECSUlimitName = string;
-    export interface ECSUpdateContainerAgentRequest {
-        cluster?: ECSString;
-        containerInstance: ECSString;
-    }
-
-    export interface ECSUpdateContainerAgentResponse {
-        containerInstance?: ECSContainerInstance;
-    }
-
-    export interface ECSUpdateInProgressException {
-    }
-
-    export interface ECSUpdateServiceRequest {
-        cluster?: ECSString;
-        service: ECSString;
-        desiredCount?: ECSBoxedInteger;
-        taskDefinition?: ECSString;
-    }
-
-    export interface ECSUpdateServiceResponse {
-        service?: ECSService;
-    }
-
-    export interface ECSVersionInfo {
-        agentVersion?: ECSString;
-        agentHash?: ECSString;
-        dockerVersion?: ECSString;
-    }
-
-    export interface ECSVolume {
-        name?: ECSString;
-        host?: ECSHostVolumeProperties;
-    }
-
-    export interface ECSVolumeFrom {
-        sourceContainer?: ECSString;
-        readOnly?: ECSBoxedBoolean;
-    }
-
-    export type ECSVolumeFromList = Array<ECSVolumeFrom>;
-    export type ECSVolumeList = Array<ECSVolume>;
 }

--- a/output/aws-elasticache.d.ts
+++ b/output/aws-elasticache.d.ts
@@ -6,893 +6,756 @@ declare module "aws-sdk" {
 
     export class ElastiCache extends Service {
       constructor(options?: any);
-      addTagsToResource(params: ElastiCacheAddTagsToResourceMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheSnapshotNotFoundFault|ElastiCacheTagQuotaPerResourceExceeded|ElastiCacheInvalidARNFault|any, data: ElastiCacheTagListMessage|any) => void): Request;
-      authorizeCacheSecurityGroupIngress(params: ElastiCacheAuthorizeCacheSecurityGroupIngressMessage, callback?: (err: ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheInvalidCacheSecurityGroupStateFault|ElastiCacheAuthorizationAlreadyExistsFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheAuthorizeCacheSecurityGroupIngressResult|any) => void): Request;
-      copySnapshot(params: ElastiCacheCopySnapshotMessage, callback?: (err: ElastiCacheSnapshotAlreadyExistsFault|ElastiCacheSnapshotNotFoundFault|ElastiCacheSnapshotQuotaExceededFault|ElastiCacheInvalidSnapshotStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCopySnapshotResult|any) => void): Request;
-      createCacheCluster(params: ElastiCacheCreateCacheClusterMessage, callback?: (err: ElastiCacheReplicationGroupNotFoundFault|ElastiCacheInvalidReplicationGroupStateFault|ElastiCacheCacheClusterAlreadyExistsFault|ElastiCacheInsufficientCacheClusterCapacityFault|ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheCacheSubnetGroupNotFoundFault|ElastiCacheClusterQuotaForCustomerExceededFault|ElastiCacheNodeQuotaForClusterExceededFault|ElastiCacheNodeQuotaForCustomerExceededFault|ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidVPCNetworkStateFault|ElastiCacheTagQuotaPerResourceExceeded|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCreateCacheClusterResult|any) => void): Request;
-      createCacheParameterGroup(params: ElastiCacheCreateCacheParameterGroupMessage, callback?: (err: ElastiCacheCacheParameterGroupQuotaExceededFault|ElastiCacheCacheParameterGroupAlreadyExistsFault|ElastiCacheInvalidCacheParameterGroupStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCreateCacheParameterGroupResult|any) => void): Request;
-      createCacheSecurityGroup(params: ElastiCacheCreateCacheSecurityGroupMessage, callback?: (err: ElastiCacheCacheSecurityGroupAlreadyExistsFault|ElastiCacheCacheSecurityGroupQuotaExceededFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCreateCacheSecurityGroupResult|any) => void): Request;
-      createCacheSubnetGroup(params: ElastiCacheCreateCacheSubnetGroupMessage, callback?: (err: ElastiCacheCacheSubnetGroupAlreadyExistsFault|ElastiCacheCacheSubnetGroupQuotaExceededFault|ElastiCacheCacheSubnetQuotaExceededFault|ElastiCacheInvalidSubnet|any, data: ElastiCacheCreateCacheSubnetGroupResult|any) => void): Request;
-      createReplicationGroup(params: ElastiCacheCreateReplicationGroupMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheInvalidCacheClusterStateFault|ElastiCacheReplicationGroupAlreadyExistsFault|ElastiCacheInsufficientCacheClusterCapacityFault|ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheCacheSubnetGroupNotFoundFault|ElastiCacheClusterQuotaForCustomerExceededFault|ElastiCacheNodeQuotaForClusterExceededFault|ElastiCacheNodeQuotaForCustomerExceededFault|ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidVPCNetworkStateFault|ElastiCacheTagQuotaPerResourceExceeded|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCreateReplicationGroupResult|any) => void): Request;
-      createSnapshot(params: ElastiCacheCreateSnapshotMessage, callback?: (err: ElastiCacheSnapshotAlreadyExistsFault|ElastiCacheCacheClusterNotFoundFault|ElastiCacheInvalidCacheClusterStateFault|ElastiCacheSnapshotQuotaExceededFault|ElastiCacheSnapshotFeatureNotSupportedFault|ElastiCacheInvalidParameterCombinationException|ElastiCacheInvalidParameterValueException|any, data: ElastiCacheCreateSnapshotResult|any) => void): Request;
-      deleteCacheCluster(params: ElastiCacheDeleteCacheClusterMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheInvalidCacheClusterStateFault|ElastiCacheSnapshotAlreadyExistsFault|ElastiCacheSnapshotFeatureNotSupportedFault|ElastiCacheSnapshotQuotaExceededFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheDeleteCacheClusterResult|any) => void): Request;
-      deleteCacheParameterGroup(params: ElastiCacheDeleteCacheParameterGroupMessage, callback?: (err: ElastiCacheInvalidCacheParameterGroupStateFault|ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: any) => void): Request;
-      deleteCacheSecurityGroup(params: ElastiCacheDeleteCacheSecurityGroupMessage, callback?: (err: ElastiCacheInvalidCacheSecurityGroupStateFault|ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: any) => void): Request;
-      deleteCacheSubnetGroup(params: ElastiCacheDeleteCacheSubnetGroupMessage, callback?: (err: ElastiCacheCacheSubnetGroupInUse|ElastiCacheCacheSubnetGroupNotFoundFault|any, data: any) => void): Request;
-      deleteReplicationGroup(params: ElastiCacheDeleteReplicationGroupMessage, callback?: (err: ElastiCacheReplicationGroupNotFoundFault|ElastiCacheInvalidReplicationGroupStateFault|ElastiCacheSnapshotAlreadyExistsFault|ElastiCacheSnapshotFeatureNotSupportedFault|ElastiCacheSnapshotQuotaExceededFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheDeleteReplicationGroupResult|any) => void): Request;
-      deleteSnapshot(params: ElastiCacheDeleteSnapshotMessage, callback?: (err: ElastiCacheSnapshotNotFoundFault|ElastiCacheInvalidSnapshotStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheDeleteSnapshotResult|any) => void): Request;
-      describeCacheClusters(params: ElastiCacheDescribeCacheClustersMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCacheClusterMessage|any) => void): Request;
-      describeCacheEngineVersions(params: ElastiCacheDescribeCacheEngineVersionsMessage, callback?: (err: any, data: ElastiCacheCacheEngineVersionMessage|any) => void): Request;
-      describeCacheParameterGroups(params: ElastiCacheDescribeCacheParameterGroupsMessage, callback?: (err: ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCacheParameterGroupsMessage|any) => void): Request;
-      describeCacheParameters(params: ElastiCacheDescribeCacheParametersMessage, callback?: (err: ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCacheParameterGroupDetails|any) => void): Request;
-      describeCacheSecurityGroups(params: ElastiCacheDescribeCacheSecurityGroupsMessage, callback?: (err: ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCacheSecurityGroupMessage|any) => void): Request;
-      describeCacheSubnetGroups(params: ElastiCacheDescribeCacheSubnetGroupsMessage, callback?: (err: ElastiCacheCacheSubnetGroupNotFoundFault|any, data: ElastiCacheCacheSubnetGroupMessage|any) => void): Request;
-      describeEngineDefaultParameters(params: ElastiCacheDescribeEngineDefaultParametersMessage, callback?: (err: ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheDescribeEngineDefaultParametersResult|any) => void): Request;
-      describeEvents(params: ElastiCacheDescribeEventsMessage, callback?: (err: ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheEventsMessage|any) => void): Request;
-      describeReplicationGroups(params: ElastiCacheDescribeReplicationGroupsMessage, callback?: (err: ElastiCacheReplicationGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheReplicationGroupMessage|any) => void): Request;
-      describeReservedCacheNodes(params: ElastiCacheDescribeReservedCacheNodesMessage, callback?: (err: ElastiCacheReservedCacheNodeNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheReservedCacheNodeMessage|any) => void): Request;
-      describeReservedCacheNodesOfferings(params: ElastiCacheDescribeReservedCacheNodesOfferingsMessage, callback?: (err: ElastiCacheReservedCacheNodesOfferingNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheReservedCacheNodesOfferingMessage|any) => void): Request;
-      describeSnapshots(params: ElastiCacheDescribeSnapshotsMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheSnapshotNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheDescribeSnapshotsListMessage|any) => void): Request;
-      listTagsForResource(params: ElastiCacheListTagsForResourceMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheSnapshotNotFoundFault|ElastiCacheInvalidARNFault|any, data: ElastiCacheTagListMessage|any) => void): Request;
-      modifyCacheCluster(params: ElastiCacheModifyCacheClusterMessage, callback?: (err: ElastiCacheInvalidCacheClusterStateFault|ElastiCacheInvalidCacheSecurityGroupStateFault|ElastiCacheInsufficientCacheClusterCapacityFault|ElastiCacheCacheClusterNotFoundFault|ElastiCacheNodeQuotaForClusterExceededFault|ElastiCacheNodeQuotaForCustomerExceededFault|ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidVPCNetworkStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheModifyCacheClusterResult|any) => void): Request;
-      modifyCacheParameterGroup(params: ElastiCacheModifyCacheParameterGroupMessage, callback?: (err: ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidCacheParameterGroupStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCacheParameterGroupNameMessage|any) => void): Request;
-      modifyCacheSubnetGroup(params: ElastiCacheModifyCacheSubnetGroupMessage, callback?: (err: ElastiCacheCacheSubnetGroupNotFoundFault|ElastiCacheCacheSubnetQuotaExceededFault|ElastiCacheSubnetInUse|ElastiCacheInvalidSubnet|any, data: ElastiCacheModifyCacheSubnetGroupResult|any) => void): Request;
-      modifyReplicationGroup(params: ElastiCacheModifyReplicationGroupMessage, callback?: (err: ElastiCacheReplicationGroupNotFoundFault|ElastiCacheInvalidReplicationGroupStateFault|ElastiCacheInvalidCacheClusterStateFault|ElastiCacheInvalidCacheSecurityGroupStateFault|ElastiCacheInsufficientCacheClusterCapacityFault|ElastiCacheCacheClusterNotFoundFault|ElastiCacheNodeQuotaForClusterExceededFault|ElastiCacheNodeQuotaForCustomerExceededFault|ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidVPCNetworkStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheModifyReplicationGroupResult|any) => void): Request;
-      purchaseReservedCacheNodesOffering(params: ElastiCachePurchaseReservedCacheNodesOfferingMessage, callback?: (err: ElastiCacheReservedCacheNodesOfferingNotFoundFault|ElastiCacheReservedCacheNodeAlreadyExistsFault|ElastiCacheReservedCacheNodeQuotaExceededFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCachePurchaseReservedCacheNodesOfferingResult|any) => void): Request;
-      rebootCacheCluster(params: ElastiCacheRebootCacheClusterMessage, callback?: (err: ElastiCacheInvalidCacheClusterStateFault|ElastiCacheCacheClusterNotFoundFault|any, data: ElastiCacheRebootCacheClusterResult|any) => void): Request;
-      removeTagsFromResource(params: ElastiCacheRemoveTagsFromResourceMessage, callback?: (err: ElastiCacheCacheClusterNotFoundFault|ElastiCacheSnapshotNotFoundFault|ElastiCacheInvalidARNFault|ElastiCacheTagNotFoundFault|any, data: ElastiCacheTagListMessage|any) => void): Request;
-      resetCacheParameterGroup(params: ElastiCacheResetCacheParameterGroupMessage, callback?: (err: ElastiCacheInvalidCacheParameterGroupStateFault|ElastiCacheCacheParameterGroupNotFoundFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheCacheParameterGroupNameMessage|any) => void): Request;
-      revokeCacheSecurityGroupIngress(params: ElastiCacheRevokeCacheSecurityGroupIngressMessage, callback?: (err: ElastiCacheCacheSecurityGroupNotFoundFault|ElastiCacheAuthorizationNotFoundFault|ElastiCacheInvalidCacheSecurityGroupStateFault|ElastiCacheInvalidParameterValueException|ElastiCacheInvalidParameterCombinationException|any, data: ElastiCacheRevokeCacheSecurityGroupIngressResult|any) => void): Request;
-    }
-
-    export type ElastiCacheAZMode = string;
-    export interface ElastiCacheAddTagsToResourceMessage {
-        ResourceName: ElastiCacheString;
-        Tags: ElastiCacheTagList;
-    }
-
-    export interface ElastiCacheAuthorizationAlreadyExistsFault {
-    }
-
-    export interface ElastiCacheAuthorizationNotFoundFault {
-    }
-
-    export interface ElastiCacheAuthorizeCacheSecurityGroupIngressMessage {
-        CacheSecurityGroupName: ElastiCacheString;
-        EC2SecurityGroupName: ElastiCacheString;
-        EC2SecurityGroupOwnerId: ElastiCacheString;
-    }
-
-    export type ElastiCacheAutomaticFailoverStatus = string;
-    export interface ElastiCacheAvailabilityZone {
-        Name?: ElastiCacheString;
-    }
-
-    export type ElastiCacheAvailabilityZonesList = Array<ElastiCacheString>;
-    export type ElastiCacheAwsQueryErrorMessage = string;
-    export type ElastiCacheBoolean = boolean;
-    export type ElastiCacheBooleanOptional = boolean;
-    export interface ElastiCacheCacheCluster {
-        CacheClusterId?: ElastiCacheString;
-        ConfigurationEndpoint?: ElastiCacheEndpoint;
-        ClientDownloadLandingPage?: ElastiCacheString;
-        CacheNodeType?: ElastiCacheString;
-        Engine?: ElastiCacheString;
-        EngineVersion?: ElastiCacheString;
-        CacheClusterStatus?: ElastiCacheString;
-        NumCacheNodes?: ElastiCacheIntegerOptional;
-        PreferredAvailabilityZone?: ElastiCacheString;
-        CacheClusterCreateTime?: ElastiCacheTStamp;
-        PreferredMaintenanceWindow?: ElastiCacheString;
-        PendingModifiedValues?: ElastiCachePendingModifiedValues;
-        NotificationConfiguration?: ElastiCacheNotificationConfiguration;
-        CacheSecurityGroups?: ElastiCacheCacheSecurityGroupMembershipList;
-        CacheParameterGroup?: ElastiCacheCacheParameterGroupStatus;
-        CacheSubnetGroupName?: ElastiCacheString;
-        CacheNodes?: ElastiCacheCacheNodeList;
-        AutoMinorVersionUpgrade?: ElastiCacheBoolean;
-        SecurityGroups?: ElastiCacheSecurityGroupMembershipList;
-        ReplicationGroupId?: ElastiCacheString;
-        SnapshotRetentionLimit?: ElastiCacheIntegerOptional;
-        SnapshotWindow?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCacheClusterAlreadyExistsFault {
-    }
-
-    export type ElastiCacheCacheClusterList = Array<ElastiCacheCacheCluster>;
-    export interface ElastiCacheCacheClusterMessage {
-        Marker?: ElastiCacheString;
-        CacheClusters?: ElastiCacheCacheClusterList;
-    }
-
-    export interface ElastiCacheCacheClusterNotFoundFault {
-    }
-
-    export interface ElastiCacheCacheEngineVersion {
-        Engine?: ElastiCacheString;
-        EngineVersion?: ElastiCacheString;
-        CacheParameterGroupFamily?: ElastiCacheString;
-        CacheEngineDescription?: ElastiCacheString;
-        CacheEngineVersionDescription?: ElastiCacheString;
-    }
-
-    export type ElastiCacheCacheEngineVersionList = Array<ElastiCacheCacheEngineVersion>;
-    export interface ElastiCacheCacheEngineVersionMessage {
-        Marker?: ElastiCacheString;
-        CacheEngineVersions?: ElastiCacheCacheEngineVersionList;
-    }
-
-    export interface ElastiCacheCacheNode {
-        CacheNodeId?: ElastiCacheString;
-        CacheNodeStatus?: ElastiCacheString;
-        CacheNodeCreateTime?: ElastiCacheTStamp;
-        Endpoint?: ElastiCacheEndpoint;
-        ParameterGroupStatus?: ElastiCacheString;
-        SourceCacheNodeId?: ElastiCacheString;
-        CustomerAvailabilityZone?: ElastiCacheString;
-    }
-
-    export type ElastiCacheCacheNodeIdsList = Array<ElastiCacheString>;
-    export type ElastiCacheCacheNodeList = Array<ElastiCacheCacheNode>;
-    export interface ElastiCacheCacheNodeTypeSpecificParameter {
-        ParameterName?: ElastiCacheString;
-        Description?: ElastiCacheString;
-        Source?: ElastiCacheString;
-        DataType?: ElastiCacheString;
-        AllowedValues?: ElastiCacheString;
-        IsModifiable?: ElastiCacheBoolean;
-        MinimumEngineVersion?: ElastiCacheString;
-        CacheNodeTypeSpecificValues?: ElastiCacheCacheNodeTypeSpecificValueList;
-    }
-
-    export type ElastiCacheCacheNodeTypeSpecificParametersList = Array<ElastiCacheCacheNodeTypeSpecificParameter>;
-    export interface ElastiCacheCacheNodeTypeSpecificValue {
-        CacheNodeType?: ElastiCacheString;
-        Value?: ElastiCacheString;
-    }
-
-    export type ElastiCacheCacheNodeTypeSpecificValueList = Array<ElastiCacheCacheNodeTypeSpecificValue>;
-    export interface ElastiCacheCacheParameterGroup {
-        CacheParameterGroupName?: ElastiCacheString;
-        CacheParameterGroupFamily?: ElastiCacheString;
-        Description?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCacheParameterGroupAlreadyExistsFault {
-    }
-
-    export interface ElastiCacheCacheParameterGroupDetails {
-        Marker?: ElastiCacheString;
-        Parameters?: ElastiCacheParametersList;
-        CacheNodeTypeSpecificParameters?: ElastiCacheCacheNodeTypeSpecificParametersList;
-    }
-
-    export type ElastiCacheCacheParameterGroupList = Array<ElastiCacheCacheParameterGroup>;
-    export interface ElastiCacheCacheParameterGroupNameMessage {
-        CacheParameterGroupName?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCacheParameterGroupNotFoundFault {
-    }
-
-    export interface ElastiCacheCacheParameterGroupQuotaExceededFault {
-    }
-
-    export interface ElastiCacheCacheParameterGroupStatus {
-        CacheParameterGroupName?: ElastiCacheString;
-        ParameterApplyStatus?: ElastiCacheString;
-        CacheNodeIdsToReboot?: ElastiCacheCacheNodeIdsList;
-    }
-
-    export interface ElastiCacheCacheParameterGroupsMessage {
-        Marker?: ElastiCacheString;
-        CacheParameterGroups?: ElastiCacheCacheParameterGroupList;
-    }
-
-    export interface ElastiCacheCacheSecurityGroup {
-        OwnerId?: ElastiCacheString;
-        CacheSecurityGroupName?: ElastiCacheString;
-        Description?: ElastiCacheString;
-        EC2SecurityGroups?: ElastiCacheEC2SecurityGroupList;
-    }
-
-    export interface ElastiCacheCacheSecurityGroupAlreadyExistsFault {
-    }
-
-    export interface ElastiCacheCacheSecurityGroupMembership {
-        CacheSecurityGroupName?: ElastiCacheString;
-        Status?: ElastiCacheString;
-    }
-
-    export type ElastiCacheCacheSecurityGroupMembershipList = Array<ElastiCacheCacheSecurityGroupMembership>;
-    export interface ElastiCacheCacheSecurityGroupMessage {
-        Marker?: ElastiCacheString;
-        CacheSecurityGroups?: ElastiCacheCacheSecurityGroups;
-    }
-
-    export type ElastiCacheCacheSecurityGroupNameList = Array<ElastiCacheString>;
-    export interface ElastiCacheCacheSecurityGroupNotFoundFault {
-    }
-
-    export interface ElastiCacheCacheSecurityGroupQuotaExceededFault {
-    }
-
-    export type ElastiCacheCacheSecurityGroups = Array<ElastiCacheCacheSecurityGroup>;
-    export interface ElastiCacheCacheSubnetGroup {
-        CacheSubnetGroupName?: ElastiCacheString;
-        CacheSubnetGroupDescription?: ElastiCacheString;
-        VpcId?: ElastiCacheString;
-        Subnets?: ElastiCacheSubnetList;
-    }
-
-    export interface ElastiCacheCacheSubnetGroupAlreadyExistsFault {
-    }
-
-    export interface ElastiCacheCacheSubnetGroupInUse {
-    }
-
-    export interface ElastiCacheCacheSubnetGroupMessage {
-        Marker?: ElastiCacheString;
-        CacheSubnetGroups?: ElastiCacheCacheSubnetGroups;
-    }
-
-    export interface ElastiCacheCacheSubnetGroupNotFoundFault {
-    }
-
-    export interface ElastiCacheCacheSubnetGroupQuotaExceededFault {
-    }
-
-    export type ElastiCacheCacheSubnetGroups = Array<ElastiCacheCacheSubnetGroup>;
-    export interface ElastiCacheCacheSubnetQuotaExceededFault {
-    }
-
-    export type ElastiCacheClusterIdList = Array<ElastiCacheString>;
-    export interface ElastiCacheClusterQuotaForCustomerExceededFault {
-    }
-
-    export interface ElastiCacheCopySnapshotMessage {
-        SourceSnapshotName: ElastiCacheString;
-        TargetSnapshotName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCreateCacheClusterMessage {
-        CacheClusterId: ElastiCacheString;
-        ReplicationGroupId?: ElastiCacheString;
-        AZMode?: ElastiCacheAZMode;
-        PreferredAvailabilityZone?: ElastiCacheString;
-        PreferredAvailabilityZones?: ElastiCachePreferredAvailabilityZoneList;
-        NumCacheNodes?: ElastiCacheIntegerOptional;
-        CacheNodeType?: ElastiCacheString;
-        Engine?: ElastiCacheString;
-        EngineVersion?: ElastiCacheString;
-        CacheParameterGroupName?: ElastiCacheString;
-        CacheSubnetGroupName?: ElastiCacheString;
-        CacheSecurityGroupNames?: ElastiCacheCacheSecurityGroupNameList;
-        SecurityGroupIds?: ElastiCacheSecurityGroupIdsList;
-        Tags?: ElastiCacheTagList;
-        SnapshotArns?: ElastiCacheSnapshotArnsList;
-        SnapshotName?: ElastiCacheString;
-        PreferredMaintenanceWindow?: ElastiCacheString;
-        Port?: ElastiCacheIntegerOptional;
-        NotificationTopicArn?: ElastiCacheString;
-        AutoMinorVersionUpgrade?: ElastiCacheBooleanOptional;
-        SnapshotRetentionLimit?: ElastiCacheIntegerOptional;
-        SnapshotWindow?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCreateCacheParameterGroupMessage {
-        CacheParameterGroupName: ElastiCacheString;
-        CacheParameterGroupFamily: ElastiCacheString;
-        Description: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCreateCacheSecurityGroupMessage {
-        CacheSecurityGroupName: ElastiCacheString;
-        Description: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCreateCacheSubnetGroupMessage {
-        CacheSubnetGroupName: ElastiCacheString;
-        CacheSubnetGroupDescription: ElastiCacheString;
-        SubnetIds: ElastiCacheSubnetIdentifierList;
-    }
-
-    export interface ElastiCacheCreateReplicationGroupMessage {
-        ReplicationGroupId: ElastiCacheString;
-        ReplicationGroupDescription: ElastiCacheString;
-        PrimaryClusterId?: ElastiCacheString;
-        AutomaticFailoverEnabled?: ElastiCacheBooleanOptional;
-        NumCacheClusters?: ElastiCacheIntegerOptional;
-        PreferredCacheClusterAZs?: ElastiCacheAvailabilityZonesList;
-        CacheNodeType?: ElastiCacheString;
-        Engine?: ElastiCacheString;
-        EngineVersion?: ElastiCacheString;
-        CacheParameterGroupName?: ElastiCacheString;
-        CacheSubnetGroupName?: ElastiCacheString;
-        CacheSecurityGroupNames?: ElastiCacheCacheSecurityGroupNameList;
-        SecurityGroupIds?: ElastiCacheSecurityGroupIdsList;
-        Tags?: ElastiCacheTagList;
-        SnapshotArns?: ElastiCacheSnapshotArnsList;
-        SnapshotName?: ElastiCacheString;
-        PreferredMaintenanceWindow?: ElastiCacheString;
-        Port?: ElastiCacheIntegerOptional;
-        NotificationTopicArn?: ElastiCacheString;
-        AutoMinorVersionUpgrade?: ElastiCacheBooleanOptional;
-        SnapshotRetentionLimit?: ElastiCacheIntegerOptional;
-        SnapshotWindow?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheCreateSnapshotMessage {
-        CacheClusterId: ElastiCacheString;
-        SnapshotName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDeleteCacheClusterMessage {
-        CacheClusterId: ElastiCacheString;
-        FinalSnapshotIdentifier?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDeleteCacheParameterGroupMessage {
-        CacheParameterGroupName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDeleteCacheSecurityGroupMessage {
-        CacheSecurityGroupName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDeleteCacheSubnetGroupMessage {
-        CacheSubnetGroupName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDeleteReplicationGroupMessage {
-        ReplicationGroupId: ElastiCacheString;
-        RetainPrimaryCluster?: ElastiCacheBooleanOptional;
-        FinalSnapshotIdentifier?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDeleteSnapshotMessage {
-        SnapshotName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeCacheClustersMessage {
-        CacheClusterId?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-        ShowCacheNodeInfo?: ElastiCacheBooleanOptional;
-    }
-
-    export interface ElastiCacheDescribeCacheEngineVersionsMessage {
-        Engine?: ElastiCacheString;
-        EngineVersion?: ElastiCacheString;
-        CacheParameterGroupFamily?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-        DefaultOnly?: ElastiCacheBoolean;
-    }
-
-    export interface ElastiCacheDescribeCacheParameterGroupsMessage {
-        CacheParameterGroupName?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeCacheParametersMessage {
-        CacheParameterGroupName: ElastiCacheString;
-        Source?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeCacheSecurityGroupsMessage {
-        CacheSecurityGroupName?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeCacheSubnetGroupsMessage {
-        CacheSubnetGroupName?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeEngineDefaultParametersMessage {
-        CacheParameterGroupFamily: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeEventsMessage {
-        SourceIdentifier?: ElastiCacheString;
-        SourceType?: ElastiCacheSourceType;
-        StartTime?: ElastiCacheTStamp;
-        EndTime?: ElastiCacheTStamp;
-        Duration?: ElastiCacheIntegerOptional;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeReplicationGroupsMessage {
-        ReplicationGroupId?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeReservedCacheNodesMessage {
-        ReservedCacheNodeId?: ElastiCacheString;
-        ReservedCacheNodesOfferingId?: ElastiCacheString;
-        CacheNodeType?: ElastiCacheString;
-        Duration?: ElastiCacheString;
-        ProductDescription?: ElastiCacheString;
-        OfferingType?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeReservedCacheNodesOfferingsMessage {
-        ReservedCacheNodesOfferingId?: ElastiCacheString;
-        CacheNodeType?: ElastiCacheString;
-        Duration?: ElastiCacheString;
-        ProductDescription?: ElastiCacheString;
-        OfferingType?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-        Marker?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheDescribeSnapshotsListMessage {
-        Marker?: ElastiCacheString;
-        Snapshots?: ElastiCacheSnapshotList;
-    }
-
-    export interface ElastiCacheDescribeSnapshotsMessage {
-        CacheClusterId?: ElastiCacheString;
-        SnapshotName?: ElastiCacheString;
-        SnapshotSource?: ElastiCacheString;
-        Marker?: ElastiCacheString;
-        MaxRecords?: ElastiCacheIntegerOptional;
-    }
-
-    export type ElastiCacheDouble = number;
-    export interface ElastiCacheEC2SecurityGroup {
-        Status?: ElastiCacheString;
-        EC2SecurityGroupName?: ElastiCacheString;
-        EC2SecurityGroupOwnerId?: ElastiCacheString;
-    }
-
-    export type ElastiCacheEC2SecurityGroupList = Array<ElastiCacheEC2SecurityGroup>;
-    export interface ElastiCacheEndpoint {
-        Address?: ElastiCacheString;
-        Port?: ElastiCacheInteger;
-    }
-
-    export interface ElastiCacheEngineDefaults {
-        CacheParameterGroupFamily?: ElastiCacheString;
-        Marker?: ElastiCacheString;
-        Parameters?: ElastiCacheParametersList;
-        CacheNodeTypeSpecificParameters?: ElastiCacheCacheNodeTypeSpecificParametersList;
-    }
-
-    export interface ElastiCacheEvent {
-        SourceIdentifier?: ElastiCacheString;
-        SourceType?: ElastiCacheSourceType;
-        Message?: ElastiCacheString;
-        Date?: ElastiCacheTStamp;
-    }
-
-    export type ElastiCacheEventList = Array<ElastiCacheEvent>;
-    export interface ElastiCacheEventsMessage {
-        Marker?: ElastiCacheString;
-        Events?: ElastiCacheEventList;
-    }
-
-    export interface ElastiCacheInsufficientCacheClusterCapacityFault {
-    }
-
-    export type ElastiCacheInteger = number;
-    export type ElastiCacheIntegerOptional = number;
-    export interface ElastiCacheInvalidARNFault {
-    }
-
-    export interface ElastiCacheInvalidCacheClusterStateFault {
-    }
+      addTagsToResource(params: ElastiCache.AddTagsToResourceMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.SnapshotNotFoundFault|ElastiCache.TagQuotaPerResourceExceeded|ElastiCache.InvalidARNFault|any, data: ElastiCache.TagListMessage|any) => void): Request;
+      authorizeCacheSecurityGroupIngress(params: ElastiCache.AuthorizeCacheSecurityGroupIngressMessage, callback?: (err: ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.InvalidCacheSecurityGroupStateFault|ElastiCache.AuthorizationAlreadyExistsFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.AuthorizeCacheSecurityGroupIngressResult|any) => void): Request;
+      copySnapshot(params: ElastiCache.CopySnapshotMessage, callback?: (err: ElastiCache.SnapshotAlreadyExistsFault|ElastiCache.SnapshotNotFoundFault|ElastiCache.SnapshotQuotaExceededFault|ElastiCache.InvalidSnapshotStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CopySnapshotResult|any) => void): Request;
+      createCacheCluster(params: ElastiCache.CreateCacheClusterMessage, callback?: (err: ElastiCache.ReplicationGroupNotFoundFault|ElastiCache.InvalidReplicationGroupStateFault|ElastiCache.CacheClusterAlreadyExistsFault|ElastiCache.InsufficientCacheClusterCapacityFault|ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.CacheSubnetGroupNotFoundFault|ElastiCache.ClusterQuotaForCustomerExceededFault|ElastiCache.NodeQuotaForClusterExceededFault|ElastiCache.NodeQuotaForCustomerExceededFault|ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidVPCNetworkStateFault|ElastiCache.TagQuotaPerResourceExceeded|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CreateCacheClusterResult|any) => void): Request;
+      createCacheParameterGroup(params: ElastiCache.CreateCacheParameterGroupMessage, callback?: (err: ElastiCache.CacheParameterGroupQuotaExceededFault|ElastiCache.CacheParameterGroupAlreadyExistsFault|ElastiCache.InvalidCacheParameterGroupStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CreateCacheParameterGroupResult|any) => void): Request;
+      createCacheSecurityGroup(params: ElastiCache.CreateCacheSecurityGroupMessage, callback?: (err: ElastiCache.CacheSecurityGroupAlreadyExistsFault|ElastiCache.CacheSecurityGroupQuotaExceededFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CreateCacheSecurityGroupResult|any) => void): Request;
+      createCacheSubnetGroup(params: ElastiCache.CreateCacheSubnetGroupMessage, callback?: (err: ElastiCache.CacheSubnetGroupAlreadyExistsFault|ElastiCache.CacheSubnetGroupQuotaExceededFault|ElastiCache.CacheSubnetQuotaExceededFault|ElastiCache.InvalidSubnet|any, data: ElastiCache.CreateCacheSubnetGroupResult|any) => void): Request;
+      createReplicationGroup(params: ElastiCache.CreateReplicationGroupMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.InvalidCacheClusterStateFault|ElastiCache.ReplicationGroupAlreadyExistsFault|ElastiCache.InsufficientCacheClusterCapacityFault|ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.CacheSubnetGroupNotFoundFault|ElastiCache.ClusterQuotaForCustomerExceededFault|ElastiCache.NodeQuotaForClusterExceededFault|ElastiCache.NodeQuotaForCustomerExceededFault|ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidVPCNetworkStateFault|ElastiCache.TagQuotaPerResourceExceeded|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CreateReplicationGroupResult|any) => void): Request;
+      createSnapshot(params: ElastiCache.CreateSnapshotMessage, callback?: (err: ElastiCache.SnapshotAlreadyExistsFault|ElastiCache.CacheClusterNotFoundFault|ElastiCache.InvalidCacheClusterStateFault|ElastiCache.SnapshotQuotaExceededFault|ElastiCache.SnapshotFeatureNotSupportedFault|ElastiCache.InvalidParameterCombinationException|ElastiCache.InvalidParameterValueException|any, data: ElastiCache.CreateSnapshotResult|any) => void): Request;
+      deleteCacheCluster(params: ElastiCache.DeleteCacheClusterMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.InvalidCacheClusterStateFault|ElastiCache.SnapshotAlreadyExistsFault|ElastiCache.SnapshotFeatureNotSupportedFault|ElastiCache.SnapshotQuotaExceededFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.DeleteCacheClusterResult|any) => void): Request;
+      deleteCacheParameterGroup(params: ElastiCache.DeleteCacheParameterGroupMessage, callback?: (err: ElastiCache.InvalidCacheParameterGroupStateFault|ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: any) => void): Request;
+      deleteCacheSecurityGroup(params: ElastiCache.DeleteCacheSecurityGroupMessage, callback?: (err: ElastiCache.InvalidCacheSecurityGroupStateFault|ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: any) => void): Request;
+      deleteCacheSubnetGroup(params: ElastiCache.DeleteCacheSubnetGroupMessage, callback?: (err: ElastiCache.CacheSubnetGroupInUse|ElastiCache.CacheSubnetGroupNotFoundFault|any, data: any) => void): Request;
+      deleteReplicationGroup(params: ElastiCache.DeleteReplicationGroupMessage, callback?: (err: ElastiCache.ReplicationGroupNotFoundFault|ElastiCache.InvalidReplicationGroupStateFault|ElastiCache.SnapshotAlreadyExistsFault|ElastiCache.SnapshotFeatureNotSupportedFault|ElastiCache.SnapshotQuotaExceededFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.DeleteReplicationGroupResult|any) => void): Request;
+      deleteSnapshot(params: ElastiCache.DeleteSnapshotMessage, callback?: (err: ElastiCache.SnapshotNotFoundFault|ElastiCache.InvalidSnapshotStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.DeleteSnapshotResult|any) => void): Request;
+      describeCacheClusters(params: ElastiCache.DescribeCacheClustersMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CacheClusterMessage|any) => void): Request;
+      describeCacheEngineVersions(params: ElastiCache.DescribeCacheEngineVersionsMessage, callback?: (err: any, data: ElastiCache.CacheEngineVersionMessage|any) => void): Request;
+      describeCacheParameterGroups(params: ElastiCache.DescribeCacheParameterGroupsMessage, callback?: (err: ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CacheParameterGroupsMessage|any) => void): Request;
+      describeCacheParameters(params: ElastiCache.DescribeCacheParametersMessage, callback?: (err: ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CacheParameterGroupDetails|any) => void): Request;
+      describeCacheSecurityGroups(params: ElastiCache.DescribeCacheSecurityGroupsMessage, callback?: (err: ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CacheSecurityGroupMessage|any) => void): Request;
+      describeCacheSubnetGroups(params: ElastiCache.DescribeCacheSubnetGroupsMessage, callback?: (err: ElastiCache.CacheSubnetGroupNotFoundFault|any, data: ElastiCache.CacheSubnetGroupMessage|any) => void): Request;
+      describeEngineDefaultParameters(params: ElastiCache.DescribeEngineDefaultParametersMessage, callback?: (err: ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.DescribeEngineDefaultParametersResult|any) => void): Request;
+      describeEvents(params: ElastiCache.DescribeEventsMessage, callback?: (err: ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.EventsMessage|any) => void): Request;
+      describeReplicationGroups(params: ElastiCache.DescribeReplicationGroupsMessage, callback?: (err: ElastiCache.ReplicationGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.ReplicationGroupMessage|any) => void): Request;
+      describeReservedCacheNodes(params: ElastiCache.DescribeReservedCacheNodesMessage, callback?: (err: ElastiCache.ReservedCacheNodeNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.ReservedCacheNodeMessage|any) => void): Request;
+      describeReservedCacheNodesOfferings(params: ElastiCache.DescribeReservedCacheNodesOfferingsMessage, callback?: (err: ElastiCache.ReservedCacheNodesOfferingNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.ReservedCacheNodesOfferingMessage|any) => void): Request;
+      describeSnapshots(params: ElastiCache.DescribeSnapshotsMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.SnapshotNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.DescribeSnapshotsListMessage|any) => void): Request;
+      listTagsForResource(params: ElastiCache.ListTagsForResourceMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.SnapshotNotFoundFault|ElastiCache.InvalidARNFault|any, data: ElastiCache.TagListMessage|any) => void): Request;
+      modifyCacheCluster(params: ElastiCache.ModifyCacheClusterMessage, callback?: (err: ElastiCache.InvalidCacheClusterStateFault|ElastiCache.InvalidCacheSecurityGroupStateFault|ElastiCache.InsufficientCacheClusterCapacityFault|ElastiCache.CacheClusterNotFoundFault|ElastiCache.NodeQuotaForClusterExceededFault|ElastiCache.NodeQuotaForCustomerExceededFault|ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidVPCNetworkStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.ModifyCacheClusterResult|any) => void): Request;
+      modifyCacheParameterGroup(params: ElastiCache.ModifyCacheParameterGroupMessage, callback?: (err: ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidCacheParameterGroupStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CacheParameterGroupNameMessage|any) => void): Request;
+      modifyCacheSubnetGroup(params: ElastiCache.ModifyCacheSubnetGroupMessage, callback?: (err: ElastiCache.CacheSubnetGroupNotFoundFault|ElastiCache.CacheSubnetQuotaExceededFault|ElastiCache.SubnetInUse|ElastiCache.InvalidSubnet|any, data: ElastiCache.ModifyCacheSubnetGroupResult|any) => void): Request;
+      modifyReplicationGroup(params: ElastiCache.ModifyReplicationGroupMessage, callback?: (err: ElastiCache.ReplicationGroupNotFoundFault|ElastiCache.InvalidReplicationGroupStateFault|ElastiCache.InvalidCacheClusterStateFault|ElastiCache.InvalidCacheSecurityGroupStateFault|ElastiCache.InsufficientCacheClusterCapacityFault|ElastiCache.CacheClusterNotFoundFault|ElastiCache.NodeQuotaForClusterExceededFault|ElastiCache.NodeQuotaForCustomerExceededFault|ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidVPCNetworkStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.ModifyReplicationGroupResult|any) => void): Request;
+      purchaseReservedCacheNodesOffering(params: ElastiCache.PurchaseReservedCacheNodesOfferingMessage, callback?: (err: ElastiCache.ReservedCacheNodesOfferingNotFoundFault|ElastiCache.ReservedCacheNodeAlreadyExistsFault|ElastiCache.ReservedCacheNodeQuotaExceededFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.PurchaseReservedCacheNodesOfferingResult|any) => void): Request;
+      rebootCacheCluster(params: ElastiCache.RebootCacheClusterMessage, callback?: (err: ElastiCache.InvalidCacheClusterStateFault|ElastiCache.CacheClusterNotFoundFault|any, data: ElastiCache.RebootCacheClusterResult|any) => void): Request;
+      removeTagsFromResource(params: ElastiCache.RemoveTagsFromResourceMessage, callback?: (err: ElastiCache.CacheClusterNotFoundFault|ElastiCache.SnapshotNotFoundFault|ElastiCache.InvalidARNFault|ElastiCache.TagNotFoundFault|any, data: ElastiCache.TagListMessage|any) => void): Request;
+      resetCacheParameterGroup(params: ElastiCache.ResetCacheParameterGroupMessage, callback?: (err: ElastiCache.InvalidCacheParameterGroupStateFault|ElastiCache.CacheParameterGroupNotFoundFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.CacheParameterGroupNameMessage|any) => void): Request;
+      revokeCacheSecurityGroupIngress(params: ElastiCache.RevokeCacheSecurityGroupIngressMessage, callback?: (err: ElastiCache.CacheSecurityGroupNotFoundFault|ElastiCache.AuthorizationNotFoundFault|ElastiCache.InvalidCacheSecurityGroupStateFault|ElastiCache.InvalidParameterValueException|ElastiCache.InvalidParameterCombinationException|any, data: ElastiCache.RevokeCacheSecurityGroupIngressResult|any) => void): Request;
+    }
+    
+    export module ElastiCache {
+        export type AZMode = string;
+        export type AutomaticFailoverStatus = string;
+        export type AvailabilityZonesList = String[];
+        export type AwsQueryErrorMessage = string;
+        export type Boolean = boolean;
+        export type BooleanOptional = boolean;
+        export type CacheClusterList = CacheCluster[];
+        export type CacheEngineVersionList = CacheEngineVersion[];
+        export type CacheNodeIdsList = String[];
+        export type CacheNodeList = CacheNode[];
+        export type CacheNodeTypeSpecificParametersList = CacheNodeTypeSpecificParameter[];
+        export type CacheNodeTypeSpecificValueList = CacheNodeTypeSpecificValue[];
+        export type CacheParameterGroupList = CacheParameterGroup[];
+        export type CacheSecurityGroupMembershipList = CacheSecurityGroupMembership[];
+        export type CacheSecurityGroupNameList = String[];
+        export type CacheSecurityGroups = CacheSecurityGroup[];
+        export type CacheSubnetGroups = CacheSubnetGroup[];
+        export type ClusterIdList = String[];
+        export type Double = number;
+        export type EC2SecurityGroupList = EC2SecurityGroup[];
+        export type EventList = Event[];
+        export type Integer = number;
+        export type IntegerOptional = number;
+        export type KeyList = String[];
+        export type NodeGroupList = NodeGroup[];
+        export type NodeGroupMemberList = NodeGroupMember[];
+        export type NodeSnapshotList = NodeSnapshot[];
+        export type ParameterNameValueList = ParameterNameValue[];
+        export type ParametersList = Parameter[];
+        export type PendingAutomaticFailoverStatus = string;
+        export type PreferredAvailabilityZoneList = String[];
+        export type RecurringChargeList = RecurringCharge[];
+        export type ReplicationGroupList = ReplicationGroup[];
+        export type ReservedCacheNodeList = ReservedCacheNode[];
+        export type ReservedCacheNodesOfferingList = ReservedCacheNodesOffering[];
+        export type SecurityGroupIdsList = String[];
+        export type SecurityGroupMembershipList = SecurityGroupMembership[];
+        export type SnapshotArnsList = String[];
+        export type SnapshotList = Snapshot[];
+        export type SourceType = string;
+        export type String = string;
+        export type SubnetIdentifierList = String[];
+        export type SubnetList = Subnet[];
+        export type TStamp = number;
+        export type TagList = Tag[];
+
+        export interface AddTagsToResourceMessage {
+            ResourceName: String;            
+            Tags: TagList;            
+        }
+        export interface AuthorizationAlreadyExistsFault {
+        }
+        export interface AuthorizationNotFoundFault {
+        }
+        export interface AuthorizeCacheSecurityGroupIngressMessage {
+            CacheSecurityGroupName: String;            
+            EC2SecurityGroupName: String;            
+            EC2SecurityGroupOwnerId: String;            
+        }
+        export interface AvailabilityZone {
+            Name?: String;            
+        }
+        export interface CacheCluster {
+            CacheClusterId?: String;            
+            ConfigurationEndpoint?: Endpoint;            
+            ClientDownloadLandingPage?: String;            
+            CacheNodeType?: String;            
+            Engine?: String;            
+            EngineVersion?: String;            
+            CacheClusterStatus?: String;            
+            NumCacheNodes?: IntegerOptional;            
+            PreferredAvailabilityZone?: String;            
+            CacheClusterCreateTime?: TStamp;            
+            PreferredMaintenanceWindow?: String;            
+            PendingModifiedValues?: PendingModifiedValues;            
+            NotificationConfiguration?: NotificationConfiguration;            
+            CacheSecurityGroups?: CacheSecurityGroupMembershipList;            
+            CacheParameterGroup?: CacheParameterGroupStatus;            
+            CacheSubnetGroupName?: String;            
+            CacheNodes?: CacheNodeList;            
+            AutoMinorVersionUpgrade?: Boolean;            
+            SecurityGroups?: SecurityGroupMembershipList;            
+            ReplicationGroupId?: String;            
+            SnapshotRetentionLimit?: IntegerOptional;            
+            SnapshotWindow?: String;            
+        }
+        export interface CacheClusterAlreadyExistsFault {
+        }
+        export interface CacheClusterMessage {
+            Marker?: String;            
+            CacheClusters?: CacheClusterList;            
+        }
+        export interface CacheClusterNotFoundFault {
+        }
+        export interface CacheEngineVersion {
+            Engine?: String;            
+            EngineVersion?: String;            
+            CacheParameterGroupFamily?: String;            
+            CacheEngineDescription?: String;            
+            CacheEngineVersionDescription?: String;            
+        }
+        export interface CacheEngineVersionMessage {
+            Marker?: String;            
+            CacheEngineVersions?: CacheEngineVersionList;            
+        }
+        export interface CacheNode {
+            CacheNodeId?: String;            
+            CacheNodeStatus?: String;            
+            CacheNodeCreateTime?: TStamp;            
+            Endpoint?: Endpoint;            
+            ParameterGroupStatus?: String;            
+            SourceCacheNodeId?: String;            
+            CustomerAvailabilityZone?: String;            
+        }
+        export interface CacheNodeTypeSpecificParameter {
+            ParameterName?: String;            
+            Description?: String;            
+            Source?: String;            
+            DataType?: String;            
+            AllowedValues?: String;            
+            IsModifiable?: Boolean;            
+            MinimumEngineVersion?: String;            
+            CacheNodeTypeSpecificValues?: CacheNodeTypeSpecificValueList;            
+        }
+        export interface CacheNodeTypeSpecificValue {
+            CacheNodeType?: String;            
+            Value?: String;            
+        }
+        export interface CacheParameterGroup {
+            CacheParameterGroupName?: String;            
+            CacheParameterGroupFamily?: String;            
+            Description?: String;            
+        }
+        export interface CacheParameterGroupAlreadyExistsFault {
+        }
+        export interface CacheParameterGroupDetails {
+            Marker?: String;            
+            Parameters?: ParametersList;            
+            CacheNodeTypeSpecificParameters?: CacheNodeTypeSpecificParametersList;            
+        }
+        export interface CacheParameterGroupNameMessage {
+            CacheParameterGroupName?: String;            
+        }
+        export interface CacheParameterGroupNotFoundFault {
+        }
+        export interface CacheParameterGroupQuotaExceededFault {
+        }
+        export interface CacheParameterGroupStatus {
+            CacheParameterGroupName?: String;            
+            ParameterApplyStatus?: String;            
+            CacheNodeIdsToReboot?: CacheNodeIdsList;            
+        }
+        export interface CacheParameterGroupsMessage {
+            Marker?: String;            
+            CacheParameterGroups?: CacheParameterGroupList;            
+        }
+        export interface CacheSecurityGroup {
+            OwnerId?: String;            
+            CacheSecurityGroupName?: String;            
+            Description?: String;            
+            EC2SecurityGroups?: EC2SecurityGroupList;            
+        }
+        export interface CacheSecurityGroupAlreadyExistsFault {
+        }
+        export interface CacheSecurityGroupMembership {
+            CacheSecurityGroupName?: String;            
+            Status?: String;            
+        }
+        export interface CacheSecurityGroupMessage {
+            Marker?: String;            
+            CacheSecurityGroups?: CacheSecurityGroups;            
+        }
+        export interface CacheSecurityGroupNotFoundFault {
+        }
+        export interface CacheSecurityGroupQuotaExceededFault {
+        }
+        export interface CacheSubnetGroup {
+            CacheSubnetGroupName?: String;            
+            CacheSubnetGroupDescription?: String;            
+            VpcId?: String;            
+            Subnets?: SubnetList;            
+        }
+        export interface CacheSubnetGroupAlreadyExistsFault {
+        }
+        export interface CacheSubnetGroupInUse {
+        }
+        export interface CacheSubnetGroupMessage {
+            Marker?: String;            
+            CacheSubnetGroups?: CacheSubnetGroups;            
+        }
+        export interface CacheSubnetGroupNotFoundFault {
+        }
+        export interface CacheSubnetGroupQuotaExceededFault {
+        }
+        export interface CacheSubnetQuotaExceededFault {
+        }
+        export interface ClusterQuotaForCustomerExceededFault {
+        }
+        export interface CopySnapshotMessage {
+            SourceSnapshotName: String;            
+            TargetSnapshotName: String;            
+        }
+        export interface CreateCacheClusterMessage {
+            CacheClusterId: String;            
+            ReplicationGroupId?: String;            
+            AZMode?: AZMode;            
+            PreferredAvailabilityZone?: String;            
+            PreferredAvailabilityZones?: PreferredAvailabilityZoneList;            
+            NumCacheNodes?: IntegerOptional;            
+            CacheNodeType?: String;            
+            Engine?: String;            
+            EngineVersion?: String;            
+            CacheParameterGroupName?: String;            
+            CacheSubnetGroupName?: String;            
+            CacheSecurityGroupNames?: CacheSecurityGroupNameList;            
+            SecurityGroupIds?: SecurityGroupIdsList;            
+            Tags?: TagList;            
+            SnapshotArns?: SnapshotArnsList;            
+            SnapshotName?: String;            
+            PreferredMaintenanceWindow?: String;            
+            Port?: IntegerOptional;            
+            NotificationTopicArn?: String;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            SnapshotRetentionLimit?: IntegerOptional;            
+            SnapshotWindow?: String;            
+        }
+        export interface CreateCacheParameterGroupMessage {
+            CacheParameterGroupName: String;            
+            CacheParameterGroupFamily: String;            
+            Description: String;            
+        }
+        export interface CreateCacheSecurityGroupMessage {
+            CacheSecurityGroupName: String;            
+            Description: String;            
+        }
+        export interface CreateCacheSubnetGroupMessage {
+            CacheSubnetGroupName: String;            
+            CacheSubnetGroupDescription: String;            
+            SubnetIds: SubnetIdentifierList;            
+        }
+        export interface CreateReplicationGroupMessage {
+            ReplicationGroupId: String;            
+            ReplicationGroupDescription: String;            
+            PrimaryClusterId?: String;            
+            AutomaticFailoverEnabled?: BooleanOptional;            
+            NumCacheClusters?: IntegerOptional;            
+            PreferredCacheClusterAZs?: AvailabilityZonesList;            
+            CacheNodeType?: String;            
+            Engine?: String;            
+            EngineVersion?: String;            
+            CacheParameterGroupName?: String;            
+            CacheSubnetGroupName?: String;            
+            CacheSecurityGroupNames?: CacheSecurityGroupNameList;            
+            SecurityGroupIds?: SecurityGroupIdsList;            
+            Tags?: TagList;            
+            SnapshotArns?: SnapshotArnsList;            
+            SnapshotName?: String;            
+            PreferredMaintenanceWindow?: String;            
+            Port?: IntegerOptional;            
+            NotificationTopicArn?: String;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            SnapshotRetentionLimit?: IntegerOptional;            
+            SnapshotWindow?: String;            
+        }
+        export interface CreateSnapshotMessage {
+            CacheClusterId: String;            
+            SnapshotName: String;            
+        }
+        export interface DeleteCacheClusterMessage {
+            CacheClusterId: String;            
+            FinalSnapshotIdentifier?: String;            
+        }
+        export interface DeleteCacheParameterGroupMessage {
+            CacheParameterGroupName: String;            
+        }
+        export interface DeleteCacheSecurityGroupMessage {
+            CacheSecurityGroupName: String;            
+        }
+        export interface DeleteCacheSubnetGroupMessage {
+            CacheSubnetGroupName: String;            
+        }
+        export interface DeleteReplicationGroupMessage {
+            ReplicationGroupId: String;            
+            RetainPrimaryCluster?: BooleanOptional;            
+            FinalSnapshotIdentifier?: String;            
+        }
+        export interface DeleteSnapshotMessage {
+            SnapshotName: String;            
+        }
+        export interface DescribeCacheClustersMessage {
+            CacheClusterId?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            ShowCacheNodeInfo?: BooleanOptional;            
+        }
+        export interface DescribeCacheEngineVersionsMessage {
+            Engine?: String;            
+            EngineVersion?: String;            
+            CacheParameterGroupFamily?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            DefaultOnly?: Boolean;            
+        }
+        export interface DescribeCacheParameterGroupsMessage {
+            CacheParameterGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeCacheParametersMessage {
+            CacheParameterGroupName: String;            
+            Source?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeCacheSecurityGroupsMessage {
+            CacheSecurityGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeCacheSubnetGroupsMessage {
+            CacheSubnetGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEngineDefaultParametersMessage {
+            CacheParameterGroupFamily: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEventsMessage {
+            SourceIdentifier?: String;            
+            SourceType?: SourceType;            
+            StartTime?: TStamp;            
+            EndTime?: TStamp;            
+            Duration?: IntegerOptional;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReplicationGroupsMessage {
+            ReplicationGroupId?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReservedCacheNodesMessage {
+            ReservedCacheNodeId?: String;            
+            ReservedCacheNodesOfferingId?: String;            
+            CacheNodeType?: String;            
+            Duration?: String;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReservedCacheNodesOfferingsMessage {
+            ReservedCacheNodesOfferingId?: String;            
+            CacheNodeType?: String;            
+            Duration?: String;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeSnapshotsListMessage {
+            Marker?: String;            
+            Snapshots?: SnapshotList;            
+        }
+        export interface DescribeSnapshotsMessage {
+            CacheClusterId?: String;            
+            SnapshotName?: String;            
+            SnapshotSource?: String;            
+            Marker?: String;            
+            MaxRecords?: IntegerOptional;            
+        }
+        export interface EC2SecurityGroup {
+            Status?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+        }
+        export interface Endpoint {
+            Address?: String;            
+            Port?: Integer;            
+        }
+        export interface EngineDefaults {
+            CacheParameterGroupFamily?: String;            
+            Marker?: String;            
+            Parameters?: ParametersList;            
+            CacheNodeTypeSpecificParameters?: CacheNodeTypeSpecificParametersList;            
+        }
+        export interface Event {
+            SourceIdentifier?: String;            
+            SourceType?: SourceType;            
+            Message?: String;            
+            Date?: TStamp;            
+        }
+        export interface EventsMessage {
+            Marker?: String;            
+            Events?: EventList;            
+        }
+        export interface InsufficientCacheClusterCapacityFault {
+        }
+        export interface InvalidARNFault {
+        }
+        export interface InvalidCacheClusterStateFault {
+        }
+        export interface InvalidCacheParameterGroupStateFault {
+        }
+        export interface InvalidCacheSecurityGroupStateFault {
+        }
+        export interface InvalidParameterCombinationException {
+            message?: AwsQueryErrorMessage;            
+        }
+        export interface InvalidParameterValueException {
+            message?: AwsQueryErrorMessage;            
+        }
+        export interface InvalidReplicationGroupStateFault {
+        }
+        export interface InvalidSnapshotStateFault {
+        }
+        export interface InvalidSubnet {
+        }
+        export interface InvalidVPCNetworkStateFault {
+        }
+        export interface ListTagsForResourceMessage {
+            ResourceName: String;            
+        }
+        export interface ModifyCacheClusterMessage {
+            CacheClusterId: String;            
+            NumCacheNodes?: IntegerOptional;            
+            CacheNodeIdsToRemove?: CacheNodeIdsList;            
+            AZMode?: AZMode;            
+            NewAvailabilityZones?: PreferredAvailabilityZoneList;            
+            CacheSecurityGroupNames?: CacheSecurityGroupNameList;            
+            SecurityGroupIds?: SecurityGroupIdsList;            
+            PreferredMaintenanceWindow?: String;            
+            NotificationTopicArn?: String;            
+            CacheParameterGroupName?: String;            
+            NotificationTopicStatus?: String;            
+            ApplyImmediately?: Boolean;            
+            EngineVersion?: String;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            SnapshotRetentionLimit?: IntegerOptional;            
+            SnapshotWindow?: String;            
+        }
+        export interface ModifyCacheParameterGroupMessage {
+            CacheParameterGroupName: String;            
+            ParameterNameValues: ParameterNameValueList;            
+        }
+        export interface ModifyCacheSubnetGroupMessage {
+            CacheSubnetGroupName: String;            
+            CacheSubnetGroupDescription?: String;            
+            SubnetIds?: SubnetIdentifierList;            
+        }
+        export interface ModifyReplicationGroupMessage {
+            ReplicationGroupId: String;            
+            ReplicationGroupDescription?: String;            
+            PrimaryClusterId?: String;            
+            SnapshottingClusterId?: String;            
+            AutomaticFailoverEnabled?: BooleanOptional;            
+            CacheSecurityGroupNames?: CacheSecurityGroupNameList;            
+            SecurityGroupIds?: SecurityGroupIdsList;            
+            PreferredMaintenanceWindow?: String;            
+            NotificationTopicArn?: String;            
+            CacheParameterGroupName?: String;            
+            NotificationTopicStatus?: String;            
+            ApplyImmediately?: Boolean;            
+            EngineVersion?: String;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            SnapshotRetentionLimit?: IntegerOptional;            
+            SnapshotWindow?: String;            
+        }
+        export interface NodeGroup {
+            NodeGroupId?: String;            
+            Status?: String;            
+            PrimaryEndpoint?: Endpoint;            
+            NodeGroupMembers?: NodeGroupMemberList;            
+        }
+        export interface NodeGroupMember {
+            CacheClusterId?: String;            
+            CacheNodeId?: String;            
+            ReadEndpoint?: Endpoint;            
+            PreferredAvailabilityZone?: String;            
+            CurrentRole?: String;            
+        }
+        export interface NodeQuotaForClusterExceededFault {
+        }
+        export interface NodeQuotaForCustomerExceededFault {
+        }
+        export interface NodeSnapshot {
+            CacheNodeId?: String;            
+            CacheSize?: String;            
+            CacheNodeCreateTime?: TStamp;            
+            SnapshotCreateTime?: TStamp;            
+        }
+        export interface NotificationConfiguration {
+            TopicArn?: String;            
+            TopicStatus?: String;            
+        }
+        export interface Parameter {
+            ParameterName?: String;            
+            ParameterValue?: String;            
+            Description?: String;            
+            Source?: String;            
+            DataType?: String;            
+            AllowedValues?: String;            
+            IsModifiable?: Boolean;            
+            MinimumEngineVersion?: String;            
+        }
+        export interface ParameterNameValue {
+            ParameterName?: String;            
+            ParameterValue?: String;            
+        }
+        export interface PendingModifiedValues {
+            NumCacheNodes?: IntegerOptional;            
+            CacheNodeIdsToRemove?: CacheNodeIdsList;            
+            EngineVersion?: String;            
+        }
+        export interface PurchaseReservedCacheNodesOfferingMessage {
+            ReservedCacheNodesOfferingId: String;            
+            ReservedCacheNodeId?: String;            
+            CacheNodeCount?: IntegerOptional;            
+        }
+        export interface RebootCacheClusterMessage {
+            CacheClusterId: String;            
+            CacheNodeIdsToReboot: CacheNodeIdsList;            
+        }
+        export interface RecurringCharge {
+            RecurringChargeAmount?: Double;            
+            RecurringChargeFrequency?: String;            
+        }
+        export interface RemoveTagsFromResourceMessage {
+            ResourceName: String;            
+            TagKeys: KeyList;            
+        }
+        export interface ReplicationGroup {
+            ReplicationGroupId?: String;            
+            Description?: String;            
+            Status?: String;            
+            PendingModifiedValues?: ReplicationGroupPendingModifiedValues;            
+            MemberClusters?: ClusterIdList;            
+            NodeGroups?: NodeGroupList;            
+            SnapshottingClusterId?: String;            
+            AutomaticFailover?: AutomaticFailoverStatus;            
+        }
+        export interface ReplicationGroupAlreadyExistsFault {
+        }
+        export interface ReplicationGroupMessage {
+            Marker?: String;            
+            ReplicationGroups?: ReplicationGroupList;            
+        }
+        export interface ReplicationGroupNotFoundFault {
+        }
+        export interface ReplicationGroupPendingModifiedValues {
+            PrimaryClusterId?: String;            
+            AutomaticFailoverStatus?: PendingAutomaticFailoverStatus;            
+        }
+        export interface ReservedCacheNode {
+            ReservedCacheNodeId?: String;            
+            ReservedCacheNodesOfferingId?: String;            
+            CacheNodeType?: String;            
+            StartTime?: TStamp;            
+            Duration?: Integer;            
+            FixedPrice?: Double;            
+            UsagePrice?: Double;            
+            CacheNodeCount?: Integer;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            State?: String;            
+            RecurringCharges?: RecurringChargeList;            
+        }
+        export interface ReservedCacheNodeAlreadyExistsFault {
+        }
+        export interface ReservedCacheNodeMessage {
+            Marker?: String;            
+            ReservedCacheNodes?: ReservedCacheNodeList;            
+        }
+        export interface ReservedCacheNodeNotFoundFault {
+        }
+        export interface ReservedCacheNodeQuotaExceededFault {
+        }
+        export interface ReservedCacheNodesOffering {
+            ReservedCacheNodesOfferingId?: String;            
+            CacheNodeType?: String;            
+            Duration?: Integer;            
+            FixedPrice?: Double;            
+            UsagePrice?: Double;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            RecurringCharges?: RecurringChargeList;            
+        }
+        export interface ReservedCacheNodesOfferingMessage {
+            Marker?: String;            
+            ReservedCacheNodesOfferings?: ReservedCacheNodesOfferingList;            
+        }
+        export interface ReservedCacheNodesOfferingNotFoundFault {
+        }
+        export interface ResetCacheParameterGroupMessage {
+            CacheParameterGroupName: String;            
+            ResetAllParameters?: Boolean;            
+            ParameterNameValues: ParameterNameValueList;            
+        }
+        export interface RevokeCacheSecurityGroupIngressMessage {
+            CacheSecurityGroupName: String;            
+            EC2SecurityGroupName: String;            
+            EC2SecurityGroupOwnerId: String;            
+        }
+        export interface SecurityGroupMembership {
+            SecurityGroupId?: String;            
+            Status?: String;            
+        }
+        export interface Snapshot {
+            SnapshotName?: String;            
+            CacheClusterId?: String;            
+            SnapshotStatus?: String;            
+            SnapshotSource?: String;            
+            CacheNodeType?: String;            
+            Engine?: String;            
+            EngineVersion?: String;            
+            NumCacheNodes?: IntegerOptional;            
+            PreferredAvailabilityZone?: String;            
+            CacheClusterCreateTime?: TStamp;            
+            PreferredMaintenanceWindow?: String;            
+            TopicArn?: String;            
+            Port?: IntegerOptional;            
+            CacheParameterGroupName?: String;            
+            CacheSubnetGroupName?: String;            
+            VpcId?: String;            
+            AutoMinorVersionUpgrade?: Boolean;            
+            SnapshotRetentionLimit?: IntegerOptional;            
+            SnapshotWindow?: String;            
+            NodeSnapshots?: NodeSnapshotList;            
+        }
+        export interface SnapshotAlreadyExistsFault {
+        }
+        export interface SnapshotFeatureNotSupportedFault {
+        }
+        export interface SnapshotNotFoundFault {
+        }
+        export interface SnapshotQuotaExceededFault {
+        }
+        export interface Subnet {
+            SubnetIdentifier?: String;            
+            SubnetAvailabilityZone?: AvailabilityZone;            
+        }
+        export interface SubnetInUse {
+        }
+        export interface Tag {
+            Key?: String;            
+            Value?: String;            
+        }
+        export interface TagListMessage {
+            TagList?: TagList;            
+        }
+        export interface TagNotFoundFault {
+        }
+        export interface TagQuotaPerResourceExceeded {
+        }
+        export interface AuthorizeCacheSecurityGroupIngressResult {
+            CacheSecurityGroup?: CacheSecurityGroup;            
+        }
+        export interface CopySnapshotResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface CreateCacheClusterResult {
+            CacheCluster?: CacheCluster;            
+        }
+        export interface CreateCacheParameterGroupResult {
+            CacheParameterGroup?: CacheParameterGroup;            
+        }
+        export interface CreateCacheSecurityGroupResult {
+            CacheSecurityGroup?: CacheSecurityGroup;            
+        }
+        export interface CreateCacheSubnetGroupResult {
+            CacheSubnetGroup?: CacheSubnetGroup;            
+        }
+        export interface CreateReplicationGroupResult {
+            ReplicationGroup?: ReplicationGroup;            
+        }
+        export interface CreateSnapshotResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface DeleteCacheClusterResult {
+            CacheCluster?: CacheCluster;            
+        }
+        export interface DeleteReplicationGroupResult {
+            ReplicationGroup?: ReplicationGroup;            
+        }
+        export interface DeleteSnapshotResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface DescribeEngineDefaultParametersResult {
+            EngineDefaults?: EngineDefaults;            
+        }
+        export interface ModifyCacheClusterResult {
+            CacheCluster?: CacheCluster;            
+        }
+        export interface ModifyCacheSubnetGroupResult {
+            CacheSubnetGroup?: CacheSubnetGroup;            
+        }
+        export interface ModifyReplicationGroupResult {
+            ReplicationGroup?: ReplicationGroup;            
+        }
+        export interface PurchaseReservedCacheNodesOfferingResult {
+            ReservedCacheNode?: ReservedCacheNode;            
+        }
+        export interface RebootCacheClusterResult {
+            CacheCluster?: CacheCluster;            
+        }
+        export interface RevokeCacheSecurityGroupIngressResult {
+            CacheSecurityGroup?: CacheSecurityGroup;            
+        }
 
-    export interface ElastiCacheInvalidCacheParameterGroupStateFault {
     }
-
-    export interface ElastiCacheInvalidCacheSecurityGroupStateFault {
-    }
-
-    export interface ElastiCacheInvalidParameterCombinationException {
-        message?: ElastiCacheAwsQueryErrorMessage;
-    }
-
-    export interface ElastiCacheInvalidParameterValueException {
-        message?: ElastiCacheAwsQueryErrorMessage;
-    }
-
-    export interface ElastiCacheInvalidReplicationGroupStateFault {
-    }
-
-    export interface ElastiCacheInvalidSnapshotStateFault {
-    }
-
-    export interface ElastiCacheInvalidSubnet {
-    }
-
-    export interface ElastiCacheInvalidVPCNetworkStateFault {
-    }
-
-    export type ElastiCacheKeyList = Array<ElastiCacheString>;
-    export interface ElastiCacheListTagsForResourceMessage {
-        ResourceName: ElastiCacheString;
-    }
-
-    export interface ElastiCacheModifyCacheClusterMessage {
-        CacheClusterId: ElastiCacheString;
-        NumCacheNodes?: ElastiCacheIntegerOptional;
-        CacheNodeIdsToRemove?: ElastiCacheCacheNodeIdsList;
-        AZMode?: ElastiCacheAZMode;
-        NewAvailabilityZones?: ElastiCachePreferredAvailabilityZoneList;
-        CacheSecurityGroupNames?: ElastiCacheCacheSecurityGroupNameList;
-        SecurityGroupIds?: ElastiCacheSecurityGroupIdsList;
-        PreferredMaintenanceWindow?: ElastiCacheString;
-        NotificationTopicArn?: ElastiCacheString;
-        CacheParameterGroupName?: ElastiCacheString;
-        NotificationTopicStatus?: ElastiCacheString;
-        ApplyImmediately?: ElastiCacheBoolean;
-        EngineVersion?: ElastiCacheString;
-        AutoMinorVersionUpgrade?: ElastiCacheBooleanOptional;
-        SnapshotRetentionLimit?: ElastiCacheIntegerOptional;
-        SnapshotWindow?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheModifyCacheParameterGroupMessage {
-        CacheParameterGroupName: ElastiCacheString;
-        ParameterNameValues: ElastiCacheParameterNameValueList;
-    }
-
-    export interface ElastiCacheModifyCacheSubnetGroupMessage {
-        CacheSubnetGroupName: ElastiCacheString;
-        CacheSubnetGroupDescription?: ElastiCacheString;
-        SubnetIds?: ElastiCacheSubnetIdentifierList;
-    }
-
-    export interface ElastiCacheModifyReplicationGroupMessage {
-        ReplicationGroupId: ElastiCacheString;
-        ReplicationGroupDescription?: ElastiCacheString;
-        PrimaryClusterId?: ElastiCacheString;
-        SnapshottingClusterId?: ElastiCacheString;
-        AutomaticFailoverEnabled?: ElastiCacheBooleanOptional;
-        CacheSecurityGroupNames?: ElastiCacheCacheSecurityGroupNameList;
-        SecurityGroupIds?: ElastiCacheSecurityGroupIdsList;
-        PreferredMaintenanceWindow?: ElastiCacheString;
-        NotificationTopicArn?: ElastiCacheString;
-        CacheParameterGroupName?: ElastiCacheString;
-        NotificationTopicStatus?: ElastiCacheString;
-        ApplyImmediately?: ElastiCacheBoolean;
-        EngineVersion?: ElastiCacheString;
-        AutoMinorVersionUpgrade?: ElastiCacheBooleanOptional;
-        SnapshotRetentionLimit?: ElastiCacheIntegerOptional;
-        SnapshotWindow?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheNodeGroup {
-        NodeGroupId?: ElastiCacheString;
-        Status?: ElastiCacheString;
-        PrimaryEndpoint?: ElastiCacheEndpoint;
-        NodeGroupMembers?: ElastiCacheNodeGroupMemberList;
-    }
-
-    export type ElastiCacheNodeGroupList = Array<ElastiCacheNodeGroup>;
-    export interface ElastiCacheNodeGroupMember {
-        CacheClusterId?: ElastiCacheString;
-        CacheNodeId?: ElastiCacheString;
-        ReadEndpoint?: ElastiCacheEndpoint;
-        PreferredAvailabilityZone?: ElastiCacheString;
-        CurrentRole?: ElastiCacheString;
-    }
-
-    export type ElastiCacheNodeGroupMemberList = Array<ElastiCacheNodeGroupMember>;
-    export interface ElastiCacheNodeQuotaForClusterExceededFault {
-    }
-
-    export interface ElastiCacheNodeQuotaForCustomerExceededFault {
-    }
-
-    export interface ElastiCacheNodeSnapshot {
-        CacheNodeId?: ElastiCacheString;
-        CacheSize?: ElastiCacheString;
-        CacheNodeCreateTime?: ElastiCacheTStamp;
-        SnapshotCreateTime?: ElastiCacheTStamp;
-    }
-
-    export type ElastiCacheNodeSnapshotList = Array<ElastiCacheNodeSnapshot>;
-    export interface ElastiCacheNotificationConfiguration {
-        TopicArn?: ElastiCacheString;
-        TopicStatus?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheParameter {
-        ParameterName?: ElastiCacheString;
-        ParameterValue?: ElastiCacheString;
-        Description?: ElastiCacheString;
-        Source?: ElastiCacheString;
-        DataType?: ElastiCacheString;
-        AllowedValues?: ElastiCacheString;
-        IsModifiable?: ElastiCacheBoolean;
-        MinimumEngineVersion?: ElastiCacheString;
-    }
-
-    export interface ElastiCacheParameterNameValue {
-        ParameterName?: ElastiCacheString;
-        ParameterValue?: ElastiCacheString;
-    }
-
-    export type ElastiCacheParameterNameValueList = Array<ElastiCacheParameterNameValue>;
-    export type ElastiCacheParametersList = Array<ElastiCacheParameter>;
-    export type ElastiCachePendingAutomaticFailoverStatus = string;
-    export interface ElastiCachePendingModifiedValues {
-        NumCacheNodes?: ElastiCacheIntegerOptional;
-        CacheNodeIdsToRemove?: ElastiCacheCacheNodeIdsList;
-        EngineVersion?: ElastiCacheString;
-    }
-
-    export type ElastiCachePreferredAvailabilityZoneList = Array<ElastiCacheString>;
-    export interface ElastiCachePurchaseReservedCacheNodesOfferingMessage {
-        ReservedCacheNodesOfferingId: ElastiCacheString;
-        ReservedCacheNodeId?: ElastiCacheString;
-        CacheNodeCount?: ElastiCacheIntegerOptional;
-    }
-
-    export interface ElastiCacheRebootCacheClusterMessage {
-        CacheClusterId: ElastiCacheString;
-        CacheNodeIdsToReboot: ElastiCacheCacheNodeIdsList;
-    }
-
-    export interface ElastiCacheRecurringCharge {
-        RecurringChargeAmount?: ElastiCacheDouble;
-        RecurringChargeFrequency?: ElastiCacheString;
-    }
-
-    export type ElastiCacheRecurringChargeList = Array<ElastiCacheRecurringCharge>;
-    export interface ElastiCacheRemoveTagsFromResourceMessage {
-        ResourceName: ElastiCacheString;
-        TagKeys: ElastiCacheKeyList;
-    }
-
-    export interface ElastiCacheReplicationGroup {
-        ReplicationGroupId?: ElastiCacheString;
-        Description?: ElastiCacheString;
-        Status?: ElastiCacheString;
-        PendingModifiedValues?: ElastiCacheReplicationGroupPendingModifiedValues;
-        MemberClusters?: ElastiCacheClusterIdList;
-        NodeGroups?: ElastiCacheNodeGroupList;
-        SnapshottingClusterId?: ElastiCacheString;
-        AutomaticFailover?: ElastiCacheAutomaticFailoverStatus;
-    }
-
-    export interface ElastiCacheReplicationGroupAlreadyExistsFault {
-    }
-
-    export type ElastiCacheReplicationGroupList = Array<ElastiCacheReplicationGroup>;
-    export interface ElastiCacheReplicationGroupMessage {
-        Marker?: ElastiCacheString;
-        ReplicationGroups?: ElastiCacheReplicationGroupList;
-    }
-
-    export interface ElastiCacheReplicationGroupNotFoundFault {
-    }
-
-    export interface ElastiCacheReplicationGroupPendingModifiedValues {
-        PrimaryClusterId?: ElastiCacheString;
-        AutomaticFailoverStatus?: ElastiCachePendingAutomaticFailoverStatus;
-    }
-
-    export interface ElastiCacheReservedCacheNode {
-        ReservedCacheNodeId?: ElastiCacheString;
-        ReservedCacheNodesOfferingId?: ElastiCacheString;
-        CacheNodeType?: ElastiCacheString;
-        StartTime?: ElastiCacheTStamp;
-        Duration?: ElastiCacheInteger;
-        FixedPrice?: ElastiCacheDouble;
-        UsagePrice?: ElastiCacheDouble;
-        CacheNodeCount?: ElastiCacheInteger;
-        ProductDescription?: ElastiCacheString;
-        OfferingType?: ElastiCacheString;
-        State?: ElastiCacheString;
-        RecurringCharges?: ElastiCacheRecurringChargeList;
-    }
-
-    export interface ElastiCacheReservedCacheNodeAlreadyExistsFault {
-    }
-
-    export type ElastiCacheReservedCacheNodeList = Array<ElastiCacheReservedCacheNode>;
-    export interface ElastiCacheReservedCacheNodeMessage {
-        Marker?: ElastiCacheString;
-        ReservedCacheNodes?: ElastiCacheReservedCacheNodeList;
-    }
-
-    export interface ElastiCacheReservedCacheNodeNotFoundFault {
-    }
-
-    export interface ElastiCacheReservedCacheNodeQuotaExceededFault {
-    }
-
-    export interface ElastiCacheReservedCacheNodesOffering {
-        ReservedCacheNodesOfferingId?: ElastiCacheString;
-        CacheNodeType?: ElastiCacheString;
-        Duration?: ElastiCacheInteger;
-        FixedPrice?: ElastiCacheDouble;
-        UsagePrice?: ElastiCacheDouble;
-        ProductDescription?: ElastiCacheString;
-        OfferingType?: ElastiCacheString;
-        RecurringCharges?: ElastiCacheRecurringChargeList;
-    }
-
-    export type ElastiCacheReservedCacheNodesOfferingList = Array<ElastiCacheReservedCacheNodesOffering>;
-    export interface ElastiCacheReservedCacheNodesOfferingMessage {
-        Marker?: ElastiCacheString;
-        ReservedCacheNodesOfferings?: ElastiCacheReservedCacheNodesOfferingList;
-    }
-
-    export interface ElastiCacheReservedCacheNodesOfferingNotFoundFault {
-    }
-
-    export interface ElastiCacheResetCacheParameterGroupMessage {
-        CacheParameterGroupName: ElastiCacheString;
-        ResetAllParameters?: ElastiCacheBoolean;
-        ParameterNameValues: ElastiCacheParameterNameValueList;
-    }
-
-    export interface ElastiCacheRevokeCacheSecurityGroupIngressMessage {
-        CacheSecurityGroupName: ElastiCacheString;
-        EC2SecurityGroupName: ElastiCacheString;
-        EC2SecurityGroupOwnerId: ElastiCacheString;
-    }
-
-    export type ElastiCacheSecurityGroupIdsList = Array<ElastiCacheString>;
-    export interface ElastiCacheSecurityGroupMembership {
-        SecurityGroupId?: ElastiCacheString;
-        Status?: ElastiCacheString;
-    }
-
-    export type ElastiCacheSecurityGroupMembershipList = Array<ElastiCacheSecurityGroupMembership>;
-    export interface ElastiCacheSnapshot {
-        SnapshotName?: ElastiCacheString;
-        CacheClusterId?: ElastiCacheString;
-        SnapshotStatus?: ElastiCacheString;
-        SnapshotSource?: ElastiCacheString;
-        CacheNodeType?: ElastiCacheString;
-        Engine?: ElastiCacheString;
-        EngineVersion?: ElastiCacheString;
-        NumCacheNodes?: ElastiCacheIntegerOptional;
-        PreferredAvailabilityZone?: ElastiCacheString;
-        CacheClusterCreateTime?: ElastiCacheTStamp;
-        PreferredMaintenanceWindow?: ElastiCacheString;
-        TopicArn?: ElastiCacheString;
-        Port?: ElastiCacheIntegerOptional;
-        CacheParameterGroupName?: ElastiCacheString;
-        CacheSubnetGroupName?: ElastiCacheString;
-        VpcId?: ElastiCacheString;
-        AutoMinorVersionUpgrade?: ElastiCacheBoolean;
-        SnapshotRetentionLimit?: ElastiCacheIntegerOptional;
-        SnapshotWindow?: ElastiCacheString;
-        NodeSnapshots?: ElastiCacheNodeSnapshotList;
-    }
-
-    export interface ElastiCacheSnapshotAlreadyExistsFault {
-    }
-
-    export type ElastiCacheSnapshotArnsList = Array<ElastiCacheString>;
-    export interface ElastiCacheSnapshotFeatureNotSupportedFault {
-    }
-
-    export type ElastiCacheSnapshotList = Array<ElastiCacheSnapshot>;
-    export interface ElastiCacheSnapshotNotFoundFault {
-    }
-
-    export interface ElastiCacheSnapshotQuotaExceededFault {
-    }
-
-    export type ElastiCacheSourceType = string;
-    export type ElastiCacheString = string;
-    export interface ElastiCacheSubnet {
-        SubnetIdentifier?: ElastiCacheString;
-        SubnetAvailabilityZone?: ElastiCacheAvailabilityZone;
-    }
-
-    export type ElastiCacheSubnetIdentifierList = Array<ElastiCacheString>;
-    export interface ElastiCacheSubnetInUse {
-    }
-
-    export type ElastiCacheSubnetList = Array<ElastiCacheSubnet>;
-    export type ElastiCacheTStamp = number;
-    export interface ElastiCacheTag {
-        Key?: ElastiCacheString;
-        Value?: ElastiCacheString;
-    }
-
-    export type ElastiCacheTagList = Array<ElastiCacheTag>;
-    export interface ElastiCacheTagListMessage {
-        TagList?: ElastiCacheTagList;
-    }
-
-    export interface ElastiCacheTagNotFoundFault {
-    }
-
-    export interface ElastiCacheTagQuotaPerResourceExceeded {
-    }
-
-    export interface ElastiCacheAuthorizeCacheSecurityGroupIngressResult {
-        CacheSecurityGroup?: ElastiCacheCacheSecurityGroup;
-    }
-
-    export interface ElastiCacheCopySnapshotResult {
-        Snapshot?: ElastiCacheSnapshot;
-    }
-
-    export interface ElastiCacheCreateCacheClusterResult {
-        CacheCluster?: ElastiCacheCacheCluster;
-    }
-
-    export interface ElastiCacheCreateCacheParameterGroupResult {
-        CacheParameterGroup?: ElastiCacheCacheParameterGroup;
-    }
-
-    export interface ElastiCacheCreateCacheSecurityGroupResult {
-        CacheSecurityGroup?: ElastiCacheCacheSecurityGroup;
-    }
-
-    export interface ElastiCacheCreateCacheSubnetGroupResult {
-        CacheSubnetGroup?: ElastiCacheCacheSubnetGroup;
-    }
-
-    export interface ElastiCacheCreateReplicationGroupResult {
-        ReplicationGroup?: ElastiCacheReplicationGroup;
-    }
-
-    export interface ElastiCacheCreateSnapshotResult {
-        Snapshot?: ElastiCacheSnapshot;
-    }
-
-    export interface ElastiCacheDeleteCacheClusterResult {
-        CacheCluster?: ElastiCacheCacheCluster;
-    }
-
-    export interface ElastiCacheDeleteReplicationGroupResult {
-        ReplicationGroup?: ElastiCacheReplicationGroup;
-    }
-
-    export interface ElastiCacheDeleteSnapshotResult {
-        Snapshot?: ElastiCacheSnapshot;
-    }
-
-    export interface ElastiCacheDescribeEngineDefaultParametersResult {
-        EngineDefaults?: ElastiCacheEngineDefaults;
-    }
-
-    export interface ElastiCacheModifyCacheClusterResult {
-        CacheCluster?: ElastiCacheCacheCluster;
-    }
-
-    export interface ElastiCacheModifyCacheSubnetGroupResult {
-        CacheSubnetGroup?: ElastiCacheCacheSubnetGroup;
-    }
-
-    export interface ElastiCacheModifyReplicationGroupResult {
-        ReplicationGroup?: ElastiCacheReplicationGroup;
-    }
-
-    export interface ElastiCachePurchaseReservedCacheNodesOfferingResult {
-        ReservedCacheNode?: ElastiCacheReservedCacheNode;
-    }
-
-    export interface ElastiCacheRebootCacheClusterResult {
-        CacheCluster?: ElastiCacheCacheCluster;
-    }
-
-    export interface ElastiCacheRevokeCacheSecurityGroupIngressResult {
-        CacheSecurityGroup?: ElastiCacheCacheSecurityGroup;
-    }
-
 }

--- a/output/aws-elasticbeanstalk.d.ts
+++ b/output/aws-elasticbeanstalk.d.ts
@@ -6,729 +6,640 @@ declare module "aws-sdk" {
 
     export class ElasticBeanstalk extends Service {
       constructor(options?: any);
-      abortEnvironmentUpdate(params: ElasticBeanstalkAbortEnvironmentUpdateMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: any) => void): Request;
-      checkDNSAvailability(params: ElasticBeanstalkCheckDNSAvailabilityMessage, callback?: (err: any, data: ElasticBeanstalkCheckDNSAvailabilityResultMessage|any) => void): Request;
-      composeEnvironments(params: ElasticBeanstalkComposeEnvironmentsMessage, callback?: (err: ElasticBeanstalkTooManyEnvironmentsException|ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkEnvironmentDescriptionsMessage|any) => void): Request;
-      createApplication(params: ElasticBeanstalkCreateApplicationMessage, callback?: (err: ElasticBeanstalkTooManyApplicationsException|any, data: ElasticBeanstalkApplicationDescriptionMessage|any) => void): Request;
-      createApplicationVersion(params: ElasticBeanstalkCreateApplicationVersionMessage, callback?: (err: ElasticBeanstalkTooManyApplicationsException|ElasticBeanstalkTooManyApplicationVersionsException|ElasticBeanstalkInsufficientPrivilegesException|ElasticBeanstalkS3LocationNotInServiceRegionException|any, data: ElasticBeanstalkApplicationVersionDescriptionMessage|any) => void): Request;
-      createConfigurationTemplate(params: ElasticBeanstalkCreateConfigurationTemplateMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|ElasticBeanstalkTooManyConfigurationTemplatesException|any, data: ElasticBeanstalkConfigurationSettingsDescription|any) => void): Request;
-      createEnvironment(params: ElasticBeanstalkCreateEnvironmentMessage, callback?: (err: ElasticBeanstalkTooManyEnvironmentsException|ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkEnvironmentDescription|any) => void): Request;
-      createStorageLocation(callback?: (err: ElasticBeanstalkTooManyBucketsException|ElasticBeanstalkS3SubscriptionRequiredException|ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkCreateStorageLocationResultMessage|any) => void): Request;
-      deleteApplication(params: ElasticBeanstalkDeleteApplicationMessage, callback?: (err: ElasticBeanstalkOperationInProgressException|any, data: any) => void): Request;
-      deleteApplicationVersion(params: ElasticBeanstalkDeleteApplicationVersionMessage, callback?: (err: ElasticBeanstalkSourceBundleDeletionException|ElasticBeanstalkInsufficientPrivilegesException|ElasticBeanstalkOperationInProgressException|ElasticBeanstalkS3LocationNotInServiceRegionException|any, data: any) => void): Request;
-      deleteConfigurationTemplate(params: ElasticBeanstalkDeleteConfigurationTemplateMessage, callback?: (err: ElasticBeanstalkOperationInProgressException|any, data: any) => void): Request;
-      deleteEnvironmentConfiguration(params: ElasticBeanstalkDeleteEnvironmentConfigurationMessage, callback?: (err: any, data: any) => void): Request;
-      describeApplicationVersions(params: ElasticBeanstalkDescribeApplicationVersionsMessage, callback?: (err: any, data: ElasticBeanstalkApplicationVersionDescriptionsMessage|any) => void): Request;
-      describeApplications(params: ElasticBeanstalkDescribeApplicationsMessage, callback?: (err: any, data: ElasticBeanstalkApplicationDescriptionsMessage|any) => void): Request;
-      describeConfigurationOptions(params: ElasticBeanstalkDescribeConfigurationOptionsMessage, callback?: (err: any, data: ElasticBeanstalkConfigurationOptionsDescription|any) => void): Request;
-      describeConfigurationSettings(params: ElasticBeanstalkDescribeConfigurationSettingsMessage, callback?: (err: any, data: ElasticBeanstalkConfigurationSettingsDescriptions|any) => void): Request;
-      describeEnvironmentHealth(params: ElasticBeanstalkDescribeEnvironmentHealthRequest, callback?: (err: ElasticBeanstalkInvalidRequestException|ElasticBeanstalkElasticBeanstalkServiceException|any, data: ElasticBeanstalkDescribeEnvironmentHealthResult|any) => void): Request;
-      describeEnvironmentResources(params: ElasticBeanstalkDescribeEnvironmentResourcesMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkEnvironmentResourceDescriptionsMessage|any) => void): Request;
-      describeEnvironments(params: ElasticBeanstalkDescribeEnvironmentsMessage, callback?: (err: any, data: ElasticBeanstalkEnvironmentDescriptionsMessage|any) => void): Request;
-      describeEvents(params: ElasticBeanstalkDescribeEventsMessage, callback?: (err: any, data: ElasticBeanstalkEventDescriptionsMessage|any) => void): Request;
-      describeInstancesHealth(params: ElasticBeanstalkDescribeInstancesHealthRequest, callback?: (err: ElasticBeanstalkInvalidRequestException|ElasticBeanstalkElasticBeanstalkServiceException|any, data: ElasticBeanstalkDescribeInstancesHealthResult|any) => void): Request;
-      listAvailableSolutionStacks(callback?: (err: any, data: ElasticBeanstalkListAvailableSolutionStacksResultMessage|any) => void): Request;
-      rebuildEnvironment(params: ElasticBeanstalkRebuildEnvironmentMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: any) => void): Request;
-      requestEnvironmentInfo(params: ElasticBeanstalkRequestEnvironmentInfoMessage, callback?: (err: any, data: any) => void): Request;
-      restartAppServer(params: ElasticBeanstalkRestartAppServerMessage, callback?: (err: any, data: any) => void): Request;
-      retrieveEnvironmentInfo(params: ElasticBeanstalkRetrieveEnvironmentInfoMessage, callback?: (err: any, data: ElasticBeanstalkRetrieveEnvironmentInfoResultMessage|any) => void): Request;
-      swapEnvironmentCNAMEs(params: ElasticBeanstalkSwapEnvironmentCNAMEsMessage, callback?: (err: any, data: any) => void): Request;
-      terminateEnvironment(params: ElasticBeanstalkTerminateEnvironmentMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkEnvironmentDescription|any) => void): Request;
-      updateApplication(params: ElasticBeanstalkUpdateApplicationMessage, callback?: (err: any, data: ElasticBeanstalkApplicationDescriptionMessage|any) => void): Request;
-      updateApplicationVersion(params: ElasticBeanstalkUpdateApplicationVersionMessage, callback?: (err: any, data: ElasticBeanstalkApplicationVersionDescriptionMessage|any) => void): Request;
-      updateConfigurationTemplate(params: ElasticBeanstalkUpdateConfigurationTemplateMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkConfigurationSettingsDescription|any) => void): Request;
-      updateEnvironment(params: ElasticBeanstalkUpdateEnvironmentMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkEnvironmentDescription|any) => void): Request;
-      validateConfigurationSettings(params: ElasticBeanstalkValidateConfigurationSettingsMessage, callback?: (err: ElasticBeanstalkInsufficientPrivilegesException|any, data: ElasticBeanstalkConfigurationSettingsValidationMessages|any) => void): Request;
-    }
-
-    export interface ElasticBeanstalkAbortEnvironmentUpdateMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-    }
-
-    export type ElasticBeanstalkAbortableOperationInProgress = boolean;
-    export interface ElasticBeanstalkApplicationDescription {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        Description?: ElasticBeanstalkDescription;
-        DateCreated?: ElasticBeanstalkCreationDate;
-        DateUpdated?: ElasticBeanstalkUpdateDate;
-        Versions?: ElasticBeanstalkVersionLabelsList;
-        ConfigurationTemplates?: ElasticBeanstalkConfigurationTemplateNamesList;
-    }
-
-    export type ElasticBeanstalkApplicationDescriptionList = Array<ElasticBeanstalkApplicationDescription>;
-    export interface ElasticBeanstalkApplicationDescriptionMessage {
-        Application?: ElasticBeanstalkApplicationDescription;
-    }
-
-    export interface ElasticBeanstalkApplicationDescriptionsMessage {
-        Applications?: ElasticBeanstalkApplicationDescriptionList;
-    }
-
-    export interface ElasticBeanstalkApplicationMetrics {
-        Duration?: ElasticBeanstalkNullableInteger;
-        RequestCount?: ElasticBeanstalkRequestCount;
-        StatusCodes?: ElasticBeanstalkStatusCodes;
-        Latency?: ElasticBeanstalkLatency;
-    }
-
-    export type ElasticBeanstalkApplicationName = string;
-    export type ElasticBeanstalkApplicationNamesList = Array<ElasticBeanstalkApplicationName>;
-    export interface ElasticBeanstalkApplicationVersionDescription {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        Description?: ElasticBeanstalkDescription;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        SourceBundle?: ElasticBeanstalkS3Location;
-        DateCreated?: ElasticBeanstalkCreationDate;
-        DateUpdated?: ElasticBeanstalkUpdateDate;
-        Status?: ElasticBeanstalkApplicationVersionStatus;
-    }
-
-    export type ElasticBeanstalkApplicationVersionDescriptionList = Array<ElasticBeanstalkApplicationVersionDescription>;
-    export interface ElasticBeanstalkApplicationVersionDescriptionMessage {
-        ApplicationVersion?: ElasticBeanstalkApplicationVersionDescription;
-    }
-
-    export interface ElasticBeanstalkApplicationVersionDescriptionsMessage {
-        ApplicationVersions?: ElasticBeanstalkApplicationVersionDescriptionList;
-    }
-
-    export type ElasticBeanstalkApplicationVersionProccess = boolean;
-    export type ElasticBeanstalkApplicationVersionStatus = string;
-    export type ElasticBeanstalkAutoCreateApplication = boolean;
-    export interface ElasticBeanstalkAutoScalingGroup {
-        Name?: ElasticBeanstalkResourceId;
-    }
-
-    export type ElasticBeanstalkAutoScalingGroupList = Array<ElasticBeanstalkAutoScalingGroup>;
-    export type ElasticBeanstalkAvailableSolutionStackDetailsList = Array<ElasticBeanstalkSolutionStackDescription>;
-    export type ElasticBeanstalkAvailableSolutionStackNamesList = Array<ElasticBeanstalkSolutionStackName>;
-    export interface ElasticBeanstalkCPUUtilization {
-        User?: ElasticBeanstalkNullableDouble;
-        Nice?: ElasticBeanstalkNullableDouble;
-        System?: ElasticBeanstalkNullableDouble;
-        Idle?: ElasticBeanstalkNullableDouble;
-        IOWait?: ElasticBeanstalkNullableDouble;
-        IRQ?: ElasticBeanstalkNullableDouble;
-        SoftIRQ?: ElasticBeanstalkNullableDouble;
-    }
-
-    export type ElasticBeanstalkCause = string;
-    export type ElasticBeanstalkCauses = Array<ElasticBeanstalkCause>;
-    export interface ElasticBeanstalkCheckDNSAvailabilityMessage {
-        CNAMEPrefix: ElasticBeanstalkDNSCnamePrefix;
-    }
-
-    export interface ElasticBeanstalkCheckDNSAvailabilityResultMessage {
-        Available?: ElasticBeanstalkCnameAvailability;
-        FullyQualifiedCNAME?: ElasticBeanstalkDNSCname;
-    }
-
-    export type ElasticBeanstalkCnameAvailability = boolean;
-    export interface ElasticBeanstalkComposeEnvironmentsMessage {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        GroupName?: ElasticBeanstalkGroupName;
-        VersionLabels?: ElasticBeanstalkVersionLabels;
-    }
-
-    export type ElasticBeanstalkConfigurationDeploymentStatus = string;
-    export type ElasticBeanstalkConfigurationOptionDefaultValue = string;
-    export interface ElasticBeanstalkConfigurationOptionDescription {
-        Namespace?: ElasticBeanstalkOptionNamespace;
-        Name?: ElasticBeanstalkConfigurationOptionName;
-        DefaultValue?: ElasticBeanstalkConfigurationOptionDefaultValue;
-        ChangeSeverity?: ElasticBeanstalkConfigurationOptionSeverity;
-        UserDefined?: ElasticBeanstalkUserDefinedOption;
-        ValueType?: ElasticBeanstalkConfigurationOptionValueType;
-        ValueOptions?: ElasticBeanstalkConfigurationOptionPossibleValues;
-        MinValue?: ElasticBeanstalkOptionRestrictionMinValue;
-        MaxValue?: ElasticBeanstalkOptionRestrictionMaxValue;
-        MaxLength?: ElasticBeanstalkOptionRestrictionMaxLength;
-        Regex?: ElasticBeanstalkOptionRestrictionRegex;
-    }
-
-    export type ElasticBeanstalkConfigurationOptionDescriptionsList = Array<ElasticBeanstalkConfigurationOptionDescription>;
-    export type ElasticBeanstalkConfigurationOptionName = string;
-    export type ElasticBeanstalkConfigurationOptionPossibleValue = string;
-    export type ElasticBeanstalkConfigurationOptionPossibleValues = Array<ElasticBeanstalkConfigurationOptionPossibleValue>;
-    export interface ElasticBeanstalkConfigurationOptionSetting {
-        ResourceName?: ElasticBeanstalkResourceName;
-        Namespace?: ElasticBeanstalkOptionNamespace;
-        OptionName?: ElasticBeanstalkConfigurationOptionName;
-        Value?: ElasticBeanstalkConfigurationOptionValue;
-    }
-
-    export type ElasticBeanstalkConfigurationOptionSettingsList = Array<ElasticBeanstalkConfigurationOptionSetting>;
-    export type ElasticBeanstalkConfigurationOptionSeverity = string;
-    export type ElasticBeanstalkConfigurationOptionValue = string;
-    export type ElasticBeanstalkConfigurationOptionValueType = string;
-    export interface ElasticBeanstalkConfigurationOptionsDescription {
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        Options?: ElasticBeanstalkConfigurationOptionDescriptionsList;
-    }
-
-    export interface ElasticBeanstalkConfigurationSettingsDescription {
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        Description?: ElasticBeanstalkDescription;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        DeploymentStatus?: ElasticBeanstalkConfigurationDeploymentStatus;
-        DateCreated?: ElasticBeanstalkCreationDate;
-        DateUpdated?: ElasticBeanstalkUpdateDate;
-        OptionSettings?: ElasticBeanstalkConfigurationOptionSettingsList;
-    }
-
-    export type ElasticBeanstalkConfigurationSettingsDescriptionList = Array<ElasticBeanstalkConfigurationSettingsDescription>;
-    export interface ElasticBeanstalkConfigurationSettingsDescriptions {
-        ConfigurationSettings?: ElasticBeanstalkConfigurationSettingsDescriptionList;
-    }
-
-    export interface ElasticBeanstalkConfigurationSettingsValidationMessages {
-        Messages?: ElasticBeanstalkValidationMessagesList;
-    }
-
-    export type ElasticBeanstalkConfigurationTemplateName = string;
-    export type ElasticBeanstalkConfigurationTemplateNamesList = Array<ElasticBeanstalkConfigurationTemplateName>;
-    export interface ElasticBeanstalkCreateApplicationMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        Description?: ElasticBeanstalkDescription;
-    }
-
-    export interface ElasticBeanstalkCreateApplicationVersionMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        VersionLabel: ElasticBeanstalkVersionLabel;
-        Description?: ElasticBeanstalkDescription;
-        SourceBundle?: ElasticBeanstalkS3Location;
-        AutoCreateApplication?: ElasticBeanstalkAutoCreateApplication;
-        Process?: ElasticBeanstalkApplicationVersionProccess;
-    }
-
-    export interface ElasticBeanstalkCreateConfigurationTemplateMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        TemplateName: ElasticBeanstalkConfigurationTemplateName;
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        SourceConfiguration?: ElasticBeanstalkSourceConfiguration;
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        Description?: ElasticBeanstalkDescription;
-        OptionSettings?: ElasticBeanstalkConfigurationOptionSettingsList;
-    }
-
-    export interface ElasticBeanstalkCreateEnvironmentMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        GroupName?: ElasticBeanstalkGroupName;
-        Description?: ElasticBeanstalkDescription;
-        CNAMEPrefix?: ElasticBeanstalkDNSCnamePrefix;
-        Tier?: ElasticBeanstalkEnvironmentTier;
-        Tags?: ElasticBeanstalkTags;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        OptionSettings?: ElasticBeanstalkConfigurationOptionSettingsList;
-        OptionsToRemove?: ElasticBeanstalkOptionsSpecifierList;
-    }
-
-    export interface ElasticBeanstalkCreateStorageLocationResultMessage {
-        S3Bucket?: ElasticBeanstalkS3Bucket;
-    }
-
-    export type ElasticBeanstalkCreationDate = number;
-    export type ElasticBeanstalkDNSCname = string;
-    export type ElasticBeanstalkDNSCnamePrefix = string;
-    export interface ElasticBeanstalkDeleteApplicationMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        TerminateEnvByForce?: ElasticBeanstalkTerminateEnvForce;
-    }
-
-    export interface ElasticBeanstalkDeleteApplicationVersionMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        VersionLabel: ElasticBeanstalkVersionLabel;
-        DeleteSourceBundle?: ElasticBeanstalkDeleteSourceBundle;
-    }
-
-    export interface ElasticBeanstalkDeleteConfigurationTemplateMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        TemplateName: ElasticBeanstalkConfigurationTemplateName;
-    }
-
-    export interface ElasticBeanstalkDeleteEnvironmentConfigurationMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        EnvironmentName: ElasticBeanstalkEnvironmentName;
-    }
-
-    export type ElasticBeanstalkDeleteSourceBundle = boolean;
-    export interface ElasticBeanstalkDescribeApplicationVersionsMessage {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        VersionLabels?: ElasticBeanstalkVersionLabelsList;
-    }
-
-    export interface ElasticBeanstalkDescribeApplicationsMessage {
-        ApplicationNames?: ElasticBeanstalkApplicationNamesList;
-    }
-
-    export interface ElasticBeanstalkDescribeConfigurationOptionsMessage {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        Options?: ElasticBeanstalkOptionsSpecifierList;
-    }
-
-    export interface ElasticBeanstalkDescribeConfigurationSettingsMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-    }
-
-    export interface ElasticBeanstalkDescribeEnvironmentHealthRequest {
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        AttributeNames?: ElasticBeanstalkEnvironmentHealthAttributes;
-    }
-
-    export interface ElasticBeanstalkDescribeEnvironmentHealthResult {
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        HealthStatus?: ElasticBeanstalkString;
-        Status?: ElasticBeanstalkEnvironmentHealth;
-        Color?: ElasticBeanstalkString;
-        Causes?: ElasticBeanstalkCauses;
-        ApplicationMetrics?: ElasticBeanstalkApplicationMetrics;
-        InstancesHealth?: ElasticBeanstalkInstanceHealthSummary;
-        RefreshedAt?: ElasticBeanstalkRefreshedAt;
-    }
-
-    export interface ElasticBeanstalkDescribeEnvironmentResourcesMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-    }
-
-    export interface ElasticBeanstalkDescribeEnvironmentsMessage {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        EnvironmentIds?: ElasticBeanstalkEnvironmentIdList;
-        EnvironmentNames?: ElasticBeanstalkEnvironmentNamesList;
-        IncludeDeleted?: ElasticBeanstalkIncludeDeleted;
-        IncludedDeletedBackTo?: ElasticBeanstalkIncludeDeletedBackTo;
-    }
-
-    export interface ElasticBeanstalkDescribeEventsMessage {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        RequestId?: ElasticBeanstalkRequestId;
-        Severity?: ElasticBeanstalkEventSeverity;
-        StartTime?: ElasticBeanstalkTimeFilterStart;
-        EndTime?: ElasticBeanstalkTimeFilterEnd;
-        MaxRecords?: ElasticBeanstalkMaxRecords;
-        NextToken?: ElasticBeanstalkToken;
-    }
-
-    export interface ElasticBeanstalkDescribeInstancesHealthRequest {
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        AttributeNames?: ElasticBeanstalkInstancesHealthAttributes;
-        NextToken?: ElasticBeanstalkNextToken;
-    }
-
-    export interface ElasticBeanstalkDescribeInstancesHealthResult {
-        InstanceHealthList?: ElasticBeanstalkInstanceHealthList;
-        RefreshedAt?: ElasticBeanstalkRefreshedAt;
-        NextToken?: ElasticBeanstalkNextToken;
-    }
-
-    export type ElasticBeanstalkDescription = string;
-    export type ElasticBeanstalkEc2InstanceId = string;
-    export interface ElasticBeanstalkElasticBeanstalkServiceException {
-        message?: ElasticBeanstalkExceptionMessage;
-    }
-
-    export type ElasticBeanstalkEndpointURL = string;
-    export interface ElasticBeanstalkEnvironmentDescription {
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        Description?: ElasticBeanstalkDescription;
-        EndpointURL?: ElasticBeanstalkEndpointURL;
-        CNAME?: ElasticBeanstalkDNSCname;
-        DateCreated?: ElasticBeanstalkCreationDate;
-        DateUpdated?: ElasticBeanstalkUpdateDate;
-        Status?: ElasticBeanstalkEnvironmentStatus;
-        AbortableOperationInProgress?: ElasticBeanstalkAbortableOperationInProgress;
-        Health?: ElasticBeanstalkEnvironmentHealth;
-        HealthStatus?: ElasticBeanstalkEnvironmentHealthStatus;
-        Resources?: ElasticBeanstalkEnvironmentResourcesDescription;
-        Tier?: ElasticBeanstalkEnvironmentTier;
-        EnvironmentLinks?: ElasticBeanstalkEnvironmentLinks;
-    }
-
-    export type ElasticBeanstalkEnvironmentDescriptionsList = Array<ElasticBeanstalkEnvironmentDescription>;
-    export interface ElasticBeanstalkEnvironmentDescriptionsMessage {
-        Environments?: ElasticBeanstalkEnvironmentDescriptionsList;
-    }
-
-    export type ElasticBeanstalkEnvironmentHealth = string;
-    export type ElasticBeanstalkEnvironmentHealthAttribute = string;
-    export type ElasticBeanstalkEnvironmentHealthAttributes = Array<ElasticBeanstalkEnvironmentHealthAttribute>;
-    export type ElasticBeanstalkEnvironmentHealthStatus = string;
-    export type ElasticBeanstalkEnvironmentId = string;
-    export type ElasticBeanstalkEnvironmentIdList = Array<ElasticBeanstalkEnvironmentId>;
-    export interface ElasticBeanstalkEnvironmentInfoDescription {
-        InfoType?: ElasticBeanstalkEnvironmentInfoType;
-        Ec2InstanceId?: ElasticBeanstalkEc2InstanceId;
-        SampleTimestamp?: ElasticBeanstalkSampleTimestamp;
-        Message?: ElasticBeanstalkMessage;
-    }
-
-    export type ElasticBeanstalkEnvironmentInfoDescriptionList = Array<ElasticBeanstalkEnvironmentInfoDescription>;
-    export type ElasticBeanstalkEnvironmentInfoType = string;
-    export interface ElasticBeanstalkEnvironmentLink {
-        LinkName?: ElasticBeanstalkString;
-        EnvironmentName?: ElasticBeanstalkString;
-    }
-
-    export type ElasticBeanstalkEnvironmentLinks = Array<ElasticBeanstalkEnvironmentLink>;
-    export type ElasticBeanstalkEnvironmentName = string;
-    export type ElasticBeanstalkEnvironmentNamesList = Array<ElasticBeanstalkEnvironmentName>;
-    export interface ElasticBeanstalkEnvironmentResourceDescription {
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        AutoScalingGroups?: ElasticBeanstalkAutoScalingGroupList;
-        Instances?: ElasticBeanstalkInstanceList;
-        LaunchConfigurations?: ElasticBeanstalkLaunchConfigurationList;
-        LoadBalancers?: ElasticBeanstalkLoadBalancerList;
-        Triggers?: ElasticBeanstalkTriggerList;
-        Queues?: ElasticBeanstalkQueueList;
-    }
-
-    export interface ElasticBeanstalkEnvironmentResourceDescriptionsMessage {
-        EnvironmentResources?: ElasticBeanstalkEnvironmentResourceDescription;
-    }
+      abortEnvironmentUpdate(params: ElasticBeanstalk.AbortEnvironmentUpdateMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: any) => void): Request;
+      checkDNSAvailability(params: ElasticBeanstalk.CheckDNSAvailabilityMessage, callback?: (err: any, data: ElasticBeanstalk.CheckDNSAvailabilityResultMessage|any) => void): Request;
+      composeEnvironments(params: ElasticBeanstalk.ComposeEnvironmentsMessage, callback?: (err: ElasticBeanstalk.TooManyEnvironmentsException|ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.EnvironmentDescriptionsMessage|any) => void): Request;
+      createApplication(params: ElasticBeanstalk.CreateApplicationMessage, callback?: (err: ElasticBeanstalk.TooManyApplicationsException|any, data: ElasticBeanstalk.ApplicationDescriptionMessage|any) => void): Request;
+      createApplicationVersion(params: ElasticBeanstalk.CreateApplicationVersionMessage, callback?: (err: ElasticBeanstalk.TooManyApplicationsException|ElasticBeanstalk.TooManyApplicationVersionsException|ElasticBeanstalk.InsufficientPrivilegesException|ElasticBeanstalk.S3LocationNotInServiceRegionException|any, data: ElasticBeanstalk.ApplicationVersionDescriptionMessage|any) => void): Request;
+      createConfigurationTemplate(params: ElasticBeanstalk.CreateConfigurationTemplateMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|ElasticBeanstalk.TooManyConfigurationTemplatesException|any, data: ElasticBeanstalk.ConfigurationSettingsDescription|any) => void): Request;
+      createEnvironment(params: ElasticBeanstalk.CreateEnvironmentMessage, callback?: (err: ElasticBeanstalk.TooManyEnvironmentsException|ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.EnvironmentDescription|any) => void): Request;
+      createStorageLocation(callback?: (err: ElasticBeanstalk.TooManyBucketsException|ElasticBeanstalk.S3SubscriptionRequiredException|ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.CreateStorageLocationResultMessage|any) => void): Request;
+      deleteApplication(params: ElasticBeanstalk.DeleteApplicationMessage, callback?: (err: ElasticBeanstalk.OperationInProgressException|any, data: any) => void): Request;
+      deleteApplicationVersion(params: ElasticBeanstalk.DeleteApplicationVersionMessage, callback?: (err: ElasticBeanstalk.SourceBundleDeletionException|ElasticBeanstalk.InsufficientPrivilegesException|ElasticBeanstalk.OperationInProgressException|ElasticBeanstalk.S3LocationNotInServiceRegionException|any, data: any) => void): Request;
+      deleteConfigurationTemplate(params: ElasticBeanstalk.DeleteConfigurationTemplateMessage, callback?: (err: ElasticBeanstalk.OperationInProgressException|any, data: any) => void): Request;
+      deleteEnvironmentConfiguration(params: ElasticBeanstalk.DeleteEnvironmentConfigurationMessage, callback?: (err: any, data: any) => void): Request;
+      describeApplicationVersions(params: ElasticBeanstalk.DescribeApplicationVersionsMessage, callback?: (err: any, data: ElasticBeanstalk.ApplicationVersionDescriptionsMessage|any) => void): Request;
+      describeApplications(params: ElasticBeanstalk.DescribeApplicationsMessage, callback?: (err: any, data: ElasticBeanstalk.ApplicationDescriptionsMessage|any) => void): Request;
+      describeConfigurationOptions(params: ElasticBeanstalk.DescribeConfigurationOptionsMessage, callback?: (err: any, data: ElasticBeanstalk.ConfigurationOptionsDescription|any) => void): Request;
+      describeConfigurationSettings(params: ElasticBeanstalk.DescribeConfigurationSettingsMessage, callback?: (err: any, data: ElasticBeanstalk.ConfigurationSettingsDescriptions|any) => void): Request;
+      describeEnvironmentHealth(params: ElasticBeanstalk.DescribeEnvironmentHealthRequest, callback?: (err: ElasticBeanstalk.InvalidRequestException|ElasticBeanstalk.ElasticBeanstalkServiceException|any, data: ElasticBeanstalk.DescribeEnvironmentHealthResult|any) => void): Request;
+      describeEnvironmentResources(params: ElasticBeanstalk.DescribeEnvironmentResourcesMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.EnvironmentResourceDescriptionsMessage|any) => void): Request;
+      describeEnvironments(params: ElasticBeanstalk.DescribeEnvironmentsMessage, callback?: (err: any, data: ElasticBeanstalk.EnvironmentDescriptionsMessage|any) => void): Request;
+      describeEvents(params: ElasticBeanstalk.DescribeEventsMessage, callback?: (err: any, data: ElasticBeanstalk.EventDescriptionsMessage|any) => void): Request;
+      describeInstancesHealth(params: ElasticBeanstalk.DescribeInstancesHealthRequest, callback?: (err: ElasticBeanstalk.InvalidRequestException|ElasticBeanstalk.ElasticBeanstalkServiceException|any, data: ElasticBeanstalk.DescribeInstancesHealthResult|any) => void): Request;
+      listAvailableSolutionStacks(callback?: (err: any, data: ElasticBeanstalk.ListAvailableSolutionStacksResultMessage|any) => void): Request;
+      rebuildEnvironment(params: ElasticBeanstalk.RebuildEnvironmentMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: any) => void): Request;
+      requestEnvironmentInfo(params: ElasticBeanstalk.RequestEnvironmentInfoMessage, callback?: (err: any, data: any) => void): Request;
+      restartAppServer(params: ElasticBeanstalk.RestartAppServerMessage, callback?: (err: any, data: any) => void): Request;
+      retrieveEnvironmentInfo(params: ElasticBeanstalk.RetrieveEnvironmentInfoMessage, callback?: (err: any, data: ElasticBeanstalk.RetrieveEnvironmentInfoResultMessage|any) => void): Request;
+      swapEnvironmentCNAMEs(params: ElasticBeanstalk.SwapEnvironmentCNAMEsMessage, callback?: (err: any, data: any) => void): Request;
+      terminateEnvironment(params: ElasticBeanstalk.TerminateEnvironmentMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.EnvironmentDescription|any) => void): Request;
+      updateApplication(params: ElasticBeanstalk.UpdateApplicationMessage, callback?: (err: any, data: ElasticBeanstalk.ApplicationDescriptionMessage|any) => void): Request;
+      updateApplicationVersion(params: ElasticBeanstalk.UpdateApplicationVersionMessage, callback?: (err: any, data: ElasticBeanstalk.ApplicationVersionDescriptionMessage|any) => void): Request;
+      updateConfigurationTemplate(params: ElasticBeanstalk.UpdateConfigurationTemplateMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.ConfigurationSettingsDescription|any) => void): Request;
+      updateEnvironment(params: ElasticBeanstalk.UpdateEnvironmentMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.EnvironmentDescription|any) => void): Request;
+      validateConfigurationSettings(params: ElasticBeanstalk.ValidateConfigurationSettingsMessage, callback?: (err: ElasticBeanstalk.InsufficientPrivilegesException|any, data: ElasticBeanstalk.ConfigurationSettingsValidationMessages|any) => void): Request;
+    }
+    
+    export module ElasticBeanstalk {
+        export type AbortableOperationInProgress = boolean;
+        export type ApplicationDescriptionList = ApplicationDescription[];
+        export type ApplicationName = string;    // max: 100, min: 1
+        export type ApplicationNamesList = ApplicationName[];
+        export type ApplicationVersionDescriptionList = ApplicationVersionDescription[];
+        export type ApplicationVersionProccess = boolean;
+        export type ApplicationVersionStatus = string;
+        export type AutoCreateApplication = boolean;
+        export type AutoScalingGroupList = AutoScalingGroup[];
+        export type AvailableSolutionStackDetailsList = SolutionStackDescription[];
+        export type AvailableSolutionStackNamesList = SolutionStackName[];
+        export type Cause = string;    // max: 255, min: 1
+        export type Causes = Cause[];
+        export type CnameAvailability = boolean;
+        export type ConfigurationDeploymentStatus = string;
+        export type ConfigurationOptionDefaultValue = string;
+        export type ConfigurationOptionDescriptionsList = ConfigurationOptionDescription[];
+        export type ConfigurationOptionName = string;
+        export type ConfigurationOptionPossibleValue = string;
+        export type ConfigurationOptionPossibleValues = ConfigurationOptionPossibleValue[];
+        export type ConfigurationOptionSettingsList = ConfigurationOptionSetting[];
+        export type ConfigurationOptionSeverity = string;
+        export type ConfigurationOptionValue = string;
+        export type ConfigurationOptionValueType = string;
+        export type ConfigurationSettingsDescriptionList = ConfigurationSettingsDescription[];
+        export type ConfigurationTemplateName = string;    // max: 100, min: 1
+        export type ConfigurationTemplateNamesList = ConfigurationTemplateName[];
+        export type CreationDate = number;
+        export type DNSCname = string;    // max: 255, min: 1
+        export type DNSCnamePrefix = string;    // max: 63, min: 4
+        export type DeleteSourceBundle = boolean;
+        export type Description = string;    // max: 200
+        export type Ec2InstanceId = string;
+        export type EndpointURL = string;
+        export type EnvironmentDescriptionsList = EnvironmentDescription[];
+        export type EnvironmentHealth = string;
+        export type EnvironmentHealthAttribute = string;
+        export type EnvironmentHealthAttributes = EnvironmentHealthAttribute[];
+        export type EnvironmentHealthStatus = string;
+        export type EnvironmentId = string;
+        export type EnvironmentIdList = EnvironmentId[];
+        export type EnvironmentInfoDescriptionList = EnvironmentInfoDescription[];
+        export type EnvironmentInfoType = string;
+        export type EnvironmentLinks = EnvironmentLink[];
+        export type EnvironmentName = string;    // max: 23, min: 4
+        export type EnvironmentNamesList = EnvironmentName[];
+        export type EnvironmentStatus = string;
+        export type EventDate = number;
+        export type EventDescriptionList = EventDescription[];
+        export type EventMessage = string;
+        export type EventSeverity = string;
+        export type ExceptionMessage = string;
+        export type FileTypeExtension = string;    // max: 100, min: 1
+        export type ForceTerminate = boolean;
+        export type GroupName = string;    // max: 19, min: 1
+        export type IncludeDeleted = boolean;
+        export type IncludeDeletedBackTo = number;
+        export type InstanceHealthList = SingleInstanceHealth[];
+        export type InstanceId = string;    // max: 255, min: 1
+        export type InstanceList = Instance[];
+        export type InstancesHealthAttribute = string;
+        export type InstancesHealthAttributes = InstancesHealthAttribute[];
+        export type Integer = number;
+        export type LaunchConfigurationList = LaunchConfiguration[];
+        export type LaunchedAt = number;
+        export type LoadAverage = LoadAverageValue[];
+        export type LoadAverageValue = number;
+        export type LoadBalancerList = LoadBalancer[];
+        export type LoadBalancerListenersDescription = Listener[];
+        export type MaxRecords = number;    // max: 1000, min: 1
+        export type Message = string;
+        export type NextToken = string;    // max: 100, min: 1
+        export type NullableDouble = number;
+        export type NullableInteger = number;
+        export type OptionNamespace = string;
+        export type OptionRestrictionMaxLength = number;
+        export type OptionRestrictionMaxValue = number;
+        export type OptionRestrictionMinValue = number;
+        export type OptionsSpecifierList = OptionSpecification[];
+        export type QueueList = Queue[];
+        export type RefreshedAt = number;
+        export type RegexLabel = string;
+        export type RegexPattern = string;
+        export type RequestCount = number;
+        export type RequestId = string;
+        export type ResourceId = string;
+        export type ResourceName = string;    // max: 256, min: 1
+        export type S3Bucket = string;    // max: 255
+        export type S3Key = string;    // max: 1024
+        export type SampleTimestamp = number;
+        export type SolutionStackFileTypeList = FileTypeExtension[];
+        export type SolutionStackName = string;    // max: 100
+        export type String = string;
+        export type TagKey = string;    // max: 128, min: 1
+        export type TagValue = string;    // max: 256, min: 1
+        export type Tags = Tag[];
+        export type TerminateEnvForce = boolean;
+        export type TerminateEnvironmentResources = boolean;
+        export type TimeFilterEnd = number;
+        export type TimeFilterStart = number;
+        export type Token = string;
+        export type TriggerList = Trigger[];
+        export type UpdateDate = number;
+        export type UserDefinedOption = boolean;
+        export type ValidationMessageString = string;
+        export type ValidationMessagesList = ValidationMessage[];
+        export type ValidationSeverity = string;
+        export type VersionLabel = string;    // max: 100, min: 1
+        export type VersionLabels = VersionLabel[];
+        export type VersionLabelsList = VersionLabel[];
+
+        export interface AbortEnvironmentUpdateMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+        }
+        export interface ApplicationDescription {
+            ApplicationName?: ApplicationName;            
+            Description?: Description;            
+            DateCreated?: CreationDate;            
+            DateUpdated?: UpdateDate;            
+            Versions?: VersionLabelsList;            
+            ConfigurationTemplates?: ConfigurationTemplateNamesList;            
+        }
+        export interface ApplicationDescriptionMessage {
+            Application?: ApplicationDescription;            
+        }
+        export interface ApplicationDescriptionsMessage {
+            Applications?: ApplicationDescriptionList;            
+        }
+        export interface ApplicationMetrics {
+            Duration?: NullableInteger;            
+            RequestCount?: RequestCount;            
+            StatusCodes?: StatusCodes;            
+            Latency?: Latency;            
+        }
+        export interface ApplicationVersionDescription {
+            ApplicationName?: ApplicationName;            
+            Description?: Description;            
+            VersionLabel?: VersionLabel;            
+            SourceBundle?: S3Location;            
+            DateCreated?: CreationDate;            
+            DateUpdated?: UpdateDate;            
+            Status?: ApplicationVersionStatus;            
+        }
+        export interface ApplicationVersionDescriptionMessage {
+            ApplicationVersion?: ApplicationVersionDescription;            
+        }
+        export interface ApplicationVersionDescriptionsMessage {
+            ApplicationVersions?: ApplicationVersionDescriptionList;            
+        }
+        export interface AutoScalingGroup {
+            Name?: ResourceId;            
+        }
+        export interface CPUUtilization {
+            User?: NullableDouble;            
+            Nice?: NullableDouble;            
+            System?: NullableDouble;            
+            Idle?: NullableDouble;            
+            IOWait?: NullableDouble;            
+            IRQ?: NullableDouble;            
+            SoftIRQ?: NullableDouble;            
+        }
+        export interface CheckDNSAvailabilityMessage {
+            CNAMEPrefix: DNSCnamePrefix;            
+        }
+        export interface CheckDNSAvailabilityResultMessage {
+            Available?: CnameAvailability;            
+            FullyQualifiedCNAME?: DNSCname;            
+        }
+        export interface ComposeEnvironmentsMessage {
+            ApplicationName?: ApplicationName;            
+            GroupName?: GroupName;            
+            VersionLabels?: VersionLabels;            
+        }
+        export interface ConfigurationOptionDescription {
+            Namespace?: OptionNamespace;            
+            Name?: ConfigurationOptionName;            
+            DefaultValue?: ConfigurationOptionDefaultValue;            
+            ChangeSeverity?: ConfigurationOptionSeverity;            
+            UserDefined?: UserDefinedOption;            
+            ValueType?: ConfigurationOptionValueType;            
+            ValueOptions?: ConfigurationOptionPossibleValues;            
+            MinValue?: OptionRestrictionMinValue;            
+            MaxValue?: OptionRestrictionMaxValue;            
+            MaxLength?: OptionRestrictionMaxLength;            
+            Regex?: OptionRestrictionRegex;            
+        }
+        export interface ConfigurationOptionSetting {
+            ResourceName?: ResourceName;            
+            Namespace?: OptionNamespace;            
+            OptionName?: ConfigurationOptionName;            
+            Value?: ConfigurationOptionValue;            
+        }
+        export interface ConfigurationOptionsDescription {
+            SolutionStackName?: SolutionStackName;            
+            Options?: ConfigurationOptionDescriptionsList;            
+        }
+        export interface ConfigurationSettingsDescription {
+            SolutionStackName?: SolutionStackName;            
+            ApplicationName?: ApplicationName;            
+            TemplateName?: ConfigurationTemplateName;            
+            Description?: Description;            
+            EnvironmentName?: EnvironmentName;            
+            DeploymentStatus?: ConfigurationDeploymentStatus;            
+            DateCreated?: CreationDate;            
+            DateUpdated?: UpdateDate;            
+            OptionSettings?: ConfigurationOptionSettingsList;            
+        }
+        export interface ConfigurationSettingsDescriptions {
+            ConfigurationSettings?: ConfigurationSettingsDescriptionList;            
+        }
+        export interface ConfigurationSettingsValidationMessages {
+            Messages?: ValidationMessagesList;            
+        }
+        export interface CreateApplicationMessage {
+            ApplicationName: ApplicationName;            
+            Description?: Description;            
+        }
+        export interface CreateApplicationVersionMessage {
+            ApplicationName: ApplicationName;            
+            VersionLabel: VersionLabel;            
+            Description?: Description;            
+            SourceBundle?: S3Location;            
+            AutoCreateApplication?: AutoCreateApplication;            
+            Process?: ApplicationVersionProccess;            
+        }
+        export interface CreateConfigurationTemplateMessage {
+            ApplicationName: ApplicationName;            
+            TemplateName: ConfigurationTemplateName;            
+            SolutionStackName?: SolutionStackName;            
+            SourceConfiguration?: SourceConfiguration;            
+            EnvironmentId?: EnvironmentId;            
+            Description?: Description;            
+            OptionSettings?: ConfigurationOptionSettingsList;            
+        }
+        export interface CreateEnvironmentMessage {
+            ApplicationName: ApplicationName;            
+            EnvironmentName?: EnvironmentName;            
+            GroupName?: GroupName;            
+            Description?: Description;            
+            CNAMEPrefix?: DNSCnamePrefix;            
+            Tier?: EnvironmentTier;            
+            Tags?: Tags;            
+            VersionLabel?: VersionLabel;            
+            TemplateName?: ConfigurationTemplateName;            
+            SolutionStackName?: SolutionStackName;            
+            OptionSettings?: ConfigurationOptionSettingsList;            
+            OptionsToRemove?: OptionsSpecifierList;            
+        }
+        export interface CreateStorageLocationResultMessage {
+            S3Bucket?: S3Bucket;            
+        }
+        export interface DeleteApplicationMessage {
+            ApplicationName: ApplicationName;            
+            TerminateEnvByForce?: TerminateEnvForce;            
+        }
+        export interface DeleteApplicationVersionMessage {
+            ApplicationName: ApplicationName;            
+            VersionLabel: VersionLabel;            
+            DeleteSourceBundle?: DeleteSourceBundle;            
+        }
+        export interface DeleteConfigurationTemplateMessage {
+            ApplicationName: ApplicationName;            
+            TemplateName: ConfigurationTemplateName;            
+        }
+        export interface DeleteEnvironmentConfigurationMessage {
+            ApplicationName: ApplicationName;            
+            EnvironmentName: EnvironmentName;            
+        }
+        export interface DescribeApplicationVersionsMessage {
+            ApplicationName?: ApplicationName;            
+            VersionLabels?: VersionLabelsList;            
+        }
+        export interface DescribeApplicationsMessage {
+            ApplicationNames?: ApplicationNamesList;            
+        }
+        export interface DescribeConfigurationOptionsMessage {
+            ApplicationName?: ApplicationName;            
+            TemplateName?: ConfigurationTemplateName;            
+            EnvironmentName?: EnvironmentName;            
+            SolutionStackName?: SolutionStackName;            
+            Options?: OptionsSpecifierList;            
+        }
+        export interface DescribeConfigurationSettingsMessage {
+            ApplicationName: ApplicationName;            
+            TemplateName?: ConfigurationTemplateName;            
+            EnvironmentName?: EnvironmentName;            
+        }
+        export interface DescribeEnvironmentHealthRequest {
+            EnvironmentName?: EnvironmentName;            
+            EnvironmentId?: EnvironmentId;            
+            AttributeNames?: EnvironmentHealthAttributes;            
+        }
+        export interface DescribeEnvironmentHealthResult {
+            EnvironmentName?: EnvironmentName;            
+            HealthStatus?: String;            
+            Status?: EnvironmentHealth;            
+            Color?: String;            
+            Causes?: Causes;            
+            ApplicationMetrics?: ApplicationMetrics;            
+            InstancesHealth?: InstanceHealthSummary;            
+            RefreshedAt?: RefreshedAt;            
+        }
+        export interface DescribeEnvironmentResourcesMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+        }
+        export interface DescribeEnvironmentsMessage {
+            ApplicationName?: ApplicationName;            
+            VersionLabel?: VersionLabel;            
+            EnvironmentIds?: EnvironmentIdList;            
+            EnvironmentNames?: EnvironmentNamesList;            
+            IncludeDeleted?: IncludeDeleted;            
+            IncludedDeletedBackTo?: IncludeDeletedBackTo;            
+        }
+        export interface DescribeEventsMessage {
+            ApplicationName?: ApplicationName;            
+            VersionLabel?: VersionLabel;            
+            TemplateName?: ConfigurationTemplateName;            
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+            RequestId?: RequestId;            
+            Severity?: EventSeverity;            
+            StartTime?: TimeFilterStart;            
+            EndTime?: TimeFilterEnd;            
+            MaxRecords?: MaxRecords;            
+            NextToken?: Token;            
+        }
+        export interface DescribeInstancesHealthRequest {
+            EnvironmentName?: EnvironmentName;            
+            EnvironmentId?: EnvironmentId;            
+            AttributeNames?: InstancesHealthAttributes;            
+            NextToken?: NextToken;            
+        }
+        export interface DescribeInstancesHealthResult {
+            InstanceHealthList?: InstanceHealthList;            
+            RefreshedAt?: RefreshedAt;            
+            NextToken?: NextToken;            
+        }
+        export interface ElasticBeanstalkServiceException {
+            message?: ExceptionMessage;            
+        }
+        export interface EnvironmentDescription {
+            EnvironmentName?: EnvironmentName;            
+            EnvironmentId?: EnvironmentId;            
+            ApplicationName?: ApplicationName;            
+            VersionLabel?: VersionLabel;            
+            SolutionStackName?: SolutionStackName;            
+            TemplateName?: ConfigurationTemplateName;            
+            Description?: Description;            
+            EndpointURL?: EndpointURL;            
+            CNAME?: DNSCname;            
+            DateCreated?: CreationDate;            
+            DateUpdated?: UpdateDate;            
+            Status?: EnvironmentStatus;            
+            AbortableOperationInProgress?: AbortableOperationInProgress;            
+            Health?: EnvironmentHealth;            
+            HealthStatus?: EnvironmentHealthStatus;            
+            Resources?: EnvironmentResourcesDescription;            
+            Tier?: EnvironmentTier;            
+            EnvironmentLinks?: EnvironmentLinks;            
+        }
+        export interface EnvironmentDescriptionsMessage {
+            Environments?: EnvironmentDescriptionsList;            
+        }
+        export interface EnvironmentInfoDescription {
+            InfoType?: EnvironmentInfoType;            
+            Ec2InstanceId?: Ec2InstanceId;            
+            SampleTimestamp?: SampleTimestamp;            
+            Message?: Message;            
+        }
+        export interface EnvironmentLink {
+            LinkName?: String;            
+            EnvironmentName?: String;            
+        }
+        export interface EnvironmentResourceDescription {
+            EnvironmentName?: EnvironmentName;            
+            AutoScalingGroups?: AutoScalingGroupList;            
+            Instances?: InstanceList;            
+            LaunchConfigurations?: LaunchConfigurationList;            
+            LoadBalancers?: LoadBalancerList;            
+            Triggers?: TriggerList;            
+            Queues?: QueueList;            
+        }
+        export interface EnvironmentResourceDescriptionsMessage {
+            EnvironmentResources?: EnvironmentResourceDescription;            
+        }
+        export interface EnvironmentResourcesDescription {
+            LoadBalancer?: LoadBalancerDescription;            
+        }
+        export interface EnvironmentTier {
+            Name?: String;            
+            Type?: String;            
+            Version?: String;            
+        }
+        export interface EventDescription {
+            EventDate?: EventDate;            
+            Message?: EventMessage;            
+            ApplicationName?: ApplicationName;            
+            VersionLabel?: VersionLabel;            
+            TemplateName?: ConfigurationTemplateName;            
+            EnvironmentName?: EnvironmentName;            
+            RequestId?: RequestId;            
+            Severity?: EventSeverity;            
+        }
+        export interface EventDescriptionsMessage {
+            Events?: EventDescriptionList;            
+            NextToken?: Token;            
+        }
+        export interface Instance {
+            Id?: ResourceId;            
+        }
+        export interface InstanceHealthSummary {
+            NoData?: NullableInteger;            
+            Unknown?: NullableInteger;            
+            Pending?: NullableInteger;            
+            Ok?: NullableInteger;            
+            Info?: NullableInteger;            
+            Warning?: NullableInteger;            
+            Degraded?: NullableInteger;            
+            Severe?: NullableInteger;            
+        }
+        export interface InsufficientPrivilegesException {
+        }
+        export interface InvalidRequestException {
+        }
+        export interface Latency {
+            P999?: NullableDouble;            
+            P99?: NullableDouble;            
+            P95?: NullableDouble;            
+            P90?: NullableDouble;            
+            P85?: NullableDouble;            
+            P75?: NullableDouble;            
+            P50?: NullableDouble;            
+            P10?: NullableDouble;            
+        }
+        export interface LaunchConfiguration {
+            Name?: ResourceId;            
+        }
+        export interface ListAvailableSolutionStacksResultMessage {
+            SolutionStacks?: AvailableSolutionStackNamesList;            
+            SolutionStackDetails?: AvailableSolutionStackDetailsList;            
+        }
+        export interface Listener {
+            Protocol?: String;            
+            Port?: Integer;            
+        }
+        export interface LoadBalancer {
+            Name?: ResourceId;            
+        }
+        export interface LoadBalancerDescription {
+            LoadBalancerName?: String;            
+            Domain?: String;            
+            Listeners?: LoadBalancerListenersDescription;            
+        }
+        export interface OperationInProgressException {
+        }
+        export interface OptionRestrictionRegex {
+            Pattern?: RegexPattern;            
+            Label?: RegexLabel;            
+        }
+        export interface OptionSpecification {
+            ResourceName?: ResourceName;            
+            Namespace?: OptionNamespace;            
+            OptionName?: ConfigurationOptionName;            
+        }
+        export interface Queue {
+            Name?: String;            
+            URL?: String;            
+        }
+        export interface RebuildEnvironmentMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+        }
+        export interface RequestEnvironmentInfoMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+            InfoType: EnvironmentInfoType;            
+        }
+        export interface RestartAppServerMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+        }
+        export interface RetrieveEnvironmentInfoMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+            InfoType: EnvironmentInfoType;            
+        }
+        export interface RetrieveEnvironmentInfoResultMessage {
+            EnvironmentInfo?: EnvironmentInfoDescriptionList;            
+        }
+        export interface S3Location {
+            S3Bucket?: S3Bucket;            
+            S3Key?: S3Key;            
+        }
+        export interface S3LocationNotInServiceRegionException {
+        }
+        export interface S3SubscriptionRequiredException {
+        }
+        export interface SingleInstanceHealth {
+            InstanceId?: InstanceId;            
+            HealthStatus?: String;            
+            Color?: String;            
+            Causes?: Causes;            
+            LaunchedAt?: LaunchedAt;            
+            ApplicationMetrics?: ApplicationMetrics;            
+            System?: SystemStatus;            
+        }
+        export interface SolutionStackDescription {
+            SolutionStackName?: SolutionStackName;            
+            PermittedFileTypes?: SolutionStackFileTypeList;            
+        }
+        export interface SourceBundleDeletionException {
+        }
+        export interface SourceConfiguration {
+            ApplicationName?: ApplicationName;            
+            TemplateName?: ConfigurationTemplateName;            
+        }
+        export interface StatusCodes {
+            Status2xx?: NullableInteger;            
+            Status3xx?: NullableInteger;            
+            Status4xx?: NullableInteger;            
+            Status5xx?: NullableInteger;            
+        }
+        export interface SwapEnvironmentCNAMEsMessage {
+            SourceEnvironmentId?: EnvironmentId;            
+            SourceEnvironmentName?: EnvironmentName;            
+            DestinationEnvironmentId?: EnvironmentId;            
+            DestinationEnvironmentName?: EnvironmentName;            
+        }
+        export interface SystemStatus {
+            CPUUtilization?: CPUUtilization;            
+            LoadAverage?: LoadAverage;            
+        }
+        export interface Tag {
+            Key?: TagKey;            
+            Value?: TagValue;            
+        }
+        export interface TerminateEnvironmentMessage {
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+            TerminateResources?: TerminateEnvironmentResources;            
+            ForceTerminate?: ForceTerminate;            
+        }
+        export interface TooManyApplicationVersionsException {
+        }
+        export interface TooManyApplicationsException {
+        }
+        export interface TooManyBucketsException {
+        }
+        export interface TooManyConfigurationTemplatesException {
+        }
+        export interface TooManyEnvironmentsException {
+        }
+        export interface Trigger {
+            Name?: ResourceId;            
+        }
+        export interface UpdateApplicationMessage {
+            ApplicationName: ApplicationName;            
+            Description?: Description;            
+        }
+        export interface UpdateApplicationVersionMessage {
+            ApplicationName: ApplicationName;            
+            VersionLabel: VersionLabel;            
+            Description?: Description;            
+        }
+        export interface UpdateConfigurationTemplateMessage {
+            ApplicationName: ApplicationName;            
+            TemplateName: ConfigurationTemplateName;            
+            Description?: Description;            
+            OptionSettings?: ConfigurationOptionSettingsList;            
+            OptionsToRemove?: OptionsSpecifierList;            
+        }
+        export interface UpdateEnvironmentMessage {
+            ApplicationName?: ApplicationName;            
+            EnvironmentId?: EnvironmentId;            
+            EnvironmentName?: EnvironmentName;            
+            GroupName?: GroupName;            
+            Description?: Description;            
+            Tier?: EnvironmentTier;            
+            VersionLabel?: VersionLabel;            
+            TemplateName?: ConfigurationTemplateName;            
+            SolutionStackName?: SolutionStackName;            
+            OptionSettings?: ConfigurationOptionSettingsList;            
+            OptionsToRemove?: OptionsSpecifierList;            
+        }
+        export interface ValidateConfigurationSettingsMessage {
+            ApplicationName: ApplicationName;            
+            TemplateName?: ConfigurationTemplateName;            
+            EnvironmentName?: EnvironmentName;            
+            OptionSettings: ConfigurationOptionSettingsList;            
+        }
+        export interface ValidationMessage {
+            Message?: ValidationMessageString;            
+            Severity?: ValidationSeverity;            
+            Namespace?: OptionNamespace;            
+            OptionName?: ConfigurationOptionName;            
+        }
 
-    export interface ElasticBeanstalkEnvironmentResourcesDescription {
-        LoadBalancer?: ElasticBeanstalkLoadBalancerDescription;
     }
-
-    export type ElasticBeanstalkEnvironmentStatus = string;
-    export interface ElasticBeanstalkEnvironmentTier {
-        Name?: ElasticBeanstalkString;
-        Type?: ElasticBeanstalkString;
-        Version?: ElasticBeanstalkString;
-    }
-
-    export type ElasticBeanstalkEventDate = number;
-    export interface ElasticBeanstalkEventDescription {
-        EventDate?: ElasticBeanstalkEventDate;
-        Message?: ElasticBeanstalkEventMessage;
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        RequestId?: ElasticBeanstalkRequestId;
-        Severity?: ElasticBeanstalkEventSeverity;
-    }
-
-    export type ElasticBeanstalkEventDescriptionList = Array<ElasticBeanstalkEventDescription>;
-    export interface ElasticBeanstalkEventDescriptionsMessage {
-        Events?: ElasticBeanstalkEventDescriptionList;
-        NextToken?: ElasticBeanstalkToken;
-    }
-
-    export type ElasticBeanstalkEventMessage = string;
-    export type ElasticBeanstalkEventSeverity = string;
-    export type ElasticBeanstalkExceptionMessage = string;
-    export type ElasticBeanstalkFileTypeExtension = string;
-    export type ElasticBeanstalkForceTerminate = boolean;
-    export type ElasticBeanstalkGroupName = string;
-    export type ElasticBeanstalkIncludeDeleted = boolean;
-    export type ElasticBeanstalkIncludeDeletedBackTo = number;
-    export interface ElasticBeanstalkInstance {
-        Id?: ElasticBeanstalkResourceId;
-    }
-
-    export type ElasticBeanstalkInstanceHealthList = Array<ElasticBeanstalkSingleInstanceHealth>;
-    export interface ElasticBeanstalkInstanceHealthSummary {
-        NoData?: ElasticBeanstalkNullableInteger;
-        Unknown?: ElasticBeanstalkNullableInteger;
-        Pending?: ElasticBeanstalkNullableInteger;
-        Ok?: ElasticBeanstalkNullableInteger;
-        Info?: ElasticBeanstalkNullableInteger;
-        Warning?: ElasticBeanstalkNullableInteger;
-        Degraded?: ElasticBeanstalkNullableInteger;
-        Severe?: ElasticBeanstalkNullableInteger;
-    }
-
-    export type ElasticBeanstalkInstanceId = string;
-    export type ElasticBeanstalkInstanceList = Array<ElasticBeanstalkInstance>;
-    export type ElasticBeanstalkInstancesHealthAttribute = string;
-    export type ElasticBeanstalkInstancesHealthAttributes = Array<ElasticBeanstalkInstancesHealthAttribute>;
-    export interface ElasticBeanstalkInsufficientPrivilegesException {
-    }
-
-    export type ElasticBeanstalkInteger = number;
-    export interface ElasticBeanstalkInvalidRequestException {
-    }
-
-    export interface ElasticBeanstalkLatency {
-        P999?: ElasticBeanstalkNullableDouble;
-        P99?: ElasticBeanstalkNullableDouble;
-        P95?: ElasticBeanstalkNullableDouble;
-        P90?: ElasticBeanstalkNullableDouble;
-        P85?: ElasticBeanstalkNullableDouble;
-        P75?: ElasticBeanstalkNullableDouble;
-        P50?: ElasticBeanstalkNullableDouble;
-        P10?: ElasticBeanstalkNullableDouble;
-    }
-
-    export interface ElasticBeanstalkLaunchConfiguration {
-        Name?: ElasticBeanstalkResourceId;
-    }
-
-    export type ElasticBeanstalkLaunchConfigurationList = Array<ElasticBeanstalkLaunchConfiguration>;
-    export type ElasticBeanstalkLaunchedAt = number;
-    export interface ElasticBeanstalkListAvailableSolutionStacksResultMessage {
-        SolutionStacks?: ElasticBeanstalkAvailableSolutionStackNamesList;
-        SolutionStackDetails?: ElasticBeanstalkAvailableSolutionStackDetailsList;
-    }
-
-    export interface ElasticBeanstalkListener {
-        Protocol?: ElasticBeanstalkString;
-        Port?: ElasticBeanstalkInteger;
-    }
-
-    export type ElasticBeanstalkLoadAverage = Array<ElasticBeanstalkLoadAverageValue>;
-    export type ElasticBeanstalkLoadAverageValue = number;
-    export interface ElasticBeanstalkLoadBalancer {
-        Name?: ElasticBeanstalkResourceId;
-    }
-
-    export interface ElasticBeanstalkLoadBalancerDescription {
-        LoadBalancerName?: ElasticBeanstalkString;
-        Domain?: ElasticBeanstalkString;
-        Listeners?: ElasticBeanstalkLoadBalancerListenersDescription;
-    }
-
-    export type ElasticBeanstalkLoadBalancerList = Array<ElasticBeanstalkLoadBalancer>;
-    export type ElasticBeanstalkLoadBalancerListenersDescription = Array<ElasticBeanstalkListener>;
-    export type ElasticBeanstalkMaxRecords = number;
-    export type ElasticBeanstalkMessage = string;
-    export type ElasticBeanstalkNextToken = string;
-    export type ElasticBeanstalkNullableDouble = number;
-    export type ElasticBeanstalkNullableInteger = number;
-    export interface ElasticBeanstalkOperationInProgressException {
-    }
-
-    export type ElasticBeanstalkOptionNamespace = string;
-    export type ElasticBeanstalkOptionRestrictionMaxLength = number;
-    export type ElasticBeanstalkOptionRestrictionMaxValue = number;
-    export type ElasticBeanstalkOptionRestrictionMinValue = number;
-    export interface ElasticBeanstalkOptionRestrictionRegex {
-        Pattern?: ElasticBeanstalkRegexPattern;
-        Label?: ElasticBeanstalkRegexLabel;
-    }
-
-    export interface ElasticBeanstalkOptionSpecification {
-        ResourceName?: ElasticBeanstalkResourceName;
-        Namespace?: ElasticBeanstalkOptionNamespace;
-        OptionName?: ElasticBeanstalkConfigurationOptionName;
-    }
-
-    export type ElasticBeanstalkOptionsSpecifierList = Array<ElasticBeanstalkOptionSpecification>;
-    export interface ElasticBeanstalkQueue {
-        Name?: ElasticBeanstalkString;
-        URL?: ElasticBeanstalkString;
-    }
-
-    export type ElasticBeanstalkQueueList = Array<ElasticBeanstalkQueue>;
-    export interface ElasticBeanstalkRebuildEnvironmentMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-    }
-
-    export type ElasticBeanstalkRefreshedAt = number;
-    export type ElasticBeanstalkRegexLabel = string;
-    export type ElasticBeanstalkRegexPattern = string;
-    export type ElasticBeanstalkRequestCount = number;
-    export interface ElasticBeanstalkRequestEnvironmentInfoMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        InfoType: ElasticBeanstalkEnvironmentInfoType;
-    }
-
-    export type ElasticBeanstalkRequestId = string;
-    export type ElasticBeanstalkResourceId = string;
-    export type ElasticBeanstalkResourceName = string;
-    export interface ElasticBeanstalkRestartAppServerMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-    }
-
-    export interface ElasticBeanstalkRetrieveEnvironmentInfoMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        InfoType: ElasticBeanstalkEnvironmentInfoType;
-    }
-
-    export interface ElasticBeanstalkRetrieveEnvironmentInfoResultMessage {
-        EnvironmentInfo?: ElasticBeanstalkEnvironmentInfoDescriptionList;
-    }
-
-    export type ElasticBeanstalkS3Bucket = string;
-    export type ElasticBeanstalkS3Key = string;
-    export interface ElasticBeanstalkS3Location {
-        S3Bucket?: ElasticBeanstalkS3Bucket;
-        S3Key?: ElasticBeanstalkS3Key;
-    }
-
-    export interface ElasticBeanstalkS3LocationNotInServiceRegionException {
-    }
-
-    export interface ElasticBeanstalkS3SubscriptionRequiredException {
-    }
-
-    export type ElasticBeanstalkSampleTimestamp = number;
-    export interface ElasticBeanstalkSingleInstanceHealth {
-        InstanceId?: ElasticBeanstalkInstanceId;
-        HealthStatus?: ElasticBeanstalkString;
-        Color?: ElasticBeanstalkString;
-        Causes?: ElasticBeanstalkCauses;
-        LaunchedAt?: ElasticBeanstalkLaunchedAt;
-        ApplicationMetrics?: ElasticBeanstalkApplicationMetrics;
-        System?: ElasticBeanstalkSystemStatus;
-    }
-
-    export interface ElasticBeanstalkSolutionStackDescription {
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        PermittedFileTypes?: ElasticBeanstalkSolutionStackFileTypeList;
-    }
-
-    export type ElasticBeanstalkSolutionStackFileTypeList = Array<ElasticBeanstalkFileTypeExtension>;
-    export type ElasticBeanstalkSolutionStackName = string;
-    export interface ElasticBeanstalkSourceBundleDeletionException {
-    }
-
-    export interface ElasticBeanstalkSourceConfiguration {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-    }
-
-    export interface ElasticBeanstalkStatusCodes {
-        Status2xx?: ElasticBeanstalkNullableInteger;
-        Status3xx?: ElasticBeanstalkNullableInteger;
-        Status4xx?: ElasticBeanstalkNullableInteger;
-        Status5xx?: ElasticBeanstalkNullableInteger;
-    }
-
-    export type ElasticBeanstalkString = string;
-    export interface ElasticBeanstalkSwapEnvironmentCNAMEsMessage {
-        SourceEnvironmentId?: ElasticBeanstalkEnvironmentId;
-        SourceEnvironmentName?: ElasticBeanstalkEnvironmentName;
-        DestinationEnvironmentId?: ElasticBeanstalkEnvironmentId;
-        DestinationEnvironmentName?: ElasticBeanstalkEnvironmentName;
-    }
-
-    export interface ElasticBeanstalkSystemStatus {
-        CPUUtilization?: ElasticBeanstalkCPUUtilization;
-        LoadAverage?: ElasticBeanstalkLoadAverage;
-    }
-
-    export interface ElasticBeanstalkTag {
-        Key?: ElasticBeanstalkTagKey;
-        Value?: ElasticBeanstalkTagValue;
-    }
-
-    export type ElasticBeanstalkTagKey = string;
-    export type ElasticBeanstalkTagValue = string;
-    export type ElasticBeanstalkTags = Array<ElasticBeanstalkTag>;
-    export type ElasticBeanstalkTerminateEnvForce = boolean;
-    export interface ElasticBeanstalkTerminateEnvironmentMessage {
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        TerminateResources?: ElasticBeanstalkTerminateEnvironmentResources;
-        ForceTerminate?: ElasticBeanstalkForceTerminate;
-    }
-
-    export type ElasticBeanstalkTerminateEnvironmentResources = boolean;
-    export type ElasticBeanstalkTimeFilterEnd = number;
-    export type ElasticBeanstalkTimeFilterStart = number;
-    export type ElasticBeanstalkToken = string;
-    export interface ElasticBeanstalkTooManyApplicationVersionsException {
-    }
-
-    export interface ElasticBeanstalkTooManyApplicationsException {
-    }
-
-    export interface ElasticBeanstalkTooManyBucketsException {
-    }
-
-    export interface ElasticBeanstalkTooManyConfigurationTemplatesException {
-    }
-
-    export interface ElasticBeanstalkTooManyEnvironmentsException {
-    }
-
-    export interface ElasticBeanstalkTrigger {
-        Name?: ElasticBeanstalkResourceId;
-    }
-
-    export type ElasticBeanstalkTriggerList = Array<ElasticBeanstalkTrigger>;
-    export interface ElasticBeanstalkUpdateApplicationMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        Description?: ElasticBeanstalkDescription;
-    }
-
-    export interface ElasticBeanstalkUpdateApplicationVersionMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        VersionLabel: ElasticBeanstalkVersionLabel;
-        Description?: ElasticBeanstalkDescription;
-    }
-
-    export interface ElasticBeanstalkUpdateConfigurationTemplateMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        TemplateName: ElasticBeanstalkConfigurationTemplateName;
-        Description?: ElasticBeanstalkDescription;
-        OptionSettings?: ElasticBeanstalkConfigurationOptionSettingsList;
-        OptionsToRemove?: ElasticBeanstalkOptionsSpecifierList;
-    }
-
-    export type ElasticBeanstalkUpdateDate = number;
-    export interface ElasticBeanstalkUpdateEnvironmentMessage {
-        ApplicationName?: ElasticBeanstalkApplicationName;
-        EnvironmentId?: ElasticBeanstalkEnvironmentId;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        GroupName?: ElasticBeanstalkGroupName;
-        Description?: ElasticBeanstalkDescription;
-        Tier?: ElasticBeanstalkEnvironmentTier;
-        VersionLabel?: ElasticBeanstalkVersionLabel;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        SolutionStackName?: ElasticBeanstalkSolutionStackName;
-        OptionSettings?: ElasticBeanstalkConfigurationOptionSettingsList;
-        OptionsToRemove?: ElasticBeanstalkOptionsSpecifierList;
-    }
-
-    export type ElasticBeanstalkUserDefinedOption = boolean;
-    export interface ElasticBeanstalkValidateConfigurationSettingsMessage {
-        ApplicationName: ElasticBeanstalkApplicationName;
-        TemplateName?: ElasticBeanstalkConfigurationTemplateName;
-        EnvironmentName?: ElasticBeanstalkEnvironmentName;
-        OptionSettings: ElasticBeanstalkConfigurationOptionSettingsList;
-    }
-
-    export interface ElasticBeanstalkValidationMessage {
-        Message?: ElasticBeanstalkValidationMessageString;
-        Severity?: ElasticBeanstalkValidationSeverity;
-        Namespace?: ElasticBeanstalkOptionNamespace;
-        OptionName?: ElasticBeanstalkConfigurationOptionName;
-    }
-
-    export type ElasticBeanstalkValidationMessageString = string;
-    export type ElasticBeanstalkValidationMessagesList = Array<ElasticBeanstalkValidationMessage>;
-    export type ElasticBeanstalkValidationSeverity = string;
-    export type ElasticBeanstalkVersionLabel = string;
-    export type ElasticBeanstalkVersionLabels = Array<ElasticBeanstalkVersionLabel>;
-    export type ElasticBeanstalkVersionLabelsList = Array<ElasticBeanstalkVersionLabel>;
 }

--- a/output/aws-elastictranscoder.d.ts
+++ b/output/aws-elastictranscoder.d.ts
@@ -6,597 +6,530 @@ declare module "aws-sdk" {
 
     export class ElasticTranscoder extends Service {
       constructor(options?: any);
-      cancelJob(params: ElasticTranscoderCancelJobRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderResourceInUseException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderCancelJobResponse|any) => void): Request;
-      createJob(params: ElasticTranscoderCreateJobRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderLimitExceededException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderCreateJobResponse|any) => void): Request;
-      createPipeline(params: ElasticTranscoderCreatePipelineRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderAccessDeniedException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderLimitExceededException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderCreatePipelineResponse|any) => void): Request;
-      createPreset(params: ElasticTranscoderCreatePresetRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderAccessDeniedException|ElasticTranscoderLimitExceededException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderCreatePresetResponse|any) => void): Request;
-      deletePipeline(params: ElasticTranscoderDeletePipelineRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderResourceInUseException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderDeletePipelineResponse|any) => void): Request;
-      deletePreset(params: ElasticTranscoderDeletePresetRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderDeletePresetResponse|any) => void): Request;
-      listJobsByPipeline(params: ElasticTranscoderListJobsByPipelineRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderListJobsByPipelineResponse|any) => void): Request;
-      listJobsByStatus(params: ElasticTranscoderListJobsByStatusRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderListJobsByStatusResponse|any) => void): Request;
-      listPipelines(params: ElasticTranscoderListPipelinesRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderListPipelinesResponse|any) => void): Request;
-      listPresets(params: ElasticTranscoderListPresetsRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderListPresetsResponse|any) => void): Request;
-      readJob(params: ElasticTranscoderReadJobRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderReadJobResponse|any) => void): Request;
-      readPipeline(params: ElasticTranscoderReadPipelineRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderReadPipelineResponse|any) => void): Request;
-      readPreset(params: ElasticTranscoderReadPresetRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderReadPresetResponse|any) => void): Request;
-      testRole(params: ElasticTranscoderTestRoleRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderTestRoleResponse|any) => void): Request;
-      updatePipeline(params: ElasticTranscoderUpdatePipelineRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderAccessDeniedException|ElasticTranscoderResourceInUseException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderUpdatePipelineResponse|any) => void): Request;
-      updatePipelineNotifications(params: ElasticTranscoderUpdatePipelineNotificationsRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderResourceInUseException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderUpdatePipelineNotificationsResponse|any) => void): Request;
-      updatePipelineStatus(params: ElasticTranscoderUpdatePipelineStatusRequest, callback?: (err: ElasticTranscoderValidationException|ElasticTranscoderIncompatibleVersionException|ElasticTranscoderResourceNotFoundException|ElasticTranscoderResourceInUseException|ElasticTranscoderAccessDeniedException|ElasticTranscoderInternalServiceException|any, data: ElasticTranscoderUpdatePipelineStatusResponse|any) => void): Request;
-    }
-
-    export type ElasticTranscoderAccessControl = string; // pattern: "(^FullControl$)|(^Read$)|(^ReadAcp$)|(^WriteAcp$)"
-    export type ElasticTranscoderAccessControls = Array<ElasticTranscoderAccessControl>; // max: 30
-    export interface ElasticTranscoderAccessDeniedException {
-    }
-
-    export interface ElasticTranscoderArtwork {
-        InputKey?: ElasticTranscoderWatermarkKey;
-        MaxWidth?: ElasticTranscoderDigitsOrAuto;
-        MaxHeight?: ElasticTranscoderDigitsOrAuto;
-        SizingPolicy?: ElasticTranscoderSizingPolicy;
-        PaddingPolicy?: ElasticTranscoderPaddingPolicy;
-        AlbumArtFormat?: ElasticTranscoderJpgOrPng;
-        Encryption?: ElasticTranscoderEncryption;
-    }
-
-    export type ElasticTranscoderArtworks = Array<ElasticTranscoderArtwork>;
-    export type ElasticTranscoderAscending = string; // pattern: "(^true$)|(^false$)"
-    export type ElasticTranscoderAspectRatio = string; // pattern: "(^auto$)|(^1:1$)|(^4:3$)|(^3:2$)|(^16:9$)"
-    export type ElasticTranscoderAudioBitDepth = string; // pattern: "(^16$)|(^24$)"
-    export type ElasticTranscoderAudioBitOrder = string; // pattern: "(^LittleEndian$)"
-    export type ElasticTranscoderAudioBitRate = string; // pattern: "^\d{1,3}$"
-    export type ElasticTranscoderAudioChannels = string; // pattern: "(^auto$)|(^0$)|(^1$)|(^2$)"
-    export type ElasticTranscoderAudioCodec = string; // pattern: "(^AAC$)|(^vorbis$)|(^mp3$)|(^mp2$)|(^pcm$)|(^flac$)"
-    export interface ElasticTranscoderAudioCodecOptions {
-        Profile?: ElasticTranscoderAudioCodecProfile;
-        BitDepth?: ElasticTranscoderAudioBitDepth;
-        BitOrder?: ElasticTranscoderAudioBitOrder;
-        Signed?: ElasticTranscoderAudioSigned;
-    }
-
-    export type ElasticTranscoderAudioCodecProfile = string; // pattern: "(^auto$)|(^AAC-LC$)|(^HE-AAC$)|(^HE-AACv2$)"
-    export type ElasticTranscoderAudioPackingMode = string; // pattern: "(^SingleTrack$)|(^OneChannelPerTrack$)|(^OneChannelPerTrackWithMosTo8Tracks$)"
-    export interface ElasticTranscoderAudioParameters {
-        Codec?: ElasticTranscoderAudioCodec;
-        SampleRate?: ElasticTranscoderAudioSampleRate;
-        BitRate?: ElasticTranscoderAudioBitRate;
-        Channels?: ElasticTranscoderAudioChannels;
-        AudioPackingMode?: ElasticTranscoderAudioPackingMode;
-        CodecOptions?: ElasticTranscoderAudioCodecOptions;
-    }
-
-    export type ElasticTranscoderAudioSampleRate = string; // pattern: "(^auto$)|(^22050$)|(^32000$)|(^44100$)|(^48000$)|(^96000$)|(^192000$)"
-    export type ElasticTranscoderAudioSigned = string; // pattern: "(^Signed$)"
-    export type ElasticTranscoderBase64EncodedString = string; // pattern: "^$|(^(?:[A-Za-z0-9\+/]{4})*(?:[A-Za-z0-9\+/]{2}==|[A-Za-z0-9\+/]{3}=)?$)"
-    export type ElasticTranscoderBucketName = string; // pattern: "^(\w|\.|-){1,255}$"
-    export interface ElasticTranscoderCancelJobRequest {
-        Id: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderCancelJobResponse {
-    }
-
-    export interface ElasticTranscoderCaptionFormat {
-        Format?: ElasticTranscoderCaptionFormatFormat;
-        Pattern?: ElasticTranscoderCaptionFormatPattern;
-        Encryption?: ElasticTranscoderEncryption;
-    }
-
-    export type ElasticTranscoderCaptionFormatFormat = string; // pattern: "(^mov-text$)|(^srt$)|(^scc$)|(^webvtt$)|(^dfxp$)"
-    export type ElasticTranscoderCaptionFormatPattern = string; // pattern: "(^$)|(^.*\{language\}.*$)"
-    export type ElasticTranscoderCaptionFormats = Array<ElasticTranscoderCaptionFormat>; // max: 4
-    export type ElasticTranscoderCaptionMergePolicy = string; // pattern: "(^MergeOverride$)|(^MergeRetain$)|(^Override$)"
-    export interface ElasticTranscoderCaptionSource {
-        Key?: ElasticTranscoderKey;
-        Language?: ElasticTranscoderKey;
-        TimeOffset?: ElasticTranscoderTimeOffset;
-        Label?: ElasticTranscoderName;
-        Encryption?: ElasticTranscoderEncryption;
-    }
-
-    export type ElasticTranscoderCaptionSources = Array<ElasticTranscoderCaptionSource>; // max: 20
-    export interface ElasticTranscoderCaptions {
-        MergePolicy?: ElasticTranscoderCaptionMergePolicy;
-        CaptionSources?: ElasticTranscoderCaptionSources;
-        CaptionFormats?: ElasticTranscoderCaptionFormats;
-    }
-
-    export interface ElasticTranscoderClip {
-        TimeSpan?: ElasticTranscoderTimeSpan;
-    }
-
-    export type ElasticTranscoderCodecOption = string;
-    export type ElasticTranscoderCodecOptions = any; // not really - it was 'map' instead - must fix this one
-    export type ElasticTranscoderComposition = Array<ElasticTranscoderClip>;
-    export interface ElasticTranscoderCreateJobOutput {
-        Key?: ElasticTranscoderKey;
-        ThumbnailPattern?: ElasticTranscoderThumbnailPattern;
-        ThumbnailEncryption?: ElasticTranscoderEncryption;
-        Rotate?: ElasticTranscoderRotate;
-        PresetId?: ElasticTranscoderId;
-        SegmentDuration?: ElasticTranscoderFloatString;
-        Watermarks?: ElasticTranscoderJobWatermarks;
-        AlbumArt?: ElasticTranscoderJobAlbumArt;
-        Composition?: ElasticTranscoderComposition;
-        Captions?: ElasticTranscoderCaptions;
-        Encryption?: ElasticTranscoderEncryption;
-    }
-
-    export type ElasticTranscoderCreateJobOutputs = Array<ElasticTranscoderCreateJobOutput>; // max: 30
-    export interface ElasticTranscoderCreateJobPlaylist {
-        Name?: ElasticTranscoderFilename;
-        Format?: ElasticTranscoderPlaylistFormat;
-        OutputKeys?: ElasticTranscoderOutputKeys;
-        HlsContentProtection?: ElasticTranscoderHlsContentProtection;
-        PlayReadyDrm?: ElasticTranscoderPlayReadyDrm;
-    }
-
-    export type ElasticTranscoderCreateJobPlaylists = Array<ElasticTranscoderCreateJobPlaylist>; // max: 30
-    export interface ElasticTranscoderCreateJobRequest {
-        PipelineId: ElasticTranscoderId;
-        Input: ElasticTranscoderJobInput;
-        Output?: ElasticTranscoderCreateJobOutput;
-        Outputs?: ElasticTranscoderCreateJobOutputs;
-        OutputKeyPrefix?: ElasticTranscoderKey;
-        Playlists?: ElasticTranscoderCreateJobPlaylists;
-        UserMetadata?: ElasticTranscoderUserMetadata;
-    }
-
-    export interface ElasticTranscoderCreateJobResponse {
-        Job?: ElasticTranscoderJob;
-    }
-
-    export interface ElasticTranscoderCreatePipelineRequest {
-        Name: ElasticTranscoderName;
-        InputBucket: ElasticTranscoderBucketName;
-        OutputBucket?: ElasticTranscoderBucketName;
-        Role: ElasticTranscoderRole;
-        AwsKmsKeyArn?: ElasticTranscoderKeyArn;
-        Notifications?: ElasticTranscoderNotifications;
-        ContentConfig?: ElasticTranscoderPipelineOutputConfig;
-        ThumbnailConfig?: ElasticTranscoderPipelineOutputConfig;
-    }
-
-    export interface ElasticTranscoderCreatePipelineResponse {
-        Pipeline?: ElasticTranscoderPipeline;
-        Warnings?: ElasticTranscoderWarnings;
-    }
-
-    export interface ElasticTranscoderCreatePresetRequest {
-        Name: ElasticTranscoderName;
-        Description?: ElasticTranscoderDescription;
-        Container: ElasticTranscoderPresetContainer;
-        Video?: ElasticTranscoderVideoParameters;
-        Audio?: ElasticTranscoderAudioParameters;
-        Thumbnails?: ElasticTranscoderThumbnails;
-    }
-
-    export interface ElasticTranscoderCreatePresetResponse {
-        Preset?: ElasticTranscoderPreset;
-        Warning?: ElasticTranscoderString;
-    }
-
-    export interface ElasticTranscoderDeletePipelineRequest {
-        Id: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderDeletePipelineResponse {
-    }
-
-    export interface ElasticTranscoderDeletePresetRequest {
-        Id: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderDeletePresetResponse {
-    }
-
-    export type ElasticTranscoderDescription = string;
-    export interface ElasticTranscoderDetectedProperties {
-        Width?: ElasticTranscoderNullableInteger;
-        Height?: ElasticTranscoderNullableInteger;
-        FrameRate?: ElasticTranscoderFloatString;
-        FileSize?: ElasticTranscoderNullableLong;
-        DurationMillis?: ElasticTranscoderNullableLong;
-    }
-
-    export type ElasticTranscoderDigits = string; // pattern: "^\d{1,5}$"
-    export type ElasticTranscoderDigitsOrAuto = string; // pattern: "(^auto$)|(^\d{2,4}$)"
-    export interface ElasticTranscoderEncryption {
-        Mode?: ElasticTranscoderEncryptionMode;
-        Key?: ElasticTranscoderBase64EncodedString;
-        KeyMd5?: ElasticTranscoderBase64EncodedString;
-        InitializationVector?: ElasticTranscoderZeroTo255String;
-    }
-
-    export type ElasticTranscoderEncryptionMode = string; // pattern: "(^s3$)|(^s3-aws-kms$)|(^aes-cbc-pkcs7$)|(^aes-ctr$)|(^aes-gcm$)"
-    export type ElasticTranscoderExceptionMessages = Array<ElasticTranscoderString>;
-    export type ElasticTranscoderFilename = string;
-    export type ElasticTranscoderFixedGOP = string; // pattern: "(^true$)|(^false$)"
-    export type ElasticTranscoderFloatString = string; // pattern: "^\d{1,5}(\.\d{0,5})?$"
-    export type ElasticTranscoderFrameRate = string; // pattern: "(^auto$)|(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)"
-    export type ElasticTranscoderGrantee = string;
-    export type ElasticTranscoderGranteeType = string; // pattern: "(^Canonical$)|(^Email$)|(^Group$)"
-    export interface ElasticTranscoderHlsContentProtection {
-        Method?: ElasticTranscoderHlsContentProtectionMethod;
-        Key?: ElasticTranscoderBase64EncodedString;
-        KeyMd5?: ElasticTranscoderBase64EncodedString;
-        InitializationVector?: ElasticTranscoderZeroTo255String;
-        LicenseAcquisitionUrl?: ElasticTranscoderZeroTo512String;
-        KeyStoragePolicy?: ElasticTranscoderKeyStoragePolicy;
-    }
-
-    export type ElasticTranscoderHlsContentProtectionMethod = string; // pattern: "(^aes-128$)"
-    export type ElasticTranscoderHorizontalAlign = string; // pattern: "(^Left$)|(^Right$)|(^Center$)"
-    export type ElasticTranscoderId = string; // pattern: "^\d{13}-\w{6}$"
-    export interface ElasticTranscoderIncompatibleVersionException {
-    }
-
-    export type ElasticTranscoderInterlaced = string; // pattern: "(^auto$)|(^true$)|(^false$)"
-    export interface ElasticTranscoderInternalServiceException {
-    }
-
-    export interface ElasticTranscoderJob {
-        Id?: ElasticTranscoderId;
-        Arn?: ElasticTranscoderString;
-        PipelineId?: ElasticTranscoderId;
-        Input?: ElasticTranscoderJobInput;
-        Output?: ElasticTranscoderJobOutput;
-        Outputs?: ElasticTranscoderJobOutputs;
-        OutputKeyPrefix?: ElasticTranscoderKey;
-        Playlists?: ElasticTranscoderPlaylists;
-        Status?: ElasticTranscoderJobStatus;
-        UserMetadata?: ElasticTranscoderUserMetadata;
-        Timing?: ElasticTranscoderTiming;
-    }
-
-    export interface ElasticTranscoderJobAlbumArt {
-        MergePolicy?: ElasticTranscoderMergePolicy;
-        Artwork?: ElasticTranscoderArtworks;
-    }
-
-    export type ElasticTranscoderJobContainer = string; // pattern: "(^auto$)|(^3gp$)|(^asf$)|(^avi$)|(^divx$)|(^flv$)|(^mkv$)|(^mov$)|(^mp4$)|(^mpeg$)|(^mpeg-ps$)|(^mpeg-ts$)|(^mxf$)|(^ogg$)|(^ts$)|(^vob$)|(^wav$)|(^webm$)|(^mp3$)|(^m4a$)|(^aac$)"
-    export interface ElasticTranscoderJobInput {
-        Key?: ElasticTranscoderKey;
-        FrameRate?: ElasticTranscoderFrameRate;
-        Resolution?: ElasticTranscoderResolution;
-        AspectRatio?: ElasticTranscoderAspectRatio;
-        Interlaced?: ElasticTranscoderInterlaced;
-        Container?: ElasticTranscoderJobContainer;
-        Encryption?: ElasticTranscoderEncryption;
-        DetectedProperties?: ElasticTranscoderDetectedProperties;
-    }
-
-    export interface ElasticTranscoderJobOutput {
-        Id?: ElasticTranscoderString;
-        Key?: ElasticTranscoderKey;
-        ThumbnailPattern?: ElasticTranscoderThumbnailPattern;
-        ThumbnailEncryption?: ElasticTranscoderEncryption;
-        Rotate?: ElasticTranscoderRotate;
-        PresetId?: ElasticTranscoderId;
-        SegmentDuration?: ElasticTranscoderFloatString;
-        Status?: ElasticTranscoderJobStatus;
-        StatusDetail?: ElasticTranscoderDescription;
-        Duration?: ElasticTranscoderNullableLong;
-        Width?: ElasticTranscoderNullableInteger;
-        Height?: ElasticTranscoderNullableInteger;
-        FrameRate?: ElasticTranscoderFloatString;
-        FileSize?: ElasticTranscoderNullableLong;
-        DurationMillis?: ElasticTranscoderNullableLong;
-        Watermarks?: ElasticTranscoderJobWatermarks;
-        AlbumArt?: ElasticTranscoderJobAlbumArt;
-        Composition?: ElasticTranscoderComposition;
-        Captions?: ElasticTranscoderCaptions;
-        Encryption?: ElasticTranscoderEncryption;
-        AppliedColorSpaceConversion?: ElasticTranscoderString;
-    }
-
-    export type ElasticTranscoderJobOutputs = Array<ElasticTranscoderJobOutput>;
-    export type ElasticTranscoderJobStatus = string; // pattern: "(^Submitted$)|(^Progressing$)|(^Complete$)|(^Canceled$)|(^Error$)"
-    export interface ElasticTranscoderJobWatermark {
-        PresetWatermarkId?: ElasticTranscoderPresetWatermarkId;
-        InputKey?: ElasticTranscoderWatermarkKey;
-        Encryption?: ElasticTranscoderEncryption;
-    }
-
-    export type ElasticTranscoderJobWatermarks = Array<ElasticTranscoderJobWatermark>;
-    export type ElasticTranscoderJobs = Array<ElasticTranscoderJob>;
-    export type ElasticTranscoderJpgOrPng = string; // pattern: "(^jpg$)|(^png$)"
-    export type ElasticTranscoderKey = string;
-    export type ElasticTranscoderKeyArn = string;
-    export type ElasticTranscoderKeyIdGuid = string; // pattern: "(^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$)|(^[0-9A-Fa-f]{32}$)"
-    export type ElasticTranscoderKeyStoragePolicy = string; // pattern: "(^NoStore$)|(^WithVariantPlaylists$)"
-    export type ElasticTranscoderKeyframesMaxDist = string; // pattern: "^\d{1,6}$"
-    export interface ElasticTranscoderLimitExceededException {
-    }
-
-    export interface ElasticTranscoderListJobsByPipelineRequest {
-        PipelineId: ElasticTranscoderId;
-        Ascending?: ElasticTranscoderAscending;
-        PageToken?: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderListJobsByPipelineResponse {
-        Jobs?: ElasticTranscoderJobs;
-        NextPageToken?: ElasticTranscoderId;
-    }
+      cancelJob(params: ElasticTranscoder.CancelJobRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.ResourceInUseException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.CancelJobResponse|any) => void): Request;
+      createJob(params: ElasticTranscoder.CreateJobRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.LimitExceededException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.CreateJobResponse|any) => void): Request;
+      createPipeline(params: ElasticTranscoder.CreatePipelineRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.LimitExceededException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.CreatePipelineResponse|any) => void): Request;
+      createPreset(params: ElasticTranscoder.CreatePresetRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.LimitExceededException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.CreatePresetResponse|any) => void): Request;
+      deletePipeline(params: ElasticTranscoder.DeletePipelineRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.ResourceInUseException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.DeletePipelineResponse|any) => void): Request;
+      deletePreset(params: ElasticTranscoder.DeletePresetRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.DeletePresetResponse|any) => void): Request;
+      listJobsByPipeline(params: ElasticTranscoder.ListJobsByPipelineRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ListJobsByPipelineResponse|any) => void): Request;
+      listJobsByStatus(params: ElasticTranscoder.ListJobsByStatusRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ListJobsByStatusResponse|any) => void): Request;
+      listPipelines(params: ElasticTranscoder.ListPipelinesRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ListPipelinesResponse|any) => void): Request;
+      listPresets(params: ElasticTranscoder.ListPresetsRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ListPresetsResponse|any) => void): Request;
+      readJob(params: ElasticTranscoder.ReadJobRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ReadJobResponse|any) => void): Request;
+      readPipeline(params: ElasticTranscoder.ReadPipelineRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ReadPipelineResponse|any) => void): Request;
+      readPreset(params: ElasticTranscoder.ReadPresetRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.ReadPresetResponse|any) => void): Request;
+      testRole(params: ElasticTranscoder.TestRoleRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.TestRoleResponse|any) => void): Request;
+      updatePipeline(params: ElasticTranscoder.UpdatePipelineRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.ResourceInUseException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.UpdatePipelineResponse|any) => void): Request;
+      updatePipelineNotifications(params: ElasticTranscoder.UpdatePipelineNotificationsRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.ResourceInUseException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.UpdatePipelineNotificationsResponse|any) => void): Request;
+      updatePipelineStatus(params: ElasticTranscoder.UpdatePipelineStatusRequest, callback?: (err: ElasticTranscoder.ValidationException|ElasticTranscoder.IncompatibleVersionException|ElasticTranscoder.ResourceNotFoundException|ElasticTranscoder.ResourceInUseException|ElasticTranscoder.AccessDeniedException|ElasticTranscoder.InternalServiceException|any, data: ElasticTranscoder.UpdatePipelineStatusResponse|any) => void): Request;
+    }
+    
+    export module ElasticTranscoder {
+        export type AccessControl = string;    // pattern: &quot;(^FullControl$)|(^Read$)|(^ReadAcp$)|(^WriteAcp$)&quot;
+        export type AccessControls = AccessControl[];    // max: 30
+        export type Artworks = Artwork[];
+        export type Ascending = string;    // pattern: &quot;(^true$)|(^false$)&quot;
+        export type AspectRatio = string;    // pattern: &quot;(^auto$)|(^1:1$)|(^4:3$)|(^3:2$)|(^16:9$)&quot;
+        export type AudioBitDepth = string;    // pattern: &quot;(^16$)|(^24$)&quot;
+        export type AudioBitOrder = string;    // pattern: &quot;(^LittleEndian$)&quot;
+        export type AudioBitRate = string;    // pattern: &quot;^\d{1,3}$&quot;
+        export type AudioChannels = string;    // pattern: &quot;(^auto$)|(^0$)|(^1$)|(^2$)&quot;
+        export type AudioCodec = string;    // pattern: &quot;(^AAC$)|(^vorbis$)|(^mp3$)|(^mp2$)|(^pcm$)|(^flac$)&quot;
+        export type AudioCodecProfile = string;    // pattern: &quot;(^auto$)|(^AAC-LC$)|(^HE-AAC$)|(^HE-AACv2$)&quot;
+        export type AudioPackingMode = string;    // pattern: &quot;(^SingleTrack$)|(^OneChannelPerTrack$)|(^OneChannelPerTrackWithMosTo8Tracks$)&quot;
+        export type AudioSampleRate = string;    // pattern: &quot;(^auto$)|(^22050$)|(^32000$)|(^44100$)|(^48000$)|(^96000$)|(^192000$)&quot;
+        export type AudioSigned = string;    // pattern: &quot;(^Signed$)&quot;
+        export type Base64EncodedString = string;    // pattern: &quot;^$|(^(?:[A-Za-z0-9\+/]{4})*(?:[A-Za-z0-9\+/]{2}==|[A-Za-z0-9\+/]{3}=)?$)&quot;
+        export type BucketName = string;    // pattern: &quot;^(\w|\.|-){1,255}$&quot;
+        export type CaptionFormatFormat = string;    // pattern: &quot;(^mov-text$)|(^srt$)|(^scc$)|(^webvtt$)|(^dfxp$)&quot;
+        export type CaptionFormatPattern = string;    // pattern: &quot;(^$)|(^.*\{language\}.*$)&quot;
+        export type CaptionFormats = CaptionFormat[];    // max: 4
+        export type CaptionMergePolicy = string;    // pattern: &quot;(^MergeOverride$)|(^MergeRetain$)|(^Override$)&quot;
+        export type CaptionSources = CaptionSource[];    // max: 20
+        export type CodecOption = string;    // max: 255, min: 1
+        export type CodecOptions = {[key:string]: CodecOption};    // max: 30
+        export type Composition = Clip[];
+        export type CreateJobOutputs = CreateJobOutput[];    // max: 30
+        export type CreateJobPlaylists = CreateJobPlaylist[];    // max: 30
+        export type Description = string;    // max: 255
+        export type Digits = string;    // pattern: &quot;^\d{1,5}$&quot;
+        export type DigitsOrAuto = string;    // pattern: &quot;(^auto$)|(^\d{2,4}$)&quot;
+        export type EncryptionMode = string;    // pattern: &quot;(^s3$)|(^s3-aws-kms$)|(^aes-cbc-pkcs7$)|(^aes-ctr$)|(^aes-gcm$)&quot;
+        export type ExceptionMessages = String[];
+        export type Filename = string;    // max: 255, min: 1
+        export type FixedGOP = string;    // pattern: &quot;(^true$)|(^false$)&quot;
+        export type FloatString = string;    // pattern: &quot;^\d{1,5}(\.\d{0,5})?$&quot;
+        export type FrameRate = string;    // pattern: &quot;(^auto$)|(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)&quot;
+        export type Grantee = string;    // max: 255, min: 1
+        export type GranteeType = string;    // pattern: &quot;(^Canonical$)|(^Email$)|(^Group$)&quot;
+        export type HlsContentProtectionMethod = string;    // pattern: &quot;(^aes-128$)&quot;
+        export type HorizontalAlign = string;    // pattern: &quot;(^Left$)|(^Right$)|(^Center$)&quot;
+        export type Id = string;    // pattern: &quot;^\d{13}-\w{6}$&quot;
+        export type Interlaced = string;    // pattern: &quot;(^auto$)|(^true$)|(^false$)&quot;
+        export type JobContainer = string;    // pattern: &quot;(^auto$)|(^3gp$)|(^asf$)|(^avi$)|(^divx$)|(^flv$)|(^mkv$)|(^mov$)|(^mp4$)|(^mpeg$)|(^mpeg-ps$)|(^mpeg-ts$)|(^mxf$)|(^ogg$)|(^ts$)|(^vob$)|(^wav$)|(^webm$)|(^mp3$)|(^m4a$)|(^aac$)&quot;
+        export type JobOutputs = JobOutput[];
+        export type JobStatus = string;    // pattern: &quot;(^Submitted$)|(^Progressing$)|(^Complete$)|(^Canceled$)|(^Error$)&quot;
+        export type JobWatermarks = JobWatermark[];
+        export type Jobs = Job[];
+        export type JpgOrPng = string;    // pattern: &quot;(^jpg$)|(^png$)&quot;
+        export type Key = string;    // max: 255, min: 1
+        export type KeyArn = string;    // max: 255
+        export type KeyIdGuid = string;    // pattern: &quot;(^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$)|(^[0-9A-Fa-f]{32}$)&quot;
+        export type KeyStoragePolicy = string;    // pattern: &quot;(^NoStore$)|(^WithVariantPlaylists$)&quot;
+        export type KeyframesMaxDist = string;    // pattern: &quot;^\d{1,6}$&quot;
+        export type MaxFrameRate = string;    // pattern: &quot;(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)&quot;
+        export type MergePolicy = string;    // pattern: &quot;(^Replace$)|(^Prepend$)|(^Append$)|(^Fallback$)&quot;
+        export type Name = string;    // max: 40, min: 1
+        export type NonEmptyBase64EncodedString = string;    // pattern: &quot;(^(?:[A-Za-z0-9\+/]{4})*(?:[A-Za-z0-9\+/]{2}==|[A-Za-z0-9\+/]{3}=)?$)&quot;
+        export type NullableInteger = number;
+        export type NullableLong = number;
+        export type OneTo512String = string;    // max: 512, min: 1
+        export type Opacity = string;    // pattern: &quot;^\d{1,3}(\.\d{0,20})?$&quot;
+        export type OutputKeys = Key[];    // max: 30
+        export type PaddingPolicy = string;    // pattern: &quot;(^Pad$)|(^NoPad$)&quot;
+        export type Permissions = Permission[];    // max: 30
+        export type PipelineStatus = string;    // pattern: &quot;(^Active$)|(^Paused$)&quot;
+        export type Pipelines = Pipeline[];
+        export type PixelsOrPercent = string;    // pattern: &quot;(^\d{1,3}(\.\d{0,5})?%$)|(^\d{1,4}?px$)&quot;
+        export type PlayReadyDrmFormatString = string;    // pattern: &quot;(^microsoft$)|(^discretix-3.0$)&quot;
+        export type PlaylistFormat = string;    // pattern: &quot;(^HLSv3$)|(^HLSv4$)|(^Smooth$)&quot;
+        export type Playlists = Playlist[];
+        export type PresetContainer = string;    // pattern: &quot;(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^flac$)|(^oga$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)|(^mxf$)&quot;
+        export type PresetType = string;    // pattern: &quot;(^System$)|(^Custom$)&quot;
+        export type PresetWatermarkId = string;    // max: 40, min: 1
+        export type PresetWatermarks = PresetWatermark[];
+        export type Presets = Preset[];
+        export type Resolution = string;    // pattern: &quot;(^auto$)|(^\d{1,5}x\d{1,5}$)&quot;
+        export type Role = string;    // pattern: &quot;^arn:aws:iam::\w{12}:role/.+$&quot;
+        export type Rotate = string;    // pattern: &quot;(^auto$)|(^0$)|(^90$)|(^180$)|(^270$)&quot;
+        export type SizingPolicy = string;    // pattern: &quot;(^Fit$)|(^Fill$)|(^Stretch$)|(^Keep$)|(^ShrinkToFit$)|(^ShrinkToFill$)&quot;
+        export type SnsTopic = string;    // pattern: &quot;(^$)|(^arn:aws:sns:.*:\w{12}:.+$)&quot;
+        export type SnsTopics = SnsTopic[];    // max: 30
+        export type StorageClass = string;    // pattern: &quot;(^ReducedRedundancy$)|(^Standard$)&quot;
+        export type String = string;
+        export type Success = string;    // pattern: &quot;(^true$)|(^false$)&quot;
+        export type Target = string;    // pattern: &quot;(^Content$)|(^Frame$)&quot;
+        export type ThumbnailPattern = string;    // pattern: &quot;(^$)|(^.*\{count\}.*$)&quot;
+        export type ThumbnailResolution = string;    // pattern: &quot;^\d{1,5}x\d{1,5}$&quot;
+        export type Time = string;    // pattern: &quot;(^\d{1,5}(\.\d{0,3})?$)|(^([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\.\d{0,3})?$)&quot;
+        export type TimeOffset = string;    // pattern: &quot;(^[+-]?\d{1,5}(\.\d{0,3})?$)|(^[+-]?([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\.\d{0,3})?$)&quot;
+        export type UserMetadata = {[key:string]: String};
+        export type VerticalAlign = string;    // pattern: &quot;(^Top$)|(^Bottom$)|(^Center$)&quot;
+        export type VideoBitRate = string;    // pattern: &quot;(^\d{2,5}$)|(^auto$)&quot;
+        export type VideoCodec = string;    // pattern: &quot;(^H\.264$)|(^vp8$)|(^mpeg2$)|(^gif$)&quot;
+        export type Warnings = Warning[];
+        export type WatermarkKey = string;    // pattern: &quot;(^.{1,}.jpg$)|(^.{1,}.jpeg$)|(^.{1,}.png$)&quot;, max: 255, min: 1
+        export type WatermarkSizingPolicy = string;    // pattern: &quot;(^Fit$)|(^Stretch$)|(^ShrinkToFit$)&quot;
+        export type ZeroTo255String = string;    // max: 255
+        export type ZeroTo512String = string;    // max: 512
+
+        export interface AccessDeniedException {
+        }
+        export interface Artwork {
+            InputKey?: WatermarkKey;            
+            MaxWidth?: DigitsOrAuto;            
+            MaxHeight?: DigitsOrAuto;            
+            SizingPolicy?: SizingPolicy;            
+            PaddingPolicy?: PaddingPolicy;            
+            AlbumArtFormat?: JpgOrPng;            
+            Encryption?: Encryption;            
+        }
+        export interface AudioCodecOptions {
+            Profile?: AudioCodecProfile;            
+            BitDepth?: AudioBitDepth;            
+            BitOrder?: AudioBitOrder;            
+            Signed?: AudioSigned;            
+        }
+        export interface AudioParameters {
+            Codec?: AudioCodec;            
+            SampleRate?: AudioSampleRate;            
+            BitRate?: AudioBitRate;            
+            Channels?: AudioChannels;            
+            AudioPackingMode?: AudioPackingMode;            
+            CodecOptions?: AudioCodecOptions;            
+        }
+        export interface CancelJobRequest {
+            Id: Id;            
+        }
+        export interface CancelJobResponse {
+        }
+        export interface CaptionFormat {
+            Format?: CaptionFormatFormat;            
+            Pattern?: CaptionFormatPattern;            
+            Encryption?: Encryption;            
+        }
+        export interface CaptionSource {
+            Key?: Key;            
+            Language?: Key;            
+            TimeOffset?: TimeOffset;            
+            Label?: Name;            
+            Encryption?: Encryption;            
+        }
+        export interface Captions {
+            MergePolicy?: CaptionMergePolicy;            
+            CaptionSources?: CaptionSources;            
+            CaptionFormats?: CaptionFormats;            
+        }
+        export interface Clip {
+            TimeSpan?: TimeSpan;            
+        }
+        export interface CreateJobOutput {
+            Key?: Key;            
+            ThumbnailPattern?: ThumbnailPattern;            
+            ThumbnailEncryption?: Encryption;            
+            Rotate?: Rotate;            
+            PresetId?: Id;            
+            SegmentDuration?: FloatString;            
+            Watermarks?: JobWatermarks;            
+            AlbumArt?: JobAlbumArt;            
+            Composition?: Composition;            
+            Captions?: Captions;            
+            Encryption?: Encryption;            
+        }
+        export interface CreateJobPlaylist {
+            Name?: Filename;            
+            Format?: PlaylistFormat;            
+            OutputKeys?: OutputKeys;            
+            HlsContentProtection?: HlsContentProtection;            
+            PlayReadyDrm?: PlayReadyDrm;            
+        }
+        export interface CreateJobRequest {
+            PipelineId: Id;            
+            Input: JobInput;            
+            Output?: CreateJobOutput;            
+            Outputs?: CreateJobOutputs;            
+            OutputKeyPrefix?: Key;            
+            Playlists?: CreateJobPlaylists;            
+            UserMetadata?: UserMetadata;            
+        }
+        export interface CreateJobResponse {
+            Job?: Job;            
+        }
+        export interface CreatePipelineRequest {
+            Name: Name;            
+            InputBucket: BucketName;            
+            OutputBucket?: BucketName;            
+            Role: Role;            
+            AwsKmsKeyArn?: KeyArn;            
+            Notifications?: Notifications;            
+            ContentConfig?: PipelineOutputConfig;            
+            ThumbnailConfig?: PipelineOutputConfig;            
+        }
+        export interface CreatePipelineResponse {
+            Pipeline?: Pipeline;            
+            Warnings?: Warnings;            
+        }
+        export interface CreatePresetRequest {
+            Name: Name;            
+            Description?: Description;            
+            Container: PresetContainer;            
+            Video?: VideoParameters;            
+            Audio?: AudioParameters;            
+            Thumbnails?: Thumbnails;            
+        }
+        export interface CreatePresetResponse {
+            Preset?: Preset;            
+            Warning?: String;            
+        }
+        export interface DeletePipelineRequest {
+            Id: Id;            
+        }
+        export interface DeletePipelineResponse {
+        }
+        export interface DeletePresetRequest {
+            Id: Id;            
+        }
+        export interface DeletePresetResponse {
+        }
+        export interface DetectedProperties {
+            Width?: NullableInteger;            
+            Height?: NullableInteger;            
+            FrameRate?: FloatString;            
+            FileSize?: NullableLong;            
+            DurationMillis?: NullableLong;            
+        }
+        export interface Encryption {
+            Mode?: EncryptionMode;            
+            Key?: Base64EncodedString;            
+            KeyMd5?: Base64EncodedString;            
+            InitializationVector?: ZeroTo255String;            
+        }
+        export interface HlsContentProtection {
+            Method?: HlsContentProtectionMethod;            
+            Key?: Base64EncodedString;            
+            KeyMd5?: Base64EncodedString;            
+            InitializationVector?: ZeroTo255String;            
+            LicenseAcquisitionUrl?: ZeroTo512String;            
+            KeyStoragePolicy?: KeyStoragePolicy;            
+        }
+        export interface IncompatibleVersionException {
+        }
+        export interface InternalServiceException {
+        }
+        export interface Job {
+            Id?: Id;            
+            Arn?: String;            
+            PipelineId?: Id;            
+            Input?: JobInput;            
+            Output?: JobOutput;            
+            Outputs?: JobOutputs;            
+            OutputKeyPrefix?: Key;            
+            Playlists?: Playlists;            
+            Status?: JobStatus;            
+            UserMetadata?: UserMetadata;            
+            Timing?: Timing;            
+        }
+        export interface JobAlbumArt {
+            MergePolicy?: MergePolicy;            
+            Artwork?: Artworks;            
+        }
+        export interface JobInput {
+            Key?: Key;            
+            FrameRate?: FrameRate;            
+            Resolution?: Resolution;            
+            AspectRatio?: AspectRatio;            
+            Interlaced?: Interlaced;            
+            Container?: JobContainer;            
+            Encryption?: Encryption;            
+            DetectedProperties?: DetectedProperties;            
+        }
+        export interface JobOutput {
+            Id?: String;            
+            Key?: Key;            
+            ThumbnailPattern?: ThumbnailPattern;            
+            ThumbnailEncryption?: Encryption;            
+            Rotate?: Rotate;            
+            PresetId?: Id;            
+            SegmentDuration?: FloatString;            
+            Status?: JobStatus;            
+            StatusDetail?: Description;            
+            Duration?: NullableLong;            
+            Width?: NullableInteger;            
+            Height?: NullableInteger;            
+            FrameRate?: FloatString;            
+            FileSize?: NullableLong;            
+            DurationMillis?: NullableLong;            
+            Watermarks?: JobWatermarks;            
+            AlbumArt?: JobAlbumArt;            
+            Composition?: Composition;            
+            Captions?: Captions;            
+            Encryption?: Encryption;            
+            AppliedColorSpaceConversion?: String;            
+        }
+        export interface JobWatermark {
+            PresetWatermarkId?: PresetWatermarkId;            
+            InputKey?: WatermarkKey;            
+            Encryption?: Encryption;            
+        }
+        export interface LimitExceededException {
+        }
+        export interface ListJobsByPipelineRequest {
+            PipelineId: Id;            
+            Ascending?: Ascending;            
+            PageToken?: Id;            
+        }
+        export interface ListJobsByPipelineResponse {
+            Jobs?: Jobs;            
+            NextPageToken?: Id;            
+        }
+        export interface ListJobsByStatusRequest {
+            Status: JobStatus;            
+            Ascending?: Ascending;            
+            PageToken?: Id;            
+        }
+        export interface ListJobsByStatusResponse {
+            Jobs?: Jobs;            
+            NextPageToken?: Id;            
+        }
+        export interface ListPipelinesRequest {
+            Ascending?: Ascending;            
+            PageToken?: Id;            
+        }
+        export interface ListPipelinesResponse {
+            Pipelines?: Pipelines;            
+            NextPageToken?: Id;            
+        }
+        export interface ListPresetsRequest {
+            Ascending?: Ascending;            
+            PageToken?: Id;            
+        }
+        export interface ListPresetsResponse {
+            Presets?: Presets;            
+            NextPageToken?: Id;            
+        }
+        export interface Notifications {
+            Progressing?: SnsTopic;            
+            Completed?: SnsTopic;            
+            Warning?: SnsTopic;            
+            Error?: SnsTopic;            
+        }
+        export interface Permission {
+            GranteeType?: GranteeType;            
+            Grantee?: Grantee;            
+            Access?: AccessControls;            
+        }
+        export interface Pipeline {
+            Id?: Id;            
+            Arn?: String;            
+            Name?: Name;            
+            Status?: PipelineStatus;            
+            InputBucket?: BucketName;            
+            OutputBucket?: BucketName;            
+            Role?: Role;            
+            AwsKmsKeyArn?: KeyArn;            
+            Notifications?: Notifications;            
+            ContentConfig?: PipelineOutputConfig;            
+            ThumbnailConfig?: PipelineOutputConfig;            
+        }
+        export interface PipelineOutputConfig {
+            Bucket?: BucketName;            
+            StorageClass?: StorageClass;            
+            Permissions?: Permissions;            
+        }
+        export interface PlayReadyDrm {
+            Format?: PlayReadyDrmFormatString;            
+            Key?: NonEmptyBase64EncodedString;            
+            KeyMd5?: NonEmptyBase64EncodedString;            
+            KeyId?: KeyIdGuid;            
+            InitializationVector?: ZeroTo255String;            
+            LicenseAcquisitionUrl?: OneTo512String;            
+        }
+        export interface Playlist {
+            Name?: Filename;            
+            Format?: PlaylistFormat;            
+            OutputKeys?: OutputKeys;            
+            HlsContentProtection?: HlsContentProtection;            
+            PlayReadyDrm?: PlayReadyDrm;            
+            Status?: JobStatus;            
+            StatusDetail?: Description;            
+        }
+        export interface Preset {
+            Id?: Id;            
+            Arn?: String;            
+            Name?: Name;            
+            Description?: Description;            
+            Container?: PresetContainer;            
+            Audio?: AudioParameters;            
+            Video?: VideoParameters;            
+            Thumbnails?: Thumbnails;            
+            Type?: PresetType;            
+        }
+        export interface PresetWatermark {
+            Id?: PresetWatermarkId;            
+            MaxWidth?: PixelsOrPercent;            
+            MaxHeight?: PixelsOrPercent;            
+            SizingPolicy?: WatermarkSizingPolicy;            
+            HorizontalAlign?: HorizontalAlign;            
+            HorizontalOffset?: PixelsOrPercent;            
+            VerticalAlign?: VerticalAlign;            
+            VerticalOffset?: PixelsOrPercent;            
+            Opacity?: Opacity;            
+            Target?: Target;            
+        }
+        export interface ReadJobRequest {
+            Id: Id;            
+        }
+        export interface ReadJobResponse {
+            Job?: Job;            
+        }
+        export interface ReadPipelineRequest {
+            Id: Id;            
+        }
+        export interface ReadPipelineResponse {
+            Pipeline?: Pipeline;            
+            Warnings?: Warnings;            
+        }
+        export interface ReadPresetRequest {
+            Id: Id;            
+        }
+        export interface ReadPresetResponse {
+            Preset?: Preset;            
+        }
+        export interface ResourceInUseException {
+        }
+        export interface ResourceNotFoundException {
+        }
+        export interface TestRoleRequest {
+            Role: Role;            
+            InputBucket: BucketName;            
+            OutputBucket: BucketName;            
+            Topics: SnsTopics;            
+        }
+        export interface TestRoleResponse {
+            Success?: Success;            
+            Messages?: ExceptionMessages;            
+        }
+        export interface Thumbnails {
+            Format?: JpgOrPng;            
+            Interval?: Digits;            
+            Resolution?: ThumbnailResolution;            
+            AspectRatio?: AspectRatio;            
+            MaxWidth?: DigitsOrAuto;            
+            MaxHeight?: DigitsOrAuto;            
+            SizingPolicy?: SizingPolicy;            
+            PaddingPolicy?: PaddingPolicy;            
+        }
+        export interface TimeSpan {
+            StartTime?: Time;            
+            Duration?: Time;            
+        }
+        export interface Timing {
+            SubmitTimeMillis?: NullableLong;            
+            StartTimeMillis?: NullableLong;            
+            FinishTimeMillis?: NullableLong;            
+        }
+        export interface UpdatePipelineNotificationsRequest {
+            Id: Id;            
+            Notifications: Notifications;            
+        }
+        export interface UpdatePipelineNotificationsResponse {
+            Pipeline?: Pipeline;            
+        }
+        export interface UpdatePipelineRequest {
+            Id: Id;            
+            Name?: Name;            
+            InputBucket?: BucketName;            
+            Role?: Role;            
+            AwsKmsKeyArn?: KeyArn;            
+            Notifications?: Notifications;            
+            ContentConfig?: PipelineOutputConfig;            
+            ThumbnailConfig?: PipelineOutputConfig;            
+        }
+        export interface UpdatePipelineResponse {
+            Pipeline?: Pipeline;            
+            Warnings?: Warnings;            
+        }
+        export interface UpdatePipelineStatusRequest {
+            Id: Id;            
+            Status: PipelineStatus;            
+        }
+        export interface UpdatePipelineStatusResponse {
+            Pipeline?: Pipeline;            
+        }
+        export interface ValidationException {
+        }
+        export interface VideoParameters {
+            Codec?: VideoCodec;            
+            CodecOptions?: CodecOptions;            
+            KeyframesMaxDist?: KeyframesMaxDist;            
+            FixedGOP?: FixedGOP;            
+            BitRate?: VideoBitRate;            
+            FrameRate?: FrameRate;            
+            MaxFrameRate?: MaxFrameRate;            
+            Resolution?: Resolution;            
+            AspectRatio?: AspectRatio;            
+            MaxWidth?: DigitsOrAuto;            
+            MaxHeight?: DigitsOrAuto;            
+            DisplayAspectRatio?: AspectRatio;            
+            SizingPolicy?: SizingPolicy;            
+            PaddingPolicy?: PaddingPolicy;            
+            Watermarks?: PresetWatermarks;            
+        }
+        export interface Warning {
+            Code?: String;            
+            Message?: String;            
+        }
 
-    export interface ElasticTranscoderListJobsByStatusRequest {
-        Status: ElasticTranscoderJobStatus;
-        Ascending?: ElasticTranscoderAscending;
-        PageToken?: ElasticTranscoderId;
     }
-
-    export interface ElasticTranscoderListJobsByStatusResponse {
-        Jobs?: ElasticTranscoderJobs;
-        NextPageToken?: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderListPipelinesRequest {
-        Ascending?: ElasticTranscoderAscending;
-        PageToken?: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderListPipelinesResponse {
-        Pipelines?: ElasticTranscoderPipelines;
-        NextPageToken?: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderListPresetsRequest {
-        Ascending?: ElasticTranscoderAscending;
-        PageToken?: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderListPresetsResponse {
-        Presets?: ElasticTranscoderPresets;
-        NextPageToken?: ElasticTranscoderId;
-    }
-
-    export type ElasticTranscoderMaxFrameRate = string; // pattern: "(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)"
-    export type ElasticTranscoderMergePolicy = string; // pattern: "(^Replace$)|(^Prepend$)|(^Append$)|(^Fallback$)"
-    export type ElasticTranscoderName = string;
-    export type ElasticTranscoderNonEmptyBase64EncodedString = string; // pattern: "(^(?:[A-Za-z0-9\+/]{4})*(?:[A-Za-z0-9\+/]{2}==|[A-Za-z0-9\+/]{3}=)?$)"
-    export interface ElasticTranscoderNotifications {
-        Progressing?: ElasticTranscoderSnsTopic;
-        Completed?: ElasticTranscoderSnsTopic;
-        Warning?: ElasticTranscoderSnsTopic;
-        Error?: ElasticTranscoderSnsTopic;
-    }
-
-    export type ElasticTranscoderNullableInteger = number;
-    export type ElasticTranscoderNullableLong = number;
-    export type ElasticTranscoderOneTo512String = string;
-    export type ElasticTranscoderOpacity = string; // pattern: "^\d{1,3}(\.\d{0,20})?$"
-    export type ElasticTranscoderOutputKeys = Array<ElasticTranscoderKey>; // max: 30
-    export type ElasticTranscoderPaddingPolicy = string; // pattern: "(^Pad$)|(^NoPad$)"
-    export interface ElasticTranscoderPermission {
-        GranteeType?: ElasticTranscoderGranteeType;
-        Grantee?: ElasticTranscoderGrantee;
-        Access?: ElasticTranscoderAccessControls;
-    }
-
-    export type ElasticTranscoderPermissions = Array<ElasticTranscoderPermission>; // max: 30
-    export interface ElasticTranscoderPipeline {
-        Id?: ElasticTranscoderId;
-        Arn?: ElasticTranscoderString;
-        Name?: ElasticTranscoderName;
-        Status?: ElasticTranscoderPipelineStatus;
-        InputBucket?: ElasticTranscoderBucketName;
-        OutputBucket?: ElasticTranscoderBucketName;
-        Role?: ElasticTranscoderRole;
-        AwsKmsKeyArn?: ElasticTranscoderKeyArn;
-        Notifications?: ElasticTranscoderNotifications;
-        ContentConfig?: ElasticTranscoderPipelineOutputConfig;
-        ThumbnailConfig?: ElasticTranscoderPipelineOutputConfig;
-    }
-
-    export interface ElasticTranscoderPipelineOutputConfig {
-        Bucket?: ElasticTranscoderBucketName;
-        StorageClass?: ElasticTranscoderStorageClass;
-        Permissions?: ElasticTranscoderPermissions;
-    }
-
-    export type ElasticTranscoderPipelineStatus = string; // pattern: "(^Active$)|(^Paused$)"
-    export type ElasticTranscoderPipelines = Array<ElasticTranscoderPipeline>;
-    export type ElasticTranscoderPixelsOrPercent = string; // pattern: "(^\d{1,3}(\.\d{0,5})?%$)|(^\d{1,4}?px$)"
-    export interface ElasticTranscoderPlayReadyDrm {
-        Format?: ElasticTranscoderPlayReadyDrmFormatString;
-        Key?: ElasticTranscoderNonEmptyBase64EncodedString;
-        KeyMd5?: ElasticTranscoderNonEmptyBase64EncodedString;
-        KeyId?: ElasticTranscoderKeyIdGuid;
-        InitializationVector?: ElasticTranscoderZeroTo255String;
-        LicenseAcquisitionUrl?: ElasticTranscoderOneTo512String;
-    }
-
-    export type ElasticTranscoderPlayReadyDrmFormatString = string; // pattern: "(^microsoft$)|(^discretix-3.0$)"
-    export interface ElasticTranscoderPlaylist {
-        Name?: ElasticTranscoderFilename;
-        Format?: ElasticTranscoderPlaylistFormat;
-        OutputKeys?: ElasticTranscoderOutputKeys;
-        HlsContentProtection?: ElasticTranscoderHlsContentProtection;
-        PlayReadyDrm?: ElasticTranscoderPlayReadyDrm;
-        Status?: ElasticTranscoderJobStatus;
-        StatusDetail?: ElasticTranscoderDescription;
-    }
-
-    export type ElasticTranscoderPlaylistFormat = string; // pattern: "(^HLSv3$)|(^HLSv4$)|(^Smooth$)"
-    export type ElasticTranscoderPlaylists = Array<ElasticTranscoderPlaylist>;
-    export interface ElasticTranscoderPreset {
-        Id?: ElasticTranscoderId;
-        Arn?: ElasticTranscoderString;
-        Name?: ElasticTranscoderName;
-        Description?: ElasticTranscoderDescription;
-        Container?: ElasticTranscoderPresetContainer;
-        Audio?: ElasticTranscoderAudioParameters;
-        Video?: ElasticTranscoderVideoParameters;
-        Thumbnails?: ElasticTranscoderThumbnails;
-        Type?: ElasticTranscoderPresetType;
-    }
-
-    export type ElasticTranscoderPresetContainer = string; // pattern: "(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^flac$)|(^oga$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)|(^mxf$)"
-    export type ElasticTranscoderPresetType = string; // pattern: "(^System$)|(^Custom$)"
-    export interface ElasticTranscoderPresetWatermark {
-        Id?: ElasticTranscoderPresetWatermarkId;
-        MaxWidth?: ElasticTranscoderPixelsOrPercent;
-        MaxHeight?: ElasticTranscoderPixelsOrPercent;
-        SizingPolicy?: ElasticTranscoderWatermarkSizingPolicy;
-        HorizontalAlign?: ElasticTranscoderHorizontalAlign;
-        HorizontalOffset?: ElasticTranscoderPixelsOrPercent;
-        VerticalAlign?: ElasticTranscoderVerticalAlign;
-        VerticalOffset?: ElasticTranscoderPixelsOrPercent;
-        Opacity?: ElasticTranscoderOpacity;
-        Target?: ElasticTranscoderTarget;
-    }
-
-    export type ElasticTranscoderPresetWatermarkId = string;
-    export type ElasticTranscoderPresetWatermarks = Array<ElasticTranscoderPresetWatermark>;
-    export type ElasticTranscoderPresets = Array<ElasticTranscoderPreset>;
-    export interface ElasticTranscoderReadJobRequest {
-        Id: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderReadJobResponse {
-        Job?: ElasticTranscoderJob;
-    }
-
-    export interface ElasticTranscoderReadPipelineRequest {
-        Id: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderReadPipelineResponse {
-        Pipeline?: ElasticTranscoderPipeline;
-        Warnings?: ElasticTranscoderWarnings;
-    }
-
-    export interface ElasticTranscoderReadPresetRequest {
-        Id: ElasticTranscoderId;
-    }
-
-    export interface ElasticTranscoderReadPresetResponse {
-        Preset?: ElasticTranscoderPreset;
-    }
-
-    export type ElasticTranscoderResolution = string; // pattern: "(^auto$)|(^\d{1,5}x\d{1,5}$)"
-    export interface ElasticTranscoderResourceInUseException {
-    }
-
-    export interface ElasticTranscoderResourceNotFoundException {
-    }
-
-    export type ElasticTranscoderRole = string; // pattern: "^arn:aws:iam::\w{12}:role/.+$"
-    export type ElasticTranscoderRotate = string; // pattern: "(^auto$)|(^0$)|(^90$)|(^180$)|(^270$)"
-    export type ElasticTranscoderSizingPolicy = string; // pattern: "(^Fit$)|(^Fill$)|(^Stretch$)|(^Keep$)|(^ShrinkToFit$)|(^ShrinkToFill$)"
-    export type ElasticTranscoderSnsTopic = string; // pattern: "(^$)|(^arn:aws:sns:.*:\w{12}:.+$)"
-    export type ElasticTranscoderSnsTopics = Array<ElasticTranscoderSnsTopic>; // max: 30
-    export type ElasticTranscoderStorageClass = string; // pattern: "(^ReducedRedundancy$)|(^Standard$)"
-    export type ElasticTranscoderString = string;
-    export type ElasticTranscoderSuccess = string; // pattern: "(^true$)|(^false$)"
-    export type ElasticTranscoderTarget = string; // pattern: "(^Content$)|(^Frame$)"
-    export interface ElasticTranscoderTestRoleRequest {
-        Role: ElasticTranscoderRole;
-        InputBucket: ElasticTranscoderBucketName;
-        OutputBucket: ElasticTranscoderBucketName;
-        Topics: ElasticTranscoderSnsTopics;
-    }
-
-    export interface ElasticTranscoderTestRoleResponse {
-        Success?: ElasticTranscoderSuccess;
-        Messages?: ElasticTranscoderExceptionMessages;
-    }
-
-    export type ElasticTranscoderThumbnailPattern = string; // pattern: "(^$)|(^.*\{count\}.*$)"
-    export type ElasticTranscoderThumbnailResolution = string; // pattern: "^\d{1,5}x\d{1,5}$"
-    export interface ElasticTranscoderThumbnails {
-        Format?: ElasticTranscoderJpgOrPng;
-        Interval?: ElasticTranscoderDigits;
-        Resolution?: ElasticTranscoderThumbnailResolution;
-        AspectRatio?: ElasticTranscoderAspectRatio;
-        MaxWidth?: ElasticTranscoderDigitsOrAuto;
-        MaxHeight?: ElasticTranscoderDigitsOrAuto;
-        SizingPolicy?: ElasticTranscoderSizingPolicy;
-        PaddingPolicy?: ElasticTranscoderPaddingPolicy;
-    }
-
-    export type ElasticTranscoderTime = string; // pattern: "(^\d{1,5}(\.\d{0,3})?$)|(^([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\.\d{0,3})?$)"
-    export type ElasticTranscoderTimeOffset = string; // pattern: "(^[+-]?\d{1,5}(\.\d{0,3})?$)|(^[+-]?([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\.\d{0,3})?$)"
-    export interface ElasticTranscoderTimeSpan {
-        StartTime?: ElasticTranscoderTime;
-        Duration?: ElasticTranscoderTime;
-    }
-
-    export interface ElasticTranscoderTiming {
-        SubmitTimeMillis?: ElasticTranscoderNullableLong;
-        StartTimeMillis?: ElasticTranscoderNullableLong;
-        FinishTimeMillis?: ElasticTranscoderNullableLong;
-    }
-
-    export interface ElasticTranscoderUpdatePipelineNotificationsRequest {
-        Id: ElasticTranscoderId;
-        Notifications: ElasticTranscoderNotifications;
-    }
-
-    export interface ElasticTranscoderUpdatePipelineNotificationsResponse {
-        Pipeline?: ElasticTranscoderPipeline;
-    }
-
-    export interface ElasticTranscoderUpdatePipelineRequest {
-        Id: ElasticTranscoderId;
-        Name?: ElasticTranscoderName;
-        InputBucket?: ElasticTranscoderBucketName;
-        Role?: ElasticTranscoderRole;
-        AwsKmsKeyArn?: ElasticTranscoderKeyArn;
-        Notifications?: ElasticTranscoderNotifications;
-        ContentConfig?: ElasticTranscoderPipelineOutputConfig;
-        ThumbnailConfig?: ElasticTranscoderPipelineOutputConfig;
-    }
-
-    export interface ElasticTranscoderUpdatePipelineResponse {
-        Pipeline?: ElasticTranscoderPipeline;
-        Warnings?: ElasticTranscoderWarnings;
-    }
-
-    export interface ElasticTranscoderUpdatePipelineStatusRequest {
-        Id: ElasticTranscoderId;
-        Status: ElasticTranscoderPipelineStatus;
-    }
-
-    export interface ElasticTranscoderUpdatePipelineStatusResponse {
-        Pipeline?: ElasticTranscoderPipeline;
-    }
-
-    export type ElasticTranscoderUserMetadata = any; // not really - it was 'map' instead - must fix this one
-    export interface ElasticTranscoderValidationException {
-    }
-
-    export type ElasticTranscoderVerticalAlign = string; // pattern: "(^Top$)|(^Bottom$)|(^Center$)"
-    export type ElasticTranscoderVideoBitRate = string; // pattern: "(^\d{2,5}$)|(^auto$)"
-    export type ElasticTranscoderVideoCodec = string; // pattern: "(^H\.264$)|(^vp8$)|(^mpeg2$)|(^gif$)"
-    export interface ElasticTranscoderVideoParameters {
-        Codec?: ElasticTranscoderVideoCodec;
-        CodecOptions?: ElasticTranscoderCodecOptions;
-        KeyframesMaxDist?: ElasticTranscoderKeyframesMaxDist;
-        FixedGOP?: ElasticTranscoderFixedGOP;
-        BitRate?: ElasticTranscoderVideoBitRate;
-        FrameRate?: ElasticTranscoderFrameRate;
-        MaxFrameRate?: ElasticTranscoderMaxFrameRate;
-        Resolution?: ElasticTranscoderResolution;
-        AspectRatio?: ElasticTranscoderAspectRatio;
-        MaxWidth?: ElasticTranscoderDigitsOrAuto;
-        MaxHeight?: ElasticTranscoderDigitsOrAuto;
-        DisplayAspectRatio?: ElasticTranscoderAspectRatio;
-        SizingPolicy?: ElasticTranscoderSizingPolicy;
-        PaddingPolicy?: ElasticTranscoderPaddingPolicy;
-        Watermarks?: ElasticTranscoderPresetWatermarks;
-    }
-
-    export interface ElasticTranscoderWarning {
-        Code?: ElasticTranscoderString;
-        Message?: ElasticTranscoderString;
-    }
-
-    export type ElasticTranscoderWarnings = Array<ElasticTranscoderWarning>;
-    export type ElasticTranscoderWatermarkKey = string; // pattern: "(^.{1,}.jpg$)|(^.{1,}.jpeg$)|(^.{1,}.png$)"
-    export type ElasticTranscoderWatermarkSizingPolicy = string; // pattern: "(^Fit$)|(^Stretch$)|(^ShrinkToFit$)"
-    export type ElasticTranscoderZeroTo255String = string;
-    export type ElasticTranscoderZeroTo512String = string;
 }

--- a/output/aws-es.d.ts
+++ b/output/aws-es.d.ts
@@ -6,228 +6,194 @@ declare module "aws-sdk" {
 
     export class ES extends Service {
       constructor(options?: any);
-      addTags(params: ESAddTagsRequest, callback?: (err: ESBaseException|ESLimitExceededException|ESValidationException|ESInternalException|any, data: any) => void): Request;
-      createElasticsearchDomain(params: ESCreateElasticsearchDomainRequest, callback?: (err: ESBaseException|ESDisabledOperationException|ESInternalException|ESInvalidTypeException|ESLimitExceededException|ESResourceAlreadyExistsException|ESValidationException|any, data: ESCreateElasticsearchDomainResponse|any) => void): Request;
-      deleteElasticsearchDomain(params: ESDeleteElasticsearchDomainRequest, callback?: (err: ESBaseException|ESInternalException|ESResourceNotFoundException|ESValidationException|any, data: ESDeleteElasticsearchDomainResponse|any) => void): Request;
-      describeElasticsearchDomain(params: ESDescribeElasticsearchDomainRequest, callback?: (err: ESBaseException|ESInternalException|ESResourceNotFoundException|ESValidationException|any, data: ESDescribeElasticsearchDomainResponse|any) => void): Request;
-      describeElasticsearchDomainConfig(params: ESDescribeElasticsearchDomainConfigRequest, callback?: (err: ESBaseException|ESInternalException|ESResourceNotFoundException|ESValidationException|any, data: ESDescribeElasticsearchDomainConfigResponse|any) => void): Request;
-      describeElasticsearchDomains(params: ESDescribeElasticsearchDomainsRequest, callback?: (err: ESBaseException|ESInternalException|ESValidationException|any, data: ESDescribeElasticsearchDomainsResponse|any) => void): Request;
-      listDomainNames(callback?: (err: ESBaseException|ESValidationException|any, data: ESListDomainNamesResponse|any) => void): Request;
-      listTags(params: ESListTagsRequest, callback?: (err: ESBaseException|ESResourceNotFoundException|ESValidationException|ESInternalException|any, data: ESListTagsResponse|any) => void): Request;
-      removeTags(params: ESRemoveTagsRequest, callback?: (err: ESBaseException|ESValidationException|ESInternalException|any, data: any) => void): Request;
-      updateElasticsearchDomainConfig(params: ESUpdateElasticsearchDomainConfigRequest, callback?: (err: ESBaseException|ESInternalException|ESInvalidTypeException|ESLimitExceededException|ESResourceNotFoundException|ESValidationException|any, data: ESUpdateElasticsearchDomainConfigResponse|any) => void): Request;
+      addTags(params: ES.AddTagsRequest, callback?: (err: ES.BaseException|ES.LimitExceededException|ES.ValidationException|ES.InternalException|any, data: any) => void): Request;
+      createElasticsearchDomain(params: ES.CreateElasticsearchDomainRequest, callback?: (err: ES.BaseException|ES.DisabledOperationException|ES.InternalException|ES.InvalidTypeException|ES.LimitExceededException|ES.ResourceAlreadyExistsException|ES.ValidationException|any, data: ES.CreateElasticsearchDomainResponse|any) => void): Request;
+      deleteElasticsearchDomain(params: ES.DeleteElasticsearchDomainRequest, callback?: (err: ES.BaseException|ES.InternalException|ES.ResourceNotFoundException|ES.ValidationException|any, data: ES.DeleteElasticsearchDomainResponse|any) => void): Request;
+      describeElasticsearchDomain(params: ES.DescribeElasticsearchDomainRequest, callback?: (err: ES.BaseException|ES.InternalException|ES.ResourceNotFoundException|ES.ValidationException|any, data: ES.DescribeElasticsearchDomainResponse|any) => void): Request;
+      describeElasticsearchDomainConfig(params: ES.DescribeElasticsearchDomainConfigRequest, callback?: (err: ES.BaseException|ES.InternalException|ES.ResourceNotFoundException|ES.ValidationException|any, data: ES.DescribeElasticsearchDomainConfigResponse|any) => void): Request;
+      describeElasticsearchDomains(params: ES.DescribeElasticsearchDomainsRequest, callback?: (err: ES.BaseException|ES.InternalException|ES.ValidationException|any, data: ES.DescribeElasticsearchDomainsResponse|any) => void): Request;
+      listDomainNames(callback?: (err: ES.BaseException|ES.ValidationException|any, data: ES.ListDomainNamesResponse|any) => void): Request;
+      listTags(params: ES.ListTagsRequest, callback?: (err: ES.BaseException|ES.ResourceNotFoundException|ES.ValidationException|ES.InternalException|any, data: ES.ListTagsResponse|any) => void): Request;
+      removeTags(params: ES.RemoveTagsRequest, callback?: (err: ES.BaseException|ES.ValidationException|ES.InternalException|any, data: any) => void): Request;
+      updateElasticsearchDomainConfig(params: ES.UpdateElasticsearchDomainConfigRequest, callback?: (err: ES.BaseException|ES.InternalException|ES.InvalidTypeException|ES.LimitExceededException|ES.ResourceNotFoundException|ES.ValidationException|any, data: ES.UpdateElasticsearchDomainConfigResponse|any) => void): Request;
     }
+    
+    export module ES {
+        export type ARN = string;
+        export type AdvancedOptions = {[key:string]: String};
+        export type Boolean = boolean;
+        export type DomainId = string;    // max: 64, min: 1
+        export type DomainInfoList = DomainInfo[];
+        export type DomainName = string;    // pattern: &quot;[a-z][a-z0-9\-]+&quot;, max: 28, min: 3
+        export type DomainNameList = DomainName[];
+        export type ESPartitionInstanceType = string;
+        export type ElasticsearchDomainStatusList = ElasticsearchDomainStatus[];
+        export type ErrorMessage = string;
+        export type IntegerClass = number;
+        export type OptionState = string;
+        export type PolicyDocument = string;
+        export type ServiceUrl = string;
+        export type String = string;
+        export type StringList = String[];
+        export type TagKey = string;    // max: 128, min: 1
+        export type TagList = Tag[];
+        export type TagValue = string;    // max: 256
+        export type UIntValue = number;
+        export type UpdateTimestamp = number;
+        export type VolumeType = string;
 
-    export type ESARN = string;
-    export interface ESAccessPoliciesStatus {
-        Options: ESPolicyDocument;
-        Status: ESOptionStatus;
+        export interface AccessPoliciesStatus {
+            Options: PolicyDocument;            
+            Status: OptionStatus;            
+        }
+        export interface AddTagsRequest {
+            ARN: ARN;            
+            TagList: TagList;            
+        }
+        export interface AdvancedOptionsStatus {
+            Options: AdvancedOptions;            
+            Status: OptionStatus;            
+        }
+        export interface BaseException {
+            message?: ErrorMessage;            
+        }
+        export interface CreateElasticsearchDomainRequest {
+            DomainName: DomainName;            
+            ElasticsearchClusterConfig?: ElasticsearchClusterConfig;            
+            EBSOptions?: EBSOptions;            
+            AccessPolicies?: PolicyDocument;            
+            SnapshotOptions?: SnapshotOptions;            
+            AdvancedOptions?: AdvancedOptions;            
+        }
+        export interface CreateElasticsearchDomainResponse {
+            DomainStatus?: ElasticsearchDomainStatus;            
+        }
+        export interface DeleteElasticsearchDomainRequest {
+            DomainName: DomainName;            
+        }
+        export interface DeleteElasticsearchDomainResponse {
+            DomainStatus?: ElasticsearchDomainStatus;            
+        }
+        export interface DescribeElasticsearchDomainConfigRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeElasticsearchDomainConfigResponse {
+            DomainConfig: ElasticsearchDomainConfig;            
+        }
+        export interface DescribeElasticsearchDomainRequest {
+            DomainName: DomainName;            
+        }
+        export interface DescribeElasticsearchDomainResponse {
+            DomainStatus: ElasticsearchDomainStatus;            
+        }
+        export interface DescribeElasticsearchDomainsRequest {
+            DomainNames: DomainNameList;            
+        }
+        export interface DescribeElasticsearchDomainsResponse {
+            DomainStatusList: ElasticsearchDomainStatusList;            
+        }
+        export interface DisabledOperationException {
+        }
+        export interface DomainInfo {
+            DomainName?: DomainName;            
+        }
+        export interface EBSOptions {
+            EBSEnabled?: Boolean;            
+            VolumeType?: VolumeType;            
+            VolumeSize?: IntegerClass;            
+            Iops?: IntegerClass;            
+        }
+        export interface EBSOptionsStatus {
+            Options: EBSOptions;            
+            Status: OptionStatus;            
+        }
+        export interface ElasticsearchClusterConfig {
+            InstanceType?: ESPartitionInstanceType;            
+            InstanceCount?: IntegerClass;            
+            DedicatedMasterEnabled?: Boolean;            
+            ZoneAwarenessEnabled?: Boolean;            
+            DedicatedMasterType?: ESPartitionInstanceType;            
+            DedicatedMasterCount?: IntegerClass;            
+        }
+        export interface ElasticsearchClusterConfigStatus {
+            Options: ElasticsearchClusterConfig;            
+            Status: OptionStatus;            
+        }
+        export interface ElasticsearchDomainConfig {
+            ElasticsearchClusterConfig?: ElasticsearchClusterConfigStatus;            
+            EBSOptions?: EBSOptionsStatus;            
+            AccessPolicies?: AccessPoliciesStatus;            
+            SnapshotOptions?: SnapshotOptionsStatus;            
+            AdvancedOptions?: AdvancedOptionsStatus;            
+        }
+        export interface ElasticsearchDomainStatus {
+            DomainId: DomainId;            
+            DomainName: DomainName;            
+            ARN: ARN;            
+            Created?: Boolean;            
+            Deleted?: Boolean;            
+            Endpoint?: ServiceUrl;            
+            Processing?: Boolean;            
+            ElasticsearchClusterConfig: ElasticsearchClusterConfig;            
+            EBSOptions?: EBSOptions;            
+            AccessPolicies?: PolicyDocument;            
+            SnapshotOptions?: SnapshotOptions;            
+            AdvancedOptions?: AdvancedOptions;            
+        }
+        export interface InternalException {
+        }
+        export interface InvalidTypeException {
+        }
+        export interface LimitExceededException {
+        }
+        export interface ListDomainNamesResponse {
+            DomainNames?: DomainInfoList;            
+        }
+        export interface ListTagsRequest {
+            ARN: ARN;            
+        }
+        export interface ListTagsResponse {
+            TagList?: TagList;            
+        }
+        export interface OptionStatus {
+            CreationDate: UpdateTimestamp;            
+            UpdateDate: UpdateTimestamp;            
+            UpdateVersion?: UIntValue;            
+            State: OptionState;            
+            PendingDeletion?: Boolean;            
+        }
+        export interface RemoveTagsRequest {
+            ARN: ARN;            
+            TagKeys: StringList;            
+        }
+        export interface ResourceAlreadyExistsException {
+        }
+        export interface ResourceNotFoundException {
+        }
+        export interface SnapshotOptions {
+            AutomatedSnapshotStartHour?: IntegerClass;            
+        }
+        export interface SnapshotOptionsStatus {
+            Options: SnapshotOptions;            
+            Status: OptionStatus;            
+        }
+        export interface Tag {
+            Key: TagKey;            
+            Value: TagValue;            
+        }
+        export interface UpdateElasticsearchDomainConfigRequest {
+            DomainName: DomainName;            
+            ElasticsearchClusterConfig?: ElasticsearchClusterConfig;            
+            EBSOptions?: EBSOptions;            
+            SnapshotOptions?: SnapshotOptions;            
+            AdvancedOptions?: AdvancedOptions;            
+            AccessPolicies?: PolicyDocument;            
+        }
+        export interface UpdateElasticsearchDomainConfigResponse {
+            DomainConfig: ElasticsearchDomainConfig;            
+        }
+        export interface ValidationException {
+        }
+
     }
-
-    export interface ESAddTagsRequest {
-        ARN: ESARN;
-        TagList: ESTagList;
-    }
-
-    export type ESAdvancedOptions = any; // not really - it was 'map' instead - must fix this one
-    export interface ESAdvancedOptionsStatus {
-        Options: ESAdvancedOptions;
-        Status: ESOptionStatus;
-    }
-
-    export interface ESBaseException {
-        message?: ESErrorMessage;
-    }
-
-    export type ESBoolean = boolean;
-    export interface ESCreateElasticsearchDomainRequest {
-        DomainName: ESDomainName;
-        ElasticsearchClusterConfig?: ESElasticsearchClusterConfig;
-        EBSOptions?: ESEBSOptions;
-        AccessPolicies?: ESPolicyDocument;
-        SnapshotOptions?: ESSnapshotOptions;
-        AdvancedOptions?: ESAdvancedOptions;
-    }
-
-    export interface ESCreateElasticsearchDomainResponse {
-        DomainStatus?: ESElasticsearchDomainStatus;
-    }
-
-    export interface ESDeleteElasticsearchDomainRequest {
-        DomainName: ESDomainName;
-    }
-
-    export interface ESDeleteElasticsearchDomainResponse {
-        DomainStatus?: ESElasticsearchDomainStatus;
-    }
-
-    export interface ESDescribeElasticsearchDomainConfigRequest {
-        DomainName: ESDomainName;
-    }
-
-    export interface ESDescribeElasticsearchDomainConfigResponse {
-        DomainConfig: ESElasticsearchDomainConfig;
-    }
-
-    export interface ESDescribeElasticsearchDomainRequest {
-        DomainName: ESDomainName;
-    }
-
-    export interface ESDescribeElasticsearchDomainResponse {
-        DomainStatus: ESElasticsearchDomainStatus;
-    }
-
-    export interface ESDescribeElasticsearchDomainsRequest {
-        DomainNames: ESDomainNameList;
-    }
-
-    export interface ESDescribeElasticsearchDomainsResponse {
-        DomainStatusList: ESElasticsearchDomainStatusList;
-    }
-
-    export interface ESDisabledOperationException {
-    }
-
-    export type ESDomainId = string;
-    export interface ESDomainInfo {
-        DomainName?: ESDomainName;
-    }
-
-    export type ESDomainInfoList = Array<ESDomainInfo>;
-    export type ESDomainName = string; // pattern: "[a-z][a-z0-9\-]+"
-    export type ESDomainNameList = Array<ESDomainName>;
-    export interface ESEBSOptions {
-        EBSEnabled?: ESBoolean;
-        VolumeType?: ESVolumeType;
-        VolumeSize?: ESIntegerClass;
-        Iops?: ESIntegerClass;
-    }
-
-    export interface ESEBSOptionsStatus {
-        Options: ESEBSOptions;
-        Status: ESOptionStatus;
-    }
-
-    export type ESESPartitionInstanceType = string;
-    export interface ESElasticsearchClusterConfig {
-        InstanceType?: ESESPartitionInstanceType;
-        InstanceCount?: ESIntegerClass;
-        DedicatedMasterEnabled?: ESBoolean;
-        ZoneAwarenessEnabled?: ESBoolean;
-        DedicatedMasterType?: ESESPartitionInstanceType;
-        DedicatedMasterCount?: ESIntegerClass;
-    }
-
-    export interface ESElasticsearchClusterConfigStatus {
-        Options: ESElasticsearchClusterConfig;
-        Status: ESOptionStatus;
-    }
-
-    export interface ESElasticsearchDomainConfig {
-        ElasticsearchClusterConfig?: ESElasticsearchClusterConfigStatus;
-        EBSOptions?: ESEBSOptionsStatus;
-        AccessPolicies?: ESAccessPoliciesStatus;
-        SnapshotOptions?: ESSnapshotOptionsStatus;
-        AdvancedOptions?: ESAdvancedOptionsStatus;
-    }
-
-    export interface ESElasticsearchDomainStatus {
-        DomainId: ESDomainId;
-        DomainName: ESDomainName;
-        ARN: ESARN;
-        Created?: ESBoolean;
-        Deleted?: ESBoolean;
-        Endpoint?: ESServiceUrl;
-        Processing?: ESBoolean;
-        ElasticsearchClusterConfig: ESElasticsearchClusterConfig;
-        EBSOptions?: ESEBSOptions;
-        AccessPolicies?: ESPolicyDocument;
-        SnapshotOptions?: ESSnapshotOptions;
-        AdvancedOptions?: ESAdvancedOptions;
-    }
-
-    export type ESElasticsearchDomainStatusList = Array<ESElasticsearchDomainStatus>;
-    export type ESErrorMessage = string;
-    export type ESIntegerClass = number;
-    export interface ESInternalException {
-    }
-
-    export interface ESInvalidTypeException {
-    }
-
-    export interface ESLimitExceededException {
-    }
-
-    export interface ESListDomainNamesResponse {
-        DomainNames?: ESDomainInfoList;
-    }
-
-    export interface ESListTagsRequest {
-        ARN: ESARN;
-    }
-
-    export interface ESListTagsResponse {
-        TagList?: ESTagList;
-    }
-
-    export type ESOptionState = string;
-    export interface ESOptionStatus {
-        CreationDate: ESUpdateTimestamp;
-        UpdateDate: ESUpdateTimestamp;
-        UpdateVersion?: ESUIntValue;
-        State: ESOptionState;
-        PendingDeletion?: ESBoolean;
-    }
-
-    export type ESPolicyDocument = string;
-    export interface ESRemoveTagsRequest {
-        ARN: ESARN;
-        TagKeys: ESStringList;
-    }
-
-    export interface ESResourceAlreadyExistsException {
-    }
-
-    export interface ESResourceNotFoundException {
-    }
-
-    export type ESServiceUrl = string;
-    export interface ESSnapshotOptions {
-        AutomatedSnapshotStartHour?: ESIntegerClass;
-    }
-
-    export interface ESSnapshotOptionsStatus {
-        Options: ESSnapshotOptions;
-        Status: ESOptionStatus;
-    }
-
-    export type ESString = string;
-    export type ESStringList = Array<ESString>;
-    export interface ESTag {
-        Key: ESTagKey;
-        Value: ESTagValue;
-    }
-
-    export type ESTagKey = string;
-    export type ESTagList = Array<ESTag>;
-    export type ESTagValue = string;
-    export type ESUIntValue = number;
-    export interface ESUpdateElasticsearchDomainConfigRequest {
-        DomainName: ESDomainName;
-        ElasticsearchClusterConfig?: ESElasticsearchClusterConfig;
-        EBSOptions?: ESEBSOptions;
-        SnapshotOptions?: ESSnapshotOptions;
-        AdvancedOptions?: ESAdvancedOptions;
-        AccessPolicies?: ESPolicyDocument;
-    }
-
-    export interface ESUpdateElasticsearchDomainConfigResponse {
-        DomainConfig: ESElasticsearchDomainConfig;
-    }
-
-    export type ESUpdateTimestamp = number;
-    export interface ESValidationException {
-    }
-
-    export type ESVolumeType = string;
 }

--- a/output/aws-firehose.d.ts
+++ b/output/aws-firehose.d.ts
@@ -6,236 +6,206 @@ declare module "aws-sdk" {
 
     export class Firehose extends Service {
       constructor(options?: any);
-      createDeliveryStream(params: FirehoseCreateDeliveryStreamInput, callback?: (err: FirehoseInvalidArgumentException|FirehoseLimitExceededException|FirehoseResourceInUseException|any, data: FirehoseCreateDeliveryStreamOutput|any) => void): Request;
-      deleteDeliveryStream(params: FirehoseDeleteDeliveryStreamInput, callback?: (err: FirehoseResourceInUseException|FirehoseResourceNotFoundException|any, data: FirehoseDeleteDeliveryStreamOutput|any) => void): Request;
-      describeDeliveryStream(params: FirehoseDescribeDeliveryStreamInput, callback?: (err: FirehoseResourceNotFoundException|any, data: FirehoseDescribeDeliveryStreamOutput|any) => void): Request;
-      listDeliveryStreams(params: FirehoseListDeliveryStreamsInput, callback?: (err: any, data: FirehoseListDeliveryStreamsOutput|any) => void): Request;
-      putRecord(params: FirehosePutRecordInput, callback?: (err: FirehoseResourceNotFoundException|FirehoseInvalidArgumentException|FirehoseServiceUnavailableException|any, data: FirehosePutRecordOutput|any) => void): Request;
-      putRecordBatch(params: FirehosePutRecordBatchInput, callback?: (err: FirehoseResourceNotFoundException|FirehoseInvalidArgumentException|FirehoseServiceUnavailableException|any, data: FirehosePutRecordBatchOutput|any) => void): Request;
-      updateDestination(params: FirehoseUpdateDestinationInput, callback?: (err: FirehoseInvalidArgumentException|FirehoseResourceInUseException|FirehoseResourceNotFoundException|FirehoseConcurrentModificationException|any, data: FirehoseUpdateDestinationOutput|any) => void): Request;
+      createDeliveryStream(params: Firehose.CreateDeliveryStreamInput, callback?: (err: Firehose.InvalidArgumentException|Firehose.LimitExceededException|Firehose.ResourceInUseException|any, data: Firehose.CreateDeliveryStreamOutput|any) => void): Request;
+      deleteDeliveryStream(params: Firehose.DeleteDeliveryStreamInput, callback?: (err: Firehose.ResourceInUseException|Firehose.ResourceNotFoundException|any, data: Firehose.DeleteDeliveryStreamOutput|any) => void): Request;
+      describeDeliveryStream(params: Firehose.DescribeDeliveryStreamInput, callback?: (err: Firehose.ResourceNotFoundException|any, data: Firehose.DescribeDeliveryStreamOutput|any) => void): Request;
+      listDeliveryStreams(params: Firehose.ListDeliveryStreamsInput, callback?: (err: any, data: Firehose.ListDeliveryStreamsOutput|any) => void): Request;
+      putRecord(params: Firehose.PutRecordInput, callback?: (err: Firehose.ResourceNotFoundException|Firehose.InvalidArgumentException|Firehose.ServiceUnavailableException|any, data: Firehose.PutRecordOutput|any) => void): Request;
+      putRecordBatch(params: Firehose.PutRecordBatchInput, callback?: (err: Firehose.ResourceNotFoundException|Firehose.InvalidArgumentException|Firehose.ServiceUnavailableException|any, data: Firehose.PutRecordBatchOutput|any) => void): Request;
+      updateDestination(params: Firehose.UpdateDestinationInput, callback?: (err: Firehose.InvalidArgumentException|Firehose.ResourceInUseException|Firehose.ResourceNotFoundException|Firehose.ConcurrentModificationException|any, data: Firehose.UpdateDestinationOutput|any) => void): Request;
     }
+    
+    export module Firehose {
+        export type AWSKMSKeyARN = string;    // pattern: &quot;arn:.*&quot;, max: 512, min: 1
+        export type BooleanObject = boolean;
+        export type BucketARN = string;    // pattern: &quot;arn:.*&quot;, max: 2048, min: 1
+        export type ClusterJDBCURL = string;    // pattern: &quot;jdbc:(redshift|postgresql)://((?!-)[A-Za-z0-9-]{1,63}(?&lt;!-)\.)+redshift\.amazonaws\.com:\d{1,5}/[a-zA-Z0-9_$]+&quot;, min: 1
+        export type CompressionFormat = string;
+        export type CopyOptions = string;
+        export type Data = any;    // max: 1024000, type: blob
+        export type DataTableColumns = string;
+        export type DataTableName = string;    // min: 1
+        export type DeliveryStreamARN = string;
+        export type DeliveryStreamName = string;    // pattern: &quot;[a-zA-Z0-9_.-]+&quot;, max: 64, min: 1
+        export type DeliveryStreamNameList = DeliveryStreamName[];
+        export type DeliveryStreamStatus = string;
+        export type DeliveryStreamVersionId = string;    // pattern: &quot;[0-9]+&quot;, max: 50, min: 1
+        export type DescribeDeliveryStreamInputLimit = number;    // max: 10000, min: 1
+        export type DestinationDescriptionList = DestinationDescription[];
+        export type DestinationId = string;    // max: 100, min: 1
+        export type ErrorCode = string;
+        export type ErrorMessage = string;
+        export type IntervalInSeconds = number;    // max: 900, min: 60
+        export type ListDeliveryStreamsInputLimit = number;    // max: 10000, min: 1
+        export type NoEncryptionConfig = string;
+        export type NonNegativeIntegerObject = number;
+        export type Password = string;    // min: 6
+        export type Prefix = string;
+        export type PutRecordBatchRequestEntryList = Record[];    // max: 500, min: 1
+        export type PutRecordBatchResponseEntryList = PutRecordBatchResponseEntry[];    // max: 500, min: 1
+        export type PutResponseRecordId = string;    // min: 1
+        export type RoleARN = string;    // pattern: &quot;arn:.*&quot;, max: 512, min: 1
+        export type SizeInMBs = number;    // max: 128, min: 1
+        export type Timestamp = number;
+        export type Username = string;    // min: 1
 
-    export type FirehoseAWSKMSKeyARN = string; // pattern: "arn:.*"
-    export type FirehoseBooleanObject = boolean;
-    export type FirehoseBucketARN = string; // pattern: "arn:.*"
-    export interface FirehoseBufferingHints {
-        SizeInMBs?: FirehoseSizeInMBs;
-        IntervalInSeconds?: FirehoseIntervalInSeconds;
+        export interface BufferingHints {
+            SizeInMBs?: SizeInMBs;            
+            IntervalInSeconds?: IntervalInSeconds;            
+        }
+        export interface ConcurrentModificationException {
+            message?: ErrorMessage;            
+        }
+        export interface CopyCommand {
+            DataTableName: DataTableName;            
+            DataTableColumns?: DataTableColumns;            
+            CopyOptions?: CopyOptions;            
+        }
+        export interface CreateDeliveryStreamInput {
+            DeliveryStreamName: DeliveryStreamName;            
+            S3DestinationConfiguration?: S3DestinationConfiguration;            
+            RedshiftDestinationConfiguration?: RedshiftDestinationConfiguration;            
+        }
+        export interface CreateDeliveryStreamOutput {
+            DeliveryStreamARN?: DeliveryStreamARN;            
+        }
+        export interface DeleteDeliveryStreamInput {
+            DeliveryStreamName: DeliveryStreamName;            
+        }
+        export interface DeleteDeliveryStreamOutput {
+        }
+        export interface DeliveryStreamDescription {
+            DeliveryStreamName: DeliveryStreamName;            
+            DeliveryStreamARN: DeliveryStreamARN;            
+            DeliveryStreamStatus: DeliveryStreamStatus;            
+            VersionId: DeliveryStreamVersionId;            
+            CreateTimestamp?: Timestamp;            
+            LastUpdateTimestamp?: Timestamp;            
+            Destinations: DestinationDescriptionList;            
+            HasMoreDestinations: BooleanObject;            
+        }
+        export interface DescribeDeliveryStreamInput {
+            DeliveryStreamName: DeliveryStreamName;            
+            Limit?: DescribeDeliveryStreamInputLimit;            
+            ExclusiveStartDestinationId?: DestinationId;            
+        }
+        export interface DescribeDeliveryStreamOutput {
+            DeliveryStreamDescription: DeliveryStreamDescription;            
+        }
+        export interface DestinationDescription {
+            DestinationId: DestinationId;            
+            S3DestinationDescription?: S3DestinationDescription;            
+            RedshiftDestinationDescription?: RedshiftDestinationDescription;            
+        }
+        export interface EncryptionConfiguration {
+            NoEncryptionConfig?: NoEncryptionConfig;            
+            KMSEncryptionConfig?: KMSEncryptionConfig;            
+        }
+        export interface InvalidArgumentException {
+            message?: ErrorMessage;            
+        }
+        export interface KMSEncryptionConfig {
+            AWSKMSKeyARN: AWSKMSKeyARN;            
+        }
+        export interface LimitExceededException {
+            message?: ErrorMessage;            
+        }
+        export interface ListDeliveryStreamsInput {
+            Limit?: ListDeliveryStreamsInputLimit;            
+            ExclusiveStartDeliveryStreamName?: DeliveryStreamName;            
+        }
+        export interface ListDeliveryStreamsOutput {
+            DeliveryStreamNames: DeliveryStreamNameList;            
+            HasMoreDeliveryStreams: BooleanObject;            
+        }
+        export interface PutRecordBatchInput {
+            DeliveryStreamName: DeliveryStreamName;            
+            Records: PutRecordBatchRequestEntryList;            
+        }
+        export interface PutRecordBatchOutput {
+            FailedPutCount: NonNegativeIntegerObject;            
+            RequestResponses: PutRecordBatchResponseEntryList;            
+        }
+        export interface PutRecordBatchResponseEntry {
+            RecordId?: PutResponseRecordId;            
+            ErrorCode?: ErrorCode;            
+            ErrorMessage?: ErrorMessage;            
+        }
+        export interface PutRecordInput {
+            DeliveryStreamName: DeliveryStreamName;            
+            Record: Record;            
+        }
+        export interface PutRecordOutput {
+            RecordId: PutResponseRecordId;            
+        }
+        export interface Record {
+            Data: Data;            
+        }
+        export interface RedshiftDestinationConfiguration {
+            RoleARN: RoleARN;            
+            ClusterJDBCURL: ClusterJDBCURL;            
+            CopyCommand: CopyCommand;            
+            Username: Username;            
+            Password: Password;            
+            S3Configuration: S3DestinationConfiguration;            
+        }
+        export interface RedshiftDestinationDescription {
+            RoleARN: RoleARN;            
+            ClusterJDBCURL: ClusterJDBCURL;            
+            CopyCommand: CopyCommand;            
+            Username: Username;            
+            S3DestinationDescription: S3DestinationDescription;            
+        }
+        export interface RedshiftDestinationUpdate {
+            RoleARN?: RoleARN;            
+            ClusterJDBCURL?: ClusterJDBCURL;            
+            CopyCommand?: CopyCommand;            
+            Username?: Username;            
+            Password?: Password;            
+            S3Update?: S3DestinationUpdate;            
+        }
+        export interface ResourceInUseException {
+            message?: ErrorMessage;            
+        }
+        export interface ResourceNotFoundException {
+            message?: ErrorMessage;            
+        }
+        export interface S3DestinationConfiguration {
+            RoleARN: RoleARN;            
+            BucketARN: BucketARN;            
+            Prefix?: Prefix;            
+            BufferingHints?: BufferingHints;            
+            CompressionFormat?: CompressionFormat;            
+            EncryptionConfiguration?: EncryptionConfiguration;            
+        }
+        export interface S3DestinationDescription {
+            RoleARN: RoleARN;            
+            BucketARN: BucketARN;            
+            Prefix?: Prefix;            
+            BufferingHints: BufferingHints;            
+            CompressionFormat: CompressionFormat;            
+            EncryptionConfiguration: EncryptionConfiguration;            
+        }
+        export interface S3DestinationUpdate {
+            RoleARN?: RoleARN;            
+            BucketARN?: BucketARN;            
+            Prefix?: Prefix;            
+            BufferingHints?: BufferingHints;            
+            CompressionFormat?: CompressionFormat;            
+            EncryptionConfiguration?: EncryptionConfiguration;            
+        }
+        export interface ServiceUnavailableException {
+            message?: ErrorMessage;            
+        }
+        export interface UpdateDestinationInput {
+            DeliveryStreamName: DeliveryStreamName;            
+            CurrentDeliveryStreamVersionId: DeliveryStreamVersionId;            
+            DestinationId: DestinationId;            
+            S3DestinationUpdate?: S3DestinationUpdate;            
+            RedshiftDestinationUpdate?: RedshiftDestinationUpdate;            
+        }
+        export interface UpdateDestinationOutput {
+        }
+
     }
-
-    export type FirehoseClusterJDBCURL = string; // pattern: "jdbc:(redshift|postgresql)://((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+redshift\.amazonaws\.com:\d{1,5}/[a-zA-Z0-9_$]+"
-    export type FirehoseCompressionFormat = string;
-    export interface FirehoseConcurrentModificationException {
-        message?: FirehoseErrorMessage;
-    }
-
-    export interface FirehoseCopyCommand {
-        DataTableName: FirehoseDataTableName;
-        DataTableColumns?: FirehoseDataTableColumns;
-        CopyOptions?: FirehoseCopyOptions;
-    }
-
-    export type FirehoseCopyOptions = string;
-    export interface FirehoseCreateDeliveryStreamInput {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-        S3DestinationConfiguration?: FirehoseS3DestinationConfiguration;
-        RedshiftDestinationConfiguration?: FirehoseRedshiftDestinationConfiguration;
-    }
-
-    export interface FirehoseCreateDeliveryStreamOutput {
-        DeliveryStreamARN?: FirehoseDeliveryStreamARN;
-    }
-
-    export type FirehoseData = any; // not really - it was 'blob' instead - must fix this one
-    export type FirehoseDataTableColumns = string;
-    export type FirehoseDataTableName = string;
-    export interface FirehoseDeleteDeliveryStreamInput {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-    }
-
-    export interface FirehoseDeleteDeliveryStreamOutput {
-    }
-
-    export type FirehoseDeliveryStreamARN = string;
-    export interface FirehoseDeliveryStreamDescription {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-        DeliveryStreamARN: FirehoseDeliveryStreamARN;
-        DeliveryStreamStatus: FirehoseDeliveryStreamStatus;
-        VersionId: FirehoseDeliveryStreamVersionId;
-        CreateTimestamp?: FirehoseTimestamp;
-        LastUpdateTimestamp?: FirehoseTimestamp;
-        Destinations: FirehoseDestinationDescriptionList;
-        HasMoreDestinations: FirehoseBooleanObject;
-    }
-
-    export type FirehoseDeliveryStreamName = string; // pattern: "[a-zA-Z0-9_.-]+"
-    export type FirehoseDeliveryStreamNameList = Array<FirehoseDeliveryStreamName>;
-    export type FirehoseDeliveryStreamStatus = string;
-    export type FirehoseDeliveryStreamVersionId = string; // pattern: "[0-9]+"
-    export interface FirehoseDescribeDeliveryStreamInput {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-        Limit?: FirehoseDescribeDeliveryStreamInputLimit;
-        ExclusiveStartDestinationId?: FirehoseDestinationId;
-    }
-
-    export type FirehoseDescribeDeliveryStreamInputLimit = number;
-    export interface FirehoseDescribeDeliveryStreamOutput {
-        DeliveryStreamDescription: FirehoseDeliveryStreamDescription;
-    }
-
-    export interface FirehoseDestinationDescription {
-        DestinationId: FirehoseDestinationId;
-        S3DestinationDescription?: FirehoseS3DestinationDescription;
-        RedshiftDestinationDescription?: FirehoseRedshiftDestinationDescription;
-    }
-
-    export type FirehoseDestinationDescriptionList = Array<FirehoseDestinationDescription>;
-    export type FirehoseDestinationId = string;
-    export interface FirehoseEncryptionConfiguration {
-        NoEncryptionConfig?: FirehoseNoEncryptionConfig;
-        KMSEncryptionConfig?: FirehoseKMSEncryptionConfig;
-    }
-
-    export type FirehoseErrorCode = string;
-    export type FirehoseErrorMessage = string;
-    export type FirehoseIntervalInSeconds = number;
-    export interface FirehoseInvalidArgumentException {
-        message?: FirehoseErrorMessage;
-    }
-
-    export interface FirehoseKMSEncryptionConfig {
-        AWSKMSKeyARN: FirehoseAWSKMSKeyARN;
-    }
-
-    export interface FirehoseLimitExceededException {
-        message?: FirehoseErrorMessage;
-    }
-
-    export interface FirehoseListDeliveryStreamsInput {
-        Limit?: FirehoseListDeliveryStreamsInputLimit;
-        ExclusiveStartDeliveryStreamName?: FirehoseDeliveryStreamName;
-    }
-
-    export type FirehoseListDeliveryStreamsInputLimit = number;
-    export interface FirehoseListDeliveryStreamsOutput {
-        DeliveryStreamNames: FirehoseDeliveryStreamNameList;
-        HasMoreDeliveryStreams: FirehoseBooleanObject;
-    }
-
-    export type FirehoseNoEncryptionConfig = string;
-    export type FirehoseNonNegativeIntegerObject = number;
-    export type FirehosePassword = string;
-    export type FirehosePrefix = string;
-    export interface FirehosePutRecordBatchInput {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-        Records: FirehosePutRecordBatchRequestEntryList;
-    }
-
-    export interface FirehosePutRecordBatchOutput {
-        FailedPutCount: FirehoseNonNegativeIntegerObject;
-        RequestResponses: FirehosePutRecordBatchResponseEntryList;
-    }
-
-    export type FirehosePutRecordBatchRequestEntryList = Array<FirehoseRecord>; // max: 500
-    export interface FirehosePutRecordBatchResponseEntry {
-        RecordId?: FirehosePutResponseRecordId;
-        ErrorCode?: FirehoseErrorCode;
-        ErrorMessage?: FirehoseErrorMessage;
-    }
-
-    export type FirehosePutRecordBatchResponseEntryList = Array<FirehosePutRecordBatchResponseEntry>; // max: 500
-    export interface FirehosePutRecordInput {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-        Record: FirehoseRecord;
-    }
-
-    export interface FirehosePutRecordOutput {
-        RecordId: FirehosePutResponseRecordId;
-    }
-
-    export type FirehosePutResponseRecordId = string;
-    export interface FirehoseRecord {
-        Data: FirehoseData;
-    }
-
-    export interface FirehoseRedshiftDestinationConfiguration {
-        RoleARN: FirehoseRoleARN;
-        ClusterJDBCURL: FirehoseClusterJDBCURL;
-        CopyCommand: FirehoseCopyCommand;
-        Username: FirehoseUsername;
-        Password: FirehosePassword;
-        S3Configuration: FirehoseS3DestinationConfiguration;
-    }
-
-    export interface FirehoseRedshiftDestinationDescription {
-        RoleARN: FirehoseRoleARN;
-        ClusterJDBCURL: FirehoseClusterJDBCURL;
-        CopyCommand: FirehoseCopyCommand;
-        Username: FirehoseUsername;
-        S3DestinationDescription: FirehoseS3DestinationDescription;
-    }
-
-    export interface FirehoseRedshiftDestinationUpdate {
-        RoleARN?: FirehoseRoleARN;
-        ClusterJDBCURL?: FirehoseClusterJDBCURL;
-        CopyCommand?: FirehoseCopyCommand;
-        Username?: FirehoseUsername;
-        Password?: FirehosePassword;
-        S3Update?: FirehoseS3DestinationUpdate;
-    }
-
-    export interface FirehoseResourceInUseException {
-        message?: FirehoseErrorMessage;
-    }
-
-    export interface FirehoseResourceNotFoundException {
-        message?: FirehoseErrorMessage;
-    }
-
-    export type FirehoseRoleARN = string; // pattern: "arn:.*"
-    export interface FirehoseS3DestinationConfiguration {
-        RoleARN: FirehoseRoleARN;
-        BucketARN: FirehoseBucketARN;
-        Prefix?: FirehosePrefix;
-        BufferingHints?: FirehoseBufferingHints;
-        CompressionFormat?: FirehoseCompressionFormat;
-        EncryptionConfiguration?: FirehoseEncryptionConfiguration;
-    }
-
-    export interface FirehoseS3DestinationDescription {
-        RoleARN: FirehoseRoleARN;
-        BucketARN: FirehoseBucketARN;
-        Prefix?: FirehosePrefix;
-        BufferingHints: FirehoseBufferingHints;
-        CompressionFormat: FirehoseCompressionFormat;
-        EncryptionConfiguration: FirehoseEncryptionConfiguration;
-    }
-
-    export interface FirehoseS3DestinationUpdate {
-        RoleARN?: FirehoseRoleARN;
-        BucketARN?: FirehoseBucketARN;
-        Prefix?: FirehosePrefix;
-        BufferingHints?: FirehoseBufferingHints;
-        CompressionFormat?: FirehoseCompressionFormat;
-        EncryptionConfiguration?: FirehoseEncryptionConfiguration;
-    }
-
-    export interface FirehoseServiceUnavailableException {
-        message?: FirehoseErrorMessage;
-    }
-
-    export type FirehoseSizeInMBs = number;
-    export type FirehoseTimestamp = number;
-    export interface FirehoseUpdateDestinationInput {
-        DeliveryStreamName: FirehoseDeliveryStreamName;
-        CurrentDeliveryStreamVersionId: FirehoseDeliveryStreamVersionId;
-        DestinationId: FirehoseDestinationId;
-        S3DestinationUpdate?: FirehoseS3DestinationUpdate;
-        RedshiftDestinationUpdate?: FirehoseRedshiftDestinationUpdate;
-    }
-
-    export interface FirehoseUpdateDestinationOutput {
-    }
-
-    export type FirehoseUsername = string;
 }

--- a/output/aws-glacier.d.ts
+++ b/output/aws-glacier.d.ts
@@ -6,462 +6,398 @@ declare module "aws-sdk" {
 
     export class Glacier extends Service {
       constructor(options?: any);
-      abortMultipartUpload(params: GlacierAbortMultipartUploadInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      abortVaultLock(params: GlacierAbortVaultLockInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      addTagsToVault(params: GlacierAddTagsToVaultInput, callback?: (err: GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierResourceNotFoundException|GlacierLimitExceededException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      completeMultipartUpload(params: GlacierCompleteMultipartUploadInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierArchiveCreationOutput|any) => void): Request;
-      completeVaultLock(params: GlacierCompleteVaultLockInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      createVault(params: GlacierCreateVaultInput, callback?: (err: GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|GlacierLimitExceededException|any, data: GlacierCreateVaultOutput|any) => void): Request;
-      deleteArchive(params: GlacierDeleteArchiveInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      deleteVault(params: GlacierDeleteVaultInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      deleteVaultAccessPolicy(params: GlacierDeleteVaultAccessPolicyInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      deleteVaultNotifications(params: GlacierDeleteVaultNotificationsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      describeJob(params: GlacierDescribeJobInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierGlacierJobDescription|any) => void): Request;
-      describeVault(params: GlacierDescribeVaultInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierDescribeVaultOutput|any) => void): Request;
-      getDataRetrievalPolicy(params: GlacierGetDataRetrievalPolicyInput, callback?: (err: GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierGetDataRetrievalPolicyOutput|any) => void): Request;
-      getJobOutput(params: GlacierGetJobOutputInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierGetJobOutputOutput|any) => void): Request;
-      getVaultAccessPolicy(params: GlacierGetVaultAccessPolicyInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierGetVaultAccessPolicyOutput|any) => void): Request;
-      getVaultLock(params: GlacierGetVaultLockInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierGetVaultLockOutput|any) => void): Request;
-      getVaultNotifications(params: GlacierGetVaultNotificationsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierGetVaultNotificationsOutput|any) => void): Request;
-      initiateJob(params: GlacierInitiateJobInput, callback?: (err: GlacierResourceNotFoundException|GlacierPolicyEnforcedException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierInitiateJobOutput|any) => void): Request;
-      initiateMultipartUpload(params: GlacierInitiateMultipartUploadInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierInitiateMultipartUploadOutput|any) => void): Request;
-      initiateVaultLock(params: GlacierInitiateVaultLockInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierInitiateVaultLockOutput|any) => void): Request;
-      listJobs(params: GlacierListJobsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierListJobsOutput|any) => void): Request;
-      listMultipartUploads(params: GlacierListMultipartUploadsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierListMultipartUploadsOutput|any) => void): Request;
-      listParts(params: GlacierListPartsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierListPartsOutput|any) => void): Request;
-      listTagsForVault(params: GlacierListTagsForVaultInput, callback?: (err: GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierResourceNotFoundException|GlacierServiceUnavailableException|any, data: GlacierListTagsForVaultOutput|any) => void): Request;
-      listVaults(params: GlacierListVaultsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: GlacierListVaultsOutput|any) => void): Request;
-      removeTagsFromVault(params: GlacierRemoveTagsFromVaultInput, callback?: (err: GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierResourceNotFoundException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      setDataRetrievalPolicy(params: GlacierSetDataRetrievalPolicyInput, callback?: (err: GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      setVaultAccessPolicy(params: GlacierSetVaultAccessPolicyInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      setVaultNotifications(params: GlacierSetVaultNotificationsInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierServiceUnavailableException|any, data: any) => void): Request;
-      uploadArchive(params: GlacierUploadArchiveInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierRequestTimeoutException|GlacierServiceUnavailableException|any, data: GlacierArchiveCreationOutput|any) => void): Request;
-      uploadMultipartPart(params: GlacierUploadMultipartPartInput, callback?: (err: GlacierResourceNotFoundException|GlacierInvalidParameterValueException|GlacierMissingParameterValueException|GlacierRequestTimeoutException|GlacierServiceUnavailableException|any, data: GlacierUploadMultipartPartOutput|any) => void): Request;
-    }
-
-    export interface GlacierAbortMultipartUploadInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        uploadId: Glacierstring;
-    }
-
-    export interface GlacierAbortVaultLockInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export type GlacierActionCode = string;
-    export interface GlacierAddTagsToVaultInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        Tags?: GlacierTagMap;
-    }
-
-    export interface GlacierArchiveCreationOutput {
-        location?: Glacierstring;
-        checksum?: Glacierstring;
-        archiveId?: Glacierstring;
-    }
-
-    export interface GlacierCompleteMultipartUploadInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        uploadId: Glacierstring;
-        archiveSize?: Glacierstring;
-        checksum?: Glacierstring;
-    }
-
-    export interface GlacierCompleteVaultLockInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        lockId: Glacierstring;
-    }
-
-    export interface GlacierCreateVaultInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierCreateVaultOutput {
-        location?: Glacierstring;
-    }
-
-    export interface GlacierDataRetrievalPolicy {
-        Rules?: GlacierDataRetrievalRulesList;
-    }
-
-    export interface GlacierDataRetrievalRule {
-        Strategy?: Glacierstring;
-        BytesPerHour?: GlacierNullableLong;
-    }
-
-    export type GlacierDataRetrievalRulesList = Array<GlacierDataRetrievalRule>;
-    export type GlacierDateTime = string;
-    export interface GlacierDeleteArchiveInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        archiveId: Glacierstring;
-    }
-
-    export interface GlacierDeleteVaultAccessPolicyInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierDeleteVaultInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierDeleteVaultNotificationsInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierDescribeJobInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        jobId: Glacierstring;
-    }
-
-    export interface GlacierDescribeVaultInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierDescribeVaultOutput {
-        VaultARN?: Glacierstring;
-        VaultName?: Glacierstring;
-        CreationDate?: Glacierstring;
-        LastInventoryDate?: Glacierstring;
-        NumberOfArchives?: Glacierlong;
-        SizeInBytes?: Glacierlong;
-    }
-
-    export interface GlacierGetDataRetrievalPolicyInput {
-        accountId: Glacierstring;
-    }
-
-    export interface GlacierGetDataRetrievalPolicyOutput {
-        Policy?: GlacierDataRetrievalPolicy;
-    }
-
-    export interface GlacierGetJobOutputInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        jobId: Glacierstring;
-        range?: Glacierstring;
-    }
-
-    export interface GlacierGetJobOutputOutput {
-        body?: GlacierStream;
-        checksum?: Glacierstring;
-        status?: Glacierhttpstatus;
-        contentRange?: Glacierstring;
-        acceptRanges?: Glacierstring;
-        contentType?: Glacierstring;
-        archiveDescription?: Glacierstring;
-    }
-
-    export interface GlacierGetVaultAccessPolicyInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierGetVaultAccessPolicyOutput {
-        policy?: GlacierVaultAccessPolicy;
-    }
-
-    export interface GlacierGetVaultLockInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierGetVaultLockOutput {
-        Policy?: Glacierstring;
-        State?: Glacierstring;
-        ExpirationDate?: Glacierstring;
-        CreationDate?: Glacierstring;
-    }
-
-    export interface GlacierGetVaultNotificationsInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierGetVaultNotificationsOutput {
-        vaultNotificationConfig?: GlacierVaultNotificationConfig;
-    }
-
-    export interface GlacierGlacierJobDescription {
-        JobId?: Glacierstring;
-        JobDescription?: Glacierstring;
-        Action?: GlacierActionCode;
-        ArchiveId?: Glacierstring;
-        VaultARN?: Glacierstring;
-        CreationDate?: Glacierstring;
-        Completed?: Glacierboolean;
-        StatusCode?: GlacierStatusCode;
-        StatusMessage?: Glacierstring;
-        ArchiveSizeInBytes?: GlacierSize;
-        InventorySizeInBytes?: GlacierSize;
-        SNSTopic?: Glacierstring;
-        CompletionDate?: Glacierstring;
-        SHA256TreeHash?: Glacierstring;
-        ArchiveSHA256TreeHash?: Glacierstring;
-        RetrievalByteRange?: Glacierstring;
-        InventoryRetrievalParameters?: GlacierInventoryRetrievalJobDescription;
-    }
-
-    export interface GlacierInitiateJobInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        jobParameters?: GlacierJobParameters;
-    }
-
-    export interface GlacierInitiateJobOutput {
-        location?: Glacierstring;
-        jobId?: Glacierstring;
-    }
-
-    export interface GlacierInitiateMultipartUploadInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        archiveDescription?: Glacierstring;
-        partSize?: Glacierstring;
-    }
-
-    export interface GlacierInitiateMultipartUploadOutput {
-        location?: Glacierstring;
-        uploadId?: Glacierstring;
-    }
-
-    export interface GlacierInitiateVaultLockInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        policy?: GlacierVaultLockPolicy;
-    }
-
-    export interface GlacierInitiateVaultLockOutput {
-        lockId?: Glacierstring;
-    }
-
-    export interface GlacierInvalidParameterValueException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
-    }
-
-    export interface GlacierInventoryRetrievalJobDescription {
-        Format?: Glacierstring;
-        StartDate?: GlacierDateTime;
-        EndDate?: GlacierDateTime;
-        Limit?: Glacierstring;
-        Marker?: Glacierstring;
-    }
-
-    export interface GlacierInventoryRetrievalJobInput {
-        StartDate?: Glacierstring;
-        EndDate?: Glacierstring;
-        Limit?: Glacierstring;
-        Marker?: Glacierstring;
-    }
-
-    export type GlacierJobList = Array<GlacierGlacierJobDescription>;
-    export interface GlacierJobParameters {
-        Format?: Glacierstring;
-        Type?: Glacierstring;
-        ArchiveId?: Glacierstring;
-        Description?: Glacierstring;
-        SNSTopic?: Glacierstring;
-        RetrievalByteRange?: Glacierstring;
-        InventoryRetrievalParameters?: GlacierInventoryRetrievalJobInput;
-    }
-
-    export interface GlacierLimitExceededException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
-    }
-
-    export interface GlacierListJobsInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        limit?: Glacierstring;
-        marker?: Glacierstring;
-        statuscode?: Glacierstring;
-        completed?: Glacierstring;
-    }
-
-    export interface GlacierListJobsOutput {
-        JobList?: GlacierJobList;
-        Marker?: Glacierstring;
-    }
-
-    export interface GlacierListMultipartUploadsInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        marker?: Glacierstring;
-        limit?: Glacierstring;
-    }
-
-    export interface GlacierListMultipartUploadsOutput {
-        UploadsList?: GlacierUploadsList;
-        Marker?: Glacierstring;
-    }
-
-    export interface GlacierListPartsInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        uploadId: Glacierstring;
-        marker?: Glacierstring;
-        limit?: Glacierstring;
-    }
-
-    export interface GlacierListPartsOutput {
-        MultipartUploadId?: Glacierstring;
-        VaultARN?: Glacierstring;
-        ArchiveDescription?: Glacierstring;
-        PartSizeInBytes?: Glacierlong;
-        CreationDate?: Glacierstring;
-        Parts?: GlacierPartList;
-        Marker?: Glacierstring;
-    }
-
-    export interface GlacierListTagsForVaultInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-    }
-
-    export interface GlacierListTagsForVaultOutput {
-        Tags?: GlacierTagMap;
-    }
-
-    export interface GlacierListVaultsInput {
-        accountId: Glacierstring;
-        marker?: Glacierstring;
-        limit?: Glacierstring;
-    }
-
-    export interface GlacierListVaultsOutput {
-        VaultList?: GlacierVaultList;
-        Marker?: Glacierstring;
-    }
+      abortMultipartUpload(params: Glacier.AbortMultipartUploadInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      abortVaultLock(params: Glacier.AbortVaultLockInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      addTagsToVault(params: Glacier.AddTagsToVaultInput, callback?: (err: Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ResourceNotFoundException|Glacier.LimitExceededException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      completeMultipartUpload(params: Glacier.CompleteMultipartUploadInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.ArchiveCreationOutput|any) => void): Request;
+      completeVaultLock(params: Glacier.CompleteVaultLockInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      createVault(params: Glacier.CreateVaultInput, callback?: (err: Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|Glacier.LimitExceededException|any, data: Glacier.CreateVaultOutput|any) => void): Request;
+      deleteArchive(params: Glacier.DeleteArchiveInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      deleteVault(params: Glacier.DeleteVaultInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      deleteVaultAccessPolicy(params: Glacier.DeleteVaultAccessPolicyInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      deleteVaultNotifications(params: Glacier.DeleteVaultNotificationsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      describeJob(params: Glacier.DescribeJobInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.GlacierJobDescription|any) => void): Request;
+      describeVault(params: Glacier.DescribeVaultInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.DescribeVaultOutput|any) => void): Request;
+      getDataRetrievalPolicy(params: Glacier.GetDataRetrievalPolicyInput, callback?: (err: Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.GetDataRetrievalPolicyOutput|any) => void): Request;
+      getJobOutput(params: Glacier.GetJobOutputInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.GetJobOutputOutput|any) => void): Request;
+      getVaultAccessPolicy(params: Glacier.GetVaultAccessPolicyInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.GetVaultAccessPolicyOutput|any) => void): Request;
+      getVaultLock(params: Glacier.GetVaultLockInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.GetVaultLockOutput|any) => void): Request;
+      getVaultNotifications(params: Glacier.GetVaultNotificationsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.GetVaultNotificationsOutput|any) => void): Request;
+      initiateJob(params: Glacier.InitiateJobInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.PolicyEnforcedException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.InitiateJobOutput|any) => void): Request;
+      initiateMultipartUpload(params: Glacier.InitiateMultipartUploadInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.InitiateMultipartUploadOutput|any) => void): Request;
+      initiateVaultLock(params: Glacier.InitiateVaultLockInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.InitiateVaultLockOutput|any) => void): Request;
+      listJobs(params: Glacier.ListJobsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.ListJobsOutput|any) => void): Request;
+      listMultipartUploads(params: Glacier.ListMultipartUploadsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.ListMultipartUploadsOutput|any) => void): Request;
+      listParts(params: Glacier.ListPartsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.ListPartsOutput|any) => void): Request;
+      listTagsForVault(params: Glacier.ListTagsForVaultInput, callback?: (err: Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ResourceNotFoundException|Glacier.ServiceUnavailableException|any, data: Glacier.ListTagsForVaultOutput|any) => void): Request;
+      listVaults(params: Glacier.ListVaultsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: Glacier.ListVaultsOutput|any) => void): Request;
+      removeTagsFromVault(params: Glacier.RemoveTagsFromVaultInput, callback?: (err: Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ResourceNotFoundException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      setDataRetrievalPolicy(params: Glacier.SetDataRetrievalPolicyInput, callback?: (err: Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      setVaultAccessPolicy(params: Glacier.SetVaultAccessPolicyInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      setVaultNotifications(params: Glacier.SetVaultNotificationsInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.ServiceUnavailableException|any, data: any) => void): Request;
+      uploadArchive(params: Glacier.UploadArchiveInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.RequestTimeoutException|Glacier.ServiceUnavailableException|any, data: Glacier.ArchiveCreationOutput|any) => void): Request;
+      uploadMultipartPart(params: Glacier.UploadMultipartPartInput, callback?: (err: Glacier.ResourceNotFoundException|Glacier.InvalidParameterValueException|Glacier.MissingParameterValueException|Glacier.RequestTimeoutException|Glacier.ServiceUnavailableException|any, data: Glacier.UploadMultipartPartOutput|any) => void): Request;
+    }
+    
+    export module Glacier {
+        export type ActionCode = string;
+        export type DataRetrievalRulesList = DataRetrievalRule[];
+        export type DateTime = string;
+        export type JobList = GlacierJobDescription[];
+        export type NotificationEventList = string[];
+        export type NullableLong = number;
+        export type PartList = PartListElement[];
+        export type Size = number;
+        export type StatusCode = string;
+        export type Stream = any;    // type: blob
+        export type TagKey = string;
+        export type TagKeyList = string[];
+        export type TagMap = {[key:string]: TagValue};
+        export type TagValue = string;
+        export type UploadsList = UploadListElement[];
+        export type VaultList = DescribeVaultOutput[];
+        export type httpstatus = number;
+        export type long = number;
+
+        export interface AbortMultipartUploadInput {
+            accountId: string;            
+            vaultName: string;            
+            uploadId: string;            
+        }
+        export interface AbortVaultLockInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface AddTagsToVaultInput {
+            accountId: string;            
+            vaultName: string;            
+            Tags?: TagMap;            
+        }
+        export interface ArchiveCreationOutput {
+            location?: string;            
+            checksum?: string;            
+            archiveId?: string;            
+        }
+        export interface CompleteMultipartUploadInput {
+            accountId: string;            
+            vaultName: string;            
+            uploadId: string;            
+            archiveSize?: string;            
+            checksum?: string;            
+        }
+        export interface CompleteVaultLockInput {
+            accountId: string;            
+            vaultName: string;            
+            lockId: string;            
+        }
+        export interface CreateVaultInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface CreateVaultOutput {
+            location?: string;            
+        }
+        export interface DataRetrievalPolicy {
+            Rules?: DataRetrievalRulesList;            
+        }
+        export interface DataRetrievalRule {
+            Strategy?: string;            
+            BytesPerHour?: NullableLong;            
+        }
+        export interface DeleteArchiveInput {
+            accountId: string;            
+            vaultName: string;            
+            archiveId: string;            
+        }
+        export interface DeleteVaultAccessPolicyInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface DeleteVaultInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface DeleteVaultNotificationsInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface DescribeJobInput {
+            accountId: string;            
+            vaultName: string;            
+            jobId: string;            
+        }
+        export interface DescribeVaultInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface DescribeVaultOutput {
+            VaultARN?: string;            
+            VaultName?: string;            
+            CreationDate?: string;            
+            LastInventoryDate?: string;            
+            NumberOfArchives?: long;            
+            SizeInBytes?: long;            
+        }
+        export interface GetDataRetrievalPolicyInput {
+            accountId: string;            
+        }
+        export interface GetDataRetrievalPolicyOutput {
+            Policy?: DataRetrievalPolicy;            
+        }
+        export interface GetJobOutputInput {
+            accountId: string;            
+            vaultName: string;            
+            jobId: string;            
+            range?: string;            
+        }
+        export interface GetJobOutputOutput {
+            body?: Stream;            
+            checksum?: string;            
+            status?: httpstatus;            
+            contentRange?: string;            
+            acceptRanges?: string;            
+            contentType?: string;            
+            archiveDescription?: string;            
+        }
+        export interface GetVaultAccessPolicyInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface GetVaultAccessPolicyOutput {
+            policy?: VaultAccessPolicy;            
+        }
+        export interface GetVaultLockInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface GetVaultLockOutput {
+            Policy?: string;            
+            State?: string;            
+            ExpirationDate?: string;            
+            CreationDate?: string;            
+        }
+        export interface GetVaultNotificationsInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface GetVaultNotificationsOutput {
+            vaultNotificationConfig?: VaultNotificationConfig;            
+        }
+        export interface GlacierJobDescription {
+            JobId?: string;            
+            JobDescription?: string;            
+            Action?: ActionCode;            
+            ArchiveId?: string;            
+            VaultARN?: string;            
+            CreationDate?: string;            
+            Completed?: boolean;            
+            StatusCode?: StatusCode;            
+            StatusMessage?: string;            
+            ArchiveSizeInBytes?: Size;            
+            InventorySizeInBytes?: Size;            
+            SNSTopic?: string;            
+            CompletionDate?: string;            
+            SHA256TreeHash?: string;            
+            ArchiveSHA256TreeHash?: string;            
+            RetrievalByteRange?: string;            
+            InventoryRetrievalParameters?: InventoryRetrievalJobDescription;            
+        }
+        export interface InitiateJobInput {
+            accountId: string;            
+            vaultName: string;            
+            jobParameters?: JobParameters;            
+        }
+        export interface InitiateJobOutput {
+            location?: string;            
+            jobId?: string;            
+        }
+        export interface InitiateMultipartUploadInput {
+            accountId: string;            
+            vaultName: string;            
+            archiveDescription?: string;            
+            partSize?: string;            
+        }
+        export interface InitiateMultipartUploadOutput {
+            location?: string;            
+            uploadId?: string;            
+        }
+        export interface InitiateVaultLockInput {
+            accountId: string;            
+            vaultName: string;            
+            policy?: VaultLockPolicy;            
+        }
+        export interface InitiateVaultLockOutput {
+            lockId?: string;            
+        }
+        export interface InvalidParameterValueException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface InventoryRetrievalJobDescription {
+            Format?: string;            
+            StartDate?: DateTime;            
+            EndDate?: DateTime;            
+            Limit?: string;            
+            Marker?: string;            
+        }
+        export interface InventoryRetrievalJobInput {
+            StartDate?: string;            
+            EndDate?: string;            
+            Limit?: string;            
+            Marker?: string;            
+        }
+        export interface JobParameters {
+            Format?: string;            
+            Type?: string;            
+            ArchiveId?: string;            
+            Description?: string;            
+            SNSTopic?: string;            
+            RetrievalByteRange?: string;            
+            InventoryRetrievalParameters?: InventoryRetrievalJobInput;            
+        }
+        export interface LimitExceededException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface ListJobsInput {
+            accountId: string;            
+            vaultName: string;            
+            limit?: string;            
+            marker?: string;            
+            statuscode?: string;            
+            completed?: string;            
+        }
+        export interface ListJobsOutput {
+            JobList?: JobList;            
+            Marker?: string;            
+        }
+        export interface ListMultipartUploadsInput {
+            accountId: string;            
+            vaultName: string;            
+            marker?: string;            
+            limit?: string;            
+        }
+        export interface ListMultipartUploadsOutput {
+            UploadsList?: UploadsList;            
+            Marker?: string;            
+        }
+        export interface ListPartsInput {
+            accountId: string;            
+            vaultName: string;            
+            uploadId: string;            
+            marker?: string;            
+            limit?: string;            
+        }
+        export interface ListPartsOutput {
+            MultipartUploadId?: string;            
+            VaultARN?: string;            
+            ArchiveDescription?: string;            
+            PartSizeInBytes?: long;            
+            CreationDate?: string;            
+            Parts?: PartList;            
+            Marker?: string;            
+        }
+        export interface ListTagsForVaultInput {
+            accountId: string;            
+            vaultName: string;            
+        }
+        export interface ListTagsForVaultOutput {
+            Tags?: TagMap;            
+        }
+        export interface ListVaultsInput {
+            accountId: string;            
+            marker?: string;            
+            limit?: string;            
+        }
+        export interface ListVaultsOutput {
+            VaultList?: VaultList;            
+            Marker?: string;            
+        }
+        export interface MissingParameterValueException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface PartListElement {
+            RangeInBytes?: string;            
+            SHA256TreeHash?: string;            
+        }
+        export interface PolicyEnforcedException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface RemoveTagsFromVaultInput {
+            accountId: string;            
+            vaultName: string;            
+            TagKeys?: TagKeyList;            
+        }
+        export interface RequestTimeoutException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface ResourceNotFoundException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface ServiceUnavailableException {
+            type?: string;            
+            code?: string;            
+            message?: string;            
+        }
+        export interface SetDataRetrievalPolicyInput {
+            accountId: string;            
+            Policy?: DataRetrievalPolicy;            
+        }
+        export interface SetVaultAccessPolicyInput {
+            accountId: string;            
+            vaultName: string;            
+            policy?: VaultAccessPolicy;            
+        }
+        export interface SetVaultNotificationsInput {
+            accountId: string;            
+            vaultName: string;            
+            vaultNotificationConfig?: VaultNotificationConfig;            
+        }
+        export interface UploadArchiveInput {
+            vaultName: string;            
+            accountId: string;            
+            archiveDescription?: string;            
+            checksum?: string;            
+            body?: Stream;            
+        }
+        export interface UploadListElement {
+            MultipartUploadId?: string;            
+            VaultARN?: string;            
+            ArchiveDescription?: string;            
+            PartSizeInBytes?: long;            
+            CreationDate?: string;            
+        }
+        export interface UploadMultipartPartInput {
+            accountId: string;            
+            vaultName: string;            
+            uploadId: string;            
+            checksum?: string;            
+            range?: string;            
+            body?: Stream;            
+        }
+        export interface UploadMultipartPartOutput {
+            checksum?: string;            
+        }
+        export interface VaultAccessPolicy {
+            Policy?: string;            
+        }
+        export interface VaultLockPolicy {
+            Policy?: string;            
+        }
+        export interface VaultNotificationConfig {
+            SNSTopic?: string;            
+            Events?: NotificationEventList;            
+        }
 
-    export interface GlacierMissingParameterValueException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
     }
-
-    export type GlacierNotificationEventList = Array<Glacierstring>;
-    export type GlacierNullableLong = number;
-    export type GlacierPartList = Array<GlacierPartListElement>;
-    export interface GlacierPartListElement {
-        RangeInBytes?: Glacierstring;
-        SHA256TreeHash?: Glacierstring;
-    }
-
-    export interface GlacierPolicyEnforcedException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
-    }
-
-    export interface GlacierRemoveTagsFromVaultInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        TagKeys?: GlacierTagKeyList;
-    }
-
-    export interface GlacierRequestTimeoutException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
-    }
-
-    export interface GlacierResourceNotFoundException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
-    }
-
-    export interface GlacierServiceUnavailableException {
-        type?: Glacierstring;
-        code?: Glacierstring;
-        message?: Glacierstring;
-    }
-
-    export interface GlacierSetDataRetrievalPolicyInput {
-        accountId: Glacierstring;
-        Policy?: GlacierDataRetrievalPolicy;
-    }
-
-    export interface GlacierSetVaultAccessPolicyInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        policy?: GlacierVaultAccessPolicy;
-    }
-
-    export interface GlacierSetVaultNotificationsInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        vaultNotificationConfig?: GlacierVaultNotificationConfig;
-    }
-
-    export type GlacierSize = number;
-    export type GlacierStatusCode = string;
-    export type GlacierStream = any; // not really - it was 'blob' instead - must fix this one
-    export type GlacierTagKey = string;
-    export type GlacierTagKeyList = Array<Glacierstring>;
-    export type GlacierTagMap = any; // not really - it was 'map' instead - must fix this one
-    export type GlacierTagValue = string;
-    export interface GlacierUploadArchiveInput {
-        vaultName: Glacierstring;
-        accountId: Glacierstring;
-        archiveDescription?: Glacierstring;
-        checksum?: Glacierstring;
-        body?: GlacierStream;
-    }
-
-    export interface GlacierUploadListElement {
-        MultipartUploadId?: Glacierstring;
-        VaultARN?: Glacierstring;
-        ArchiveDescription?: Glacierstring;
-        PartSizeInBytes?: Glacierlong;
-        CreationDate?: Glacierstring;
-    }
-
-    export interface GlacierUploadMultipartPartInput {
-        accountId: Glacierstring;
-        vaultName: Glacierstring;
-        uploadId: Glacierstring;
-        checksum?: Glacierstring;
-        range?: Glacierstring;
-        body?: GlacierStream;
-    }
-
-    export interface GlacierUploadMultipartPartOutput {
-        checksum?: Glacierstring;
-    }
-
-    export type GlacierUploadsList = Array<GlacierUploadListElement>;
-    export interface GlacierVaultAccessPolicy {
-        Policy?: Glacierstring;
-    }
-
-    export type GlacierVaultList = Array<GlacierDescribeVaultOutput>;
-    export interface GlacierVaultLockPolicy {
-        Policy?: Glacierstring;
-    }
-
-    export interface GlacierVaultNotificationConfig {
-        SNSTopic?: Glacierstring;
-        Events?: GlacierNotificationEventList;
-    }
-
-    export type Glacierboolean = boolean;
-    export type Glacierhttpstatus = number;
-    export type Glacierlong = number;
-    export type Glacierstring = string;
 }

--- a/output/aws-iam.d.ts
+++ b/output/aws-iam.d.ts
@@ -6,1506 +6,1285 @@ declare module "aws-sdk" {
 
     export class IAM extends Service {
       constructor(options?: any);
-      addClientIDToOpenIDConnectProvider(params: IAMAddClientIDToOpenIDConnectProviderRequest, callback?: (err: IAMInvalidInputException|IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      addRoleToInstanceProfile(params: IAMAddRoleToInstanceProfileRequest, callback?: (err: IAMNoSuchEntityException|IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      addUserToGroup(params: IAMAddUserToGroupRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      attachGroupPolicy(params: IAMAttachGroupPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMServiceFailureException|any, data: any) => void): Request;
-      attachRolePolicy(params: IAMAttachRolePolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMServiceFailureException|any, data: any) => void): Request;
-      attachUserPolicy(params: IAMAttachUserPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMServiceFailureException|any, data: any) => void): Request;
-      changePassword(params: IAMChangePasswordRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidUserTypeException|IAMLimitExceededException|IAMEntityTemporarilyUnmodifiableException|IAMPasswordPolicyViolationException|IAMServiceFailureException|any, data: any) => void): Request;
-      createAccessKey(params: IAMCreateAccessKeyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMCreateAccessKeyResponse|any) => void): Request;
-      createAccountAlias(params: IAMCreateAccountAliasRequest, callback?: (err: IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      createGroup(params: IAMCreateGroupRequest, callback?: (err: IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMCreateGroupResponse|any) => void): Request;
-      createInstanceProfile(params: IAMCreateInstanceProfileRequest, callback?: (err: IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMCreateInstanceProfileResponse|any) => void): Request;
-      createLoginProfile(params: IAMCreateLoginProfileRequest, callback?: (err: IAMEntityAlreadyExistsException|IAMNoSuchEntityException|IAMPasswordPolicyViolationException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMCreateLoginProfileResponse|any) => void): Request;
-      createOpenIDConnectProvider(params: IAMCreateOpenIDConnectProviderRequest, callback?: (err: IAMInvalidInputException|IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMCreateOpenIDConnectProviderResponse|any) => void): Request;
-      createPolicy(params: IAMCreatePolicyRequest, callback?: (err: IAMInvalidInputException|IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMMalformedPolicyDocumentException|IAMServiceFailureException|any, data: IAMCreatePolicyResponse|any) => void): Request;
-      createPolicyVersion(params: IAMCreatePolicyVersionRequest, callback?: (err: IAMNoSuchEntityException|IAMMalformedPolicyDocumentException|IAMInvalidInputException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMCreatePolicyVersionResponse|any) => void): Request;
-      createRole(params: IAMCreateRoleRequest, callback?: (err: IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMMalformedPolicyDocumentException|IAMServiceFailureException|any, data: IAMCreateRoleResponse|any) => void): Request;
-      createSAMLProvider(params: IAMCreateSAMLProviderRequest, callback?: (err: IAMInvalidInputException|IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMCreateSAMLProviderResponse|any) => void): Request;
-      createUser(params: IAMCreateUserRequest, callback?: (err: IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMCreateUserResponse|any) => void): Request;
-      createVirtualMFADevice(params: IAMCreateVirtualMFADeviceRequest, callback?: (err: IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMServiceFailureException|any, data: IAMCreateVirtualMFADeviceResponse|any) => void): Request;
-      deactivateMFADevice(params: IAMDeactivateMFADeviceRequest, callback?: (err: IAMEntityTemporarilyUnmodifiableException|IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteAccessKey(params: IAMDeleteAccessKeyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteAccountAlias(params: IAMDeleteAccountAliasRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteAccountPasswordPolicy(callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteGroup(params: IAMDeleteGroupRequest, callback?: (err: IAMNoSuchEntityException|IAMDeleteConflictException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteGroupPolicy(params: IAMDeleteGroupPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteInstanceProfile(params: IAMDeleteInstanceProfileRequest, callback?: (err: IAMNoSuchEntityException|IAMDeleteConflictException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteLoginProfile(params: IAMDeleteLoginProfileRequest, callback?: (err: IAMEntityTemporarilyUnmodifiableException|IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteOpenIDConnectProvider(params: IAMDeleteOpenIDConnectProviderRequest, callback?: (err: IAMInvalidInputException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      deletePolicy(params: IAMDeletePolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMDeleteConflictException|IAMServiceFailureException|any, data: any) => void): Request;
-      deletePolicyVersion(params: IAMDeletePolicyVersionRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMDeleteConflictException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteRole(params: IAMDeleteRoleRequest, callback?: (err: IAMNoSuchEntityException|IAMDeleteConflictException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteRolePolicy(params: IAMDeleteRolePolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteSAMLProvider(params: IAMDeleteSAMLProviderRequest, callback?: (err: IAMInvalidInputException|IAMLimitExceededException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteSSHPublicKey(params: IAMDeleteSSHPublicKeyRequest, callback?: (err: IAMNoSuchEntityException|any, data: any) => void): Request;
-      deleteServerCertificate(params: IAMDeleteServerCertificateRequest, callback?: (err: IAMNoSuchEntityException|IAMDeleteConflictException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteSigningCertificate(params: IAMDeleteSigningCertificateRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteUser(params: IAMDeleteUserRequest, callback?: (err: IAMLimitExceededException|IAMNoSuchEntityException|IAMDeleteConflictException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteUserPolicy(params: IAMDeleteUserPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      deleteVirtualMFADevice(params: IAMDeleteVirtualMFADeviceRequest, callback?: (err: IAMNoSuchEntityException|IAMDeleteConflictException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      detachGroupPolicy(params: IAMDetachGroupPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMServiceFailureException|any, data: any) => void): Request;
-      detachRolePolicy(params: IAMDetachRolePolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMServiceFailureException|any, data: any) => void): Request;
-      detachUserPolicy(params: IAMDetachUserPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMInvalidInputException|IAMServiceFailureException|any, data: any) => void): Request;
-      enableMFADevice(params: IAMEnableMFADeviceRequest, callback?: (err: IAMEntityAlreadyExistsException|IAMEntityTemporarilyUnmodifiableException|IAMInvalidAuthenticationCodeException|IAMLimitExceededException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      generateCredentialReport(callback?: (err: IAMLimitExceededException|IAMServiceFailureException|any, data: IAMGenerateCredentialReportResponse|any) => void): Request;
-      getAccessKeyLastUsed(params: IAMGetAccessKeyLastUsedRequest, callback?: (err: IAMNoSuchEntityException|any, data: IAMGetAccessKeyLastUsedResponse|any) => void): Request;
-      getAccountAuthorizationDetails(params: IAMGetAccountAuthorizationDetailsRequest, callback?: (err: IAMServiceFailureException|any, data: IAMGetAccountAuthorizationDetailsResponse|any) => void): Request;
-      getAccountPasswordPolicy(callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetAccountPasswordPolicyResponse|any) => void): Request;
-      getAccountSummary(callback?: (err: IAMServiceFailureException|any, data: IAMGetAccountSummaryResponse|any) => void): Request;
-      getContextKeysForCustomPolicy(params: IAMGetContextKeysForCustomPolicyRequest, callback?: (err: IAMInvalidInputException|any, data: IAMGetContextKeysForPolicyResponse|any) => void): Request;
-      getContextKeysForPrincipalPolicy(params: IAMGetContextKeysForPrincipalPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|any, data: IAMGetContextKeysForPolicyResponse|any) => void): Request;
-      getCredentialReport(callback?: (err: IAMCredentialReportNotPresentException|IAMCredentialReportExpiredException|IAMCredentialReportNotReadyException|IAMServiceFailureException|any, data: IAMGetCredentialReportResponse|any) => void): Request;
-      getGroup(params: IAMGetGroupRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetGroupResponse|any) => void): Request;
-      getGroupPolicy(params: IAMGetGroupPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetGroupPolicyResponse|any) => void): Request;
-      getInstanceProfile(params: IAMGetInstanceProfileRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetInstanceProfileResponse|any) => void): Request;
-      getLoginProfile(params: IAMGetLoginProfileRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetLoginProfileResponse|any) => void): Request;
-      getOpenIDConnectProvider(params: IAMGetOpenIDConnectProviderRequest, callback?: (err: IAMInvalidInputException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetOpenIDConnectProviderResponse|any) => void): Request;
-      getPolicy(params: IAMGetPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMGetPolicyResponse|any) => void): Request;
-      getPolicyVersion(params: IAMGetPolicyVersionRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMGetPolicyVersionResponse|any) => void): Request;
-      getRole(params: IAMGetRoleRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetRoleResponse|any) => void): Request;
-      getRolePolicy(params: IAMGetRolePolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetRolePolicyResponse|any) => void): Request;
-      getSAMLProvider(params: IAMGetSAMLProviderRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMGetSAMLProviderResponse|any) => void): Request;
-      getSSHPublicKey(params: IAMGetSSHPublicKeyRequest, callback?: (err: IAMNoSuchEntityException|IAMUnrecognizedPublicKeyEncodingException|any, data: IAMGetSSHPublicKeyResponse|any) => void): Request;
-      getServerCertificate(params: IAMGetServerCertificateRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetServerCertificateResponse|any) => void): Request;
-      getUser(params: IAMGetUserRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetUserResponse|any) => void): Request;
-      getUserPolicy(params: IAMGetUserPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMGetUserPolicyResponse|any) => void): Request;
-      listAccessKeys(params: IAMListAccessKeysRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListAccessKeysResponse|any) => void): Request;
-      listAccountAliases(params: IAMListAccountAliasesRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListAccountAliasesResponse|any) => void): Request;
-      listAttachedGroupPolicies(params: IAMListAttachedGroupPoliciesRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMListAttachedGroupPoliciesResponse|any) => void): Request;
-      listAttachedRolePolicies(params: IAMListAttachedRolePoliciesRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMListAttachedRolePoliciesResponse|any) => void): Request;
-      listAttachedUserPolicies(params: IAMListAttachedUserPoliciesRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMListAttachedUserPoliciesResponse|any) => void): Request;
-      listEntitiesForPolicy(params: IAMListEntitiesForPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMListEntitiesForPolicyResponse|any) => void): Request;
-      listGroupPolicies(params: IAMListGroupPoliciesRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListGroupPoliciesResponse|any) => void): Request;
-      listGroups(params: IAMListGroupsRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListGroupsResponse|any) => void): Request;
-      listGroupsForUser(params: IAMListGroupsForUserRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListGroupsForUserResponse|any) => void): Request;
-      listInstanceProfiles(params: IAMListInstanceProfilesRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListInstanceProfilesResponse|any) => void): Request;
-      listInstanceProfilesForRole(params: IAMListInstanceProfilesForRoleRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListInstanceProfilesForRoleResponse|any) => void): Request;
-      listMFADevices(params: IAMListMFADevicesRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListMFADevicesResponse|any) => void): Request;
-      listOpenIDConnectProviders(params: IAMListOpenIDConnectProvidersRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListOpenIDConnectProvidersResponse|any) => void): Request;
-      listPolicies(params: IAMListPoliciesRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListPoliciesResponse|any) => void): Request;
-      listPolicyVersions(params: IAMListPolicyVersionsRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMServiceFailureException|any, data: IAMListPolicyVersionsResponse|any) => void): Request;
-      listRolePolicies(params: IAMListRolePoliciesRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListRolePoliciesResponse|any) => void): Request;
-      listRoles(params: IAMListRolesRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListRolesResponse|any) => void): Request;
-      listSAMLProviders(params: IAMListSAMLProvidersRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListSAMLProvidersResponse|any) => void): Request;
-      listSSHPublicKeys(params: IAMListSSHPublicKeysRequest, callback?: (err: IAMNoSuchEntityException|any, data: IAMListSSHPublicKeysResponse|any) => void): Request;
-      listServerCertificates(params: IAMListServerCertificatesRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListServerCertificatesResponse|any) => void): Request;
-      listSigningCertificates(params: IAMListSigningCertificatesRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListSigningCertificatesResponse|any) => void): Request;
-      listUserPolicies(params: IAMListUserPoliciesRequest, callback?: (err: IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMListUserPoliciesResponse|any) => void): Request;
-      listUsers(params: IAMListUsersRequest, callback?: (err: IAMServiceFailureException|any, data: IAMListUsersResponse|any) => void): Request;
-      listVirtualMFADevices(params: IAMListVirtualMFADevicesRequest, callback?: (err: any, data: IAMListVirtualMFADevicesResponse|any) => void): Request;
-      putGroupPolicy(params: IAMPutGroupPolicyRequest, callback?: (err: IAMLimitExceededException|IAMMalformedPolicyDocumentException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      putRolePolicy(params: IAMPutRolePolicyRequest, callback?: (err: IAMLimitExceededException|IAMMalformedPolicyDocumentException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      putUserPolicy(params: IAMPutUserPolicyRequest, callback?: (err: IAMLimitExceededException|IAMMalformedPolicyDocumentException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      removeClientIDFromOpenIDConnectProvider(params: IAMRemoveClientIDFromOpenIDConnectProviderRequest, callback?: (err: IAMInvalidInputException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      removeRoleFromInstanceProfile(params: IAMRemoveRoleFromInstanceProfileRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      removeUserFromGroup(params: IAMRemoveUserFromGroupRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      resyncMFADevice(params: IAMResyncMFADeviceRequest, callback?: (err: IAMInvalidAuthenticationCodeException|IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      setDefaultPolicyVersion(params: IAMSetDefaultPolicyVersionRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      simulateCustomPolicy(params: IAMSimulateCustomPolicyRequest, callback?: (err: IAMInvalidInputException|IAMPolicyEvaluationException|any, data: IAMSimulatePolicyResponse|any) => void): Request;
-      simulatePrincipalPolicy(params: IAMSimulatePrincipalPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMPolicyEvaluationException|any, data: IAMSimulatePolicyResponse|any) => void): Request;
-      updateAccessKey(params: IAMUpdateAccessKeyRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateAccountPasswordPolicy(params: IAMUpdateAccountPasswordPolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMMalformedPolicyDocumentException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateAssumeRolePolicy(params: IAMUpdateAssumeRolePolicyRequest, callback?: (err: IAMNoSuchEntityException|IAMMalformedPolicyDocumentException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateGroup(params: IAMUpdateGroupRequest, callback?: (err: IAMNoSuchEntityException|IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateLoginProfile(params: IAMUpdateLoginProfileRequest, callback?: (err: IAMEntityTemporarilyUnmodifiableException|IAMNoSuchEntityException|IAMPasswordPolicyViolationException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateOpenIDConnectProviderThumbprint(params: IAMUpdateOpenIDConnectProviderThumbprintRequest, callback?: (err: IAMInvalidInputException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateSAMLProvider(params: IAMUpdateSAMLProviderRequest, callback?: (err: IAMNoSuchEntityException|IAMInvalidInputException|IAMLimitExceededException|IAMServiceFailureException|any, data: IAMUpdateSAMLProviderResponse|any) => void): Request;
-      updateSSHPublicKey(params: IAMUpdateSSHPublicKeyRequest, callback?: (err: IAMNoSuchEntityException|any, data: any) => void): Request;
-      updateServerCertificate(params: IAMUpdateServerCertificateRequest, callback?: (err: IAMNoSuchEntityException|IAMEntityAlreadyExistsException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateSigningCertificate(params: IAMUpdateSigningCertificateRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMServiceFailureException|any, data: any) => void): Request;
-      updateUser(params: IAMUpdateUserRequest, callback?: (err: IAMNoSuchEntityException|IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMEntityTemporarilyUnmodifiableException|IAMServiceFailureException|any, data: any) => void): Request;
-      uploadSSHPublicKey(params: IAMUploadSSHPublicKeyRequest, callback?: (err: IAMLimitExceededException|IAMNoSuchEntityException|IAMInvalidPublicKeyException|IAMDuplicateSSHPublicKeyException|IAMUnrecognizedPublicKeyEncodingException|any, data: IAMUploadSSHPublicKeyResponse|any) => void): Request;
-      uploadServerCertificate(params: IAMUploadServerCertificateRequest, callback?: (err: IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMMalformedCertificateException|IAMKeyPairMismatchException|IAMServiceFailureException|any, data: IAMUploadServerCertificateResponse|any) => void): Request;
-      uploadSigningCertificate(params: IAMUploadSigningCertificateRequest, callback?: (err: IAMLimitExceededException|IAMEntityAlreadyExistsException|IAMMalformedCertificateException|IAMInvalidCertificateException|IAMDuplicateCertificateException|IAMNoSuchEntityException|IAMServiceFailureException|any, data: IAMUploadSigningCertificateResponse|any) => void): Request;
-    }
-
-    export interface IAMAccessKey {
-        UserName: IAMuserNameType;
-        AccessKeyId: IAMaccessKeyIdType;
-        Status: IAMstatusType;
-        SecretAccessKey: IAMaccessKeySecretType;
-        CreateDate?: IAMdateType;
-    }
-
-    export interface IAMAccessKeyLastUsed {
-        LastUsedDate: IAMdateType;
-        ServiceName: IAMstringType;
-        Region: IAMstringType;
-    }
-
-    export interface IAMAccessKeyMetadata {
-        UserName?: IAMuserNameType;
-        AccessKeyId?: IAMaccessKeyIdType;
-        Status?: IAMstatusType;
-        CreateDate?: IAMdateType;
-    }
-
-    export type IAMActionNameListType = Array<IAMActionNameType>;
-    export type IAMActionNameType = string;
-    export interface IAMAddClientIDToOpenIDConnectProviderRequest {
-        OpenIDConnectProviderArn: IAMarnType;
-        ClientID: IAMclientIDType;
-    }
-
-    export interface IAMAddRoleToInstanceProfileRequest {
-        InstanceProfileName: IAMinstanceProfileNameType;
-        RoleName: IAMroleNameType;
-    }
-
-    export interface IAMAddUserToGroupRequest {
-        GroupName: IAMgroupNameType;
-        UserName: IAMexistingUserNameType;
-    }
-
-    export interface IAMAttachGroupPolicyRequest {
-        GroupName: IAMgroupNameType;
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMAttachRolePolicyRequest {
-        RoleName: IAMroleNameType;
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMAttachUserPolicyRequest {
-        UserName: IAMuserNameType;
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMAttachedPolicy {
-        PolicyName?: IAMpolicyNameType;
-        PolicyArn?: IAMarnType;
-    }
-
-    export type IAMBootstrapDatum = any; // not really - it was 'blob' instead - must fix this one
-    export interface IAMChangePasswordRequest {
-        OldPassword: IAMpasswordType;
-        NewPassword: IAMpasswordType;
-    }
-
-    export type IAMColumnNumber = number;
-    export interface IAMContextEntry {
-        ContextKeyName?: IAMContextKeyNameType;
-        ContextKeyValues?: IAMContextKeyValueListType;
-        ContextKeyType?: IAMContextKeyTypeEnum;
-    }
-
-    export type IAMContextEntryListType = Array<IAMContextEntry>;
-    export type IAMContextKeyNameType = string;
-    export type IAMContextKeyNamesResultListType = Array<IAMContextKeyNameType>;
-    export type IAMContextKeyTypeEnum = string;
-    export type IAMContextKeyValueListType = Array<IAMContextKeyValueType>;
-    export type IAMContextKeyValueType = string;
-    export interface IAMCreateAccessKeyRequest {
-        UserName?: IAMexistingUserNameType;
-    }
-
-    export interface IAMCreateAccessKeyResponse {
-        AccessKey: IAMAccessKey;
-    }
-
-    export interface IAMCreateAccountAliasRequest {
-        AccountAlias: IAMaccountAliasType;
-    }
-
-    export interface IAMCreateGroupRequest {
-        Path?: IAMpathType;
-        GroupName: IAMgroupNameType;
-    }
-
-    export interface IAMCreateGroupResponse {
-        Group: IAMGroup;
-    }
-
-    export interface IAMCreateInstanceProfileRequest {
-        InstanceProfileName: IAMinstanceProfileNameType;
-        Path?: IAMpathType;
-    }
-
-    export interface IAMCreateInstanceProfileResponse {
-        InstanceProfile: IAMInstanceProfile;
-    }
-
-    export interface IAMCreateLoginProfileRequest {
-        UserName: IAMuserNameType;
-        Password: IAMpasswordType;
-        PasswordResetRequired?: IAMbooleanType;
-    }
-
-    export interface IAMCreateLoginProfileResponse {
-        LoginProfile: IAMLoginProfile;
-    }
-
-    export interface IAMCreateOpenIDConnectProviderRequest {
-        Url: IAMOpenIDConnectProviderUrlType;
-        ClientIDList?: IAMclientIDListType;
-        ThumbprintList: IAMthumbprintListType;
-    }
-
-    export interface IAMCreateOpenIDConnectProviderResponse {
-        OpenIDConnectProviderArn?: IAMarnType;
-    }
-
-    export interface IAMCreatePolicyRequest {
-        PolicyName: IAMpolicyNameType;
-        Path?: IAMpolicyPathType;
-        PolicyDocument: IAMpolicyDocumentType;
-        Description?: IAMpolicyDescriptionType;
-    }
-
-    export interface IAMCreatePolicyResponse {
-        Policy?: IAMPolicy;
-    }
-
-    export interface IAMCreatePolicyVersionRequest {
-        PolicyArn: IAMarnType;
-        PolicyDocument: IAMpolicyDocumentType;
-        SetAsDefault?: IAMbooleanType;
-    }
-
-    export interface IAMCreatePolicyVersionResponse {
-        PolicyVersion?: IAMPolicyVersion;
-    }
-
-    export interface IAMCreateRoleRequest {
-        Path?: IAMpathType;
-        RoleName: IAMroleNameType;
-        AssumeRolePolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMCreateRoleResponse {
-        Role: IAMRole;
-    }
-
-    export interface IAMCreateSAMLProviderRequest {
-        SAMLMetadataDocument: IAMSAMLMetadataDocumentType;
-        Name: IAMSAMLProviderNameType;
-    }
-
-    export interface IAMCreateSAMLProviderResponse {
-        SAMLProviderArn?: IAMarnType;
-    }
-
-    export interface IAMCreateUserRequest {
-        Path?: IAMpathType;
-        UserName: IAMuserNameType;
-    }
-
-    export interface IAMCreateUserResponse {
-        User?: IAMUser;
-    }
-
-    export interface IAMCreateVirtualMFADeviceRequest {
-        Path?: IAMpathType;
-        VirtualMFADeviceName: IAMvirtualMFADeviceName;
-    }
-
-    export interface IAMCreateVirtualMFADeviceResponse {
-        VirtualMFADevice: IAMVirtualMFADevice;
-    }
-
-    export interface IAMCredentialReportExpiredException {
-        message?: IAMcredentialReportExpiredExceptionMessage;
-    }
-
-    export interface IAMCredentialReportNotPresentException {
-        message?: IAMcredentialReportNotPresentExceptionMessage;
-    }
-
-    export interface IAMCredentialReportNotReadyException {
-        message?: IAMcredentialReportNotReadyExceptionMessage;
-    }
-
-    export interface IAMDeactivateMFADeviceRequest {
-        UserName: IAMexistingUserNameType;
-        SerialNumber: IAMserialNumberType;
-    }
-
-    export interface IAMDeleteAccessKeyRequest {
-        UserName?: IAMexistingUserNameType;
-        AccessKeyId: IAMaccessKeyIdType;
-    }
-
-    export interface IAMDeleteAccountAliasRequest {
-        AccountAlias: IAMaccountAliasType;
-    }
-
-    export interface IAMDeleteConflictException {
-        message?: IAMdeleteConflictMessage;
-    }
-
-    export interface IAMDeleteGroupPolicyRequest {
-        GroupName: IAMgroupNameType;
-        PolicyName: IAMpolicyNameType;
-    }
-
-    export interface IAMDeleteGroupRequest {
-        GroupName: IAMgroupNameType;
-    }
-
-    export interface IAMDeleteInstanceProfileRequest {
-        InstanceProfileName: IAMinstanceProfileNameType;
-    }
-
-    export interface IAMDeleteLoginProfileRequest {
-        UserName: IAMuserNameType;
-    }
-
-    export interface IAMDeleteOpenIDConnectProviderRequest {
-        OpenIDConnectProviderArn: IAMarnType;
-    }
-
-    export interface IAMDeletePolicyRequest {
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMDeletePolicyVersionRequest {
-        PolicyArn: IAMarnType;
-        VersionId: IAMpolicyVersionIdType;
-    }
-
-    export interface IAMDeleteRolePolicyRequest {
-        RoleName: IAMroleNameType;
-        PolicyName: IAMpolicyNameType;
-    }
-
-    export interface IAMDeleteRoleRequest {
-        RoleName: IAMroleNameType;
-    }
-
-    export interface IAMDeleteSAMLProviderRequest {
-        SAMLProviderArn: IAMarnType;
-    }
-
-    export interface IAMDeleteSSHPublicKeyRequest {
-        UserName: IAMuserNameType;
-        SSHPublicKeyId: IAMpublicKeyIdType;
-    }
-
-    export interface IAMDeleteServerCertificateRequest {
-        ServerCertificateName: IAMserverCertificateNameType;
-    }
-
-    export interface IAMDeleteSigningCertificateRequest {
-        UserName?: IAMexistingUserNameType;
-        CertificateId: IAMcertificateIdType;
-    }
-
-    export interface IAMDeleteUserPolicyRequest {
-        UserName: IAMexistingUserNameType;
-        PolicyName: IAMpolicyNameType;
-    }
-
-    export interface IAMDeleteUserRequest {
-        UserName: IAMexistingUserNameType;
-    }
-
-    export interface IAMDeleteVirtualMFADeviceRequest {
-        SerialNumber: IAMserialNumberType;
-    }
-
-    export interface IAMDetachGroupPolicyRequest {
-        GroupName: IAMgroupNameType;
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMDetachRolePolicyRequest {
-        RoleName: IAMroleNameType;
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMDetachUserPolicyRequest {
-        UserName: IAMuserNameType;
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMDuplicateCertificateException {
-        message?: IAMduplicateCertificateMessage;
-    }
-
-    export interface IAMDuplicateSSHPublicKeyException {
-        message?: IAMduplicateSSHPublicKeyMessage;
-    }
-
-    export interface IAMEnableMFADeviceRequest {
-        UserName: IAMexistingUserNameType;
-        SerialNumber: IAMserialNumberType;
-        AuthenticationCode1: IAMauthenticationCodeType;
-        AuthenticationCode2: IAMauthenticationCodeType;
-    }
-
-    export interface IAMEntityAlreadyExistsException {
-        message?: IAMentityAlreadyExistsMessage;
-    }
-
-    export interface IAMEntityTemporarilyUnmodifiableException {
-        message?: IAMentityTemporarilyUnmodifiableMessage;
-    }
-
-    export type IAMEntityType = string;
-    export type IAMEvalDecisionDetailsType = any; // not really - it was 'map' instead - must fix this one
-    export type IAMEvalDecisionSourceType = string;
-    export interface IAMEvaluationResult {
-        EvalActionName: IAMActionNameType;
-        EvalResourceName?: IAMResourceNameType;
-        EvalDecision: IAMPolicyEvaluationDecisionType;
-        MatchedStatements?: IAMStatementListType;
-        MissingContextValues?: IAMContextKeyNamesResultListType;
-        EvalDecisionDetails?: IAMEvalDecisionDetailsType;
-        ResourceSpecificResults?: IAMResourceSpecificResultListType;
-    }
-
-    export type IAMEvaluationResultsListType = Array<IAMEvaluationResult>;
-    export interface IAMGenerateCredentialReportResponse {
-        State?: IAMReportStateType;
-        Description?: IAMReportStateDescriptionType;
-    }
-
-    export interface IAMGetAccessKeyLastUsedRequest {
-        AccessKeyId: IAMaccessKeyIdType;
-    }
-
-    export interface IAMGetAccessKeyLastUsedResponse {
-        UserName?: IAMexistingUserNameType;
-        AccessKeyLastUsed?: IAMAccessKeyLastUsed;
-    }
-
-    export interface IAMGetAccountAuthorizationDetailsRequest {
-        Filter?: IAMentityListType;
-        MaxItems?: IAMmaxItemsType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMGetAccountAuthorizationDetailsResponse {
-        UserDetailList?: IAMuserDetailListType;
-        GroupDetailList?: IAMgroupDetailListType;
-        RoleDetailList?: IAMroleDetailListType;
-        Policies?: IAMManagedPolicyDetailListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMGetAccountPasswordPolicyResponse {
-        PasswordPolicy: IAMPasswordPolicy;
-    }
-
-    export interface IAMGetAccountSummaryResponse {
-        SummaryMap?: IAMsummaryMapType;
-    }
-
-    export interface IAMGetContextKeysForCustomPolicyRequest {
-        PolicyInputList: IAMSimulationPolicyListType;
-    }
-
-    export interface IAMGetContextKeysForPolicyResponse {
-        ContextKeyNames?: IAMContextKeyNamesResultListType;
-    }
-
-    export interface IAMGetContextKeysForPrincipalPolicyRequest {
-        PolicySourceArn: IAMarnType;
-        PolicyInputList?: IAMSimulationPolicyListType;
-    }
-
-    export interface IAMGetCredentialReportResponse {
-        Content?: IAMReportContentType;
-        ReportFormat?: IAMReportFormatType;
-        GeneratedTime?: IAMdateType;
-    }
-
-    export interface IAMGetGroupPolicyRequest {
-        GroupName: IAMgroupNameType;
-        PolicyName: IAMpolicyNameType;
-    }
-
-    export interface IAMGetGroupPolicyResponse {
-        GroupName: IAMgroupNameType;
-        PolicyName: IAMpolicyNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMGetGroupRequest {
-        GroupName: IAMgroupNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMGetGroupResponse {
-        Group: IAMGroup;
-        Users: IAMuserListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMGetInstanceProfileRequest {
-        InstanceProfileName: IAMinstanceProfileNameType;
-    }
-
-    export interface IAMGetInstanceProfileResponse {
-        InstanceProfile: IAMInstanceProfile;
-    }
-
-    export interface IAMGetLoginProfileRequest {
-        UserName: IAMuserNameType;
-    }
-
-    export interface IAMGetLoginProfileResponse {
-        LoginProfile: IAMLoginProfile;
-    }
-
-    export interface IAMGetOpenIDConnectProviderRequest {
-        OpenIDConnectProviderArn: IAMarnType;
-    }
-
-    export interface IAMGetOpenIDConnectProviderResponse {
-        Url?: IAMOpenIDConnectProviderUrlType;
-        ClientIDList?: IAMclientIDListType;
-        ThumbprintList?: IAMthumbprintListType;
-        CreateDate?: IAMdateType;
-    }
-
-    export interface IAMGetPolicyRequest {
-        PolicyArn: IAMarnType;
-    }
-
-    export interface IAMGetPolicyResponse {
-        Policy?: IAMPolicy;
-    }
-
-    export interface IAMGetPolicyVersionRequest {
-        PolicyArn: IAMarnType;
-        VersionId: IAMpolicyVersionIdType;
-    }
-
-    export interface IAMGetPolicyVersionResponse {
-        PolicyVersion?: IAMPolicyVersion;
-    }
-
-    export interface IAMGetRolePolicyRequest {
-        RoleName: IAMroleNameType;
-        PolicyName: IAMpolicyNameType;
-    }
-
-    export interface IAMGetRolePolicyResponse {
-        RoleName: IAMroleNameType;
-        PolicyName: IAMpolicyNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMGetRoleRequest {
-        RoleName: IAMroleNameType;
-    }
-
-    export interface IAMGetRoleResponse {
-        Role: IAMRole;
-    }
-
-    export interface IAMGetSAMLProviderRequest {
-        SAMLProviderArn: IAMarnType;
-    }
-
-    export interface IAMGetSAMLProviderResponse {
-        SAMLMetadataDocument?: IAMSAMLMetadataDocumentType;
-        CreateDate?: IAMdateType;
-        ValidUntil?: IAMdateType;
-    }
-
-    export interface IAMGetSSHPublicKeyRequest {
-        UserName: IAMuserNameType;
-        SSHPublicKeyId: IAMpublicKeyIdType;
-        Encoding: IAMencodingType;
-    }
-
-    export interface IAMGetSSHPublicKeyResponse {
-        SSHPublicKey?: IAMSSHPublicKey;
-    }
-
-    export interface IAMGetServerCertificateRequest {
-        ServerCertificateName: IAMserverCertificateNameType;
-    }
-
-    export interface IAMGetServerCertificateResponse {
-        ServerCertificate: IAMServerCertificate;
-    }
-
-    export interface IAMGetUserPolicyRequest {
-        UserName: IAMexistingUserNameType;
-        PolicyName: IAMpolicyNameType;
-    }
-
-    export interface IAMGetUserPolicyResponse {
-        UserName: IAMexistingUserNameType;
-        PolicyName: IAMpolicyNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMGetUserRequest {
-        UserName?: IAMexistingUserNameType;
-    }
-
-    export interface IAMGetUserResponse {
-        User: IAMUser;
-    }
-
-    export interface IAMGroup {
-        Path: IAMpathType;
-        GroupName: IAMgroupNameType;
-        GroupId: IAMidType;
-        Arn: IAMarnType;
-        CreateDate: IAMdateType;
-    }
-
-    export interface IAMGroupDetail {
-        Path?: IAMpathType;
-        GroupName?: IAMgroupNameType;
-        GroupId?: IAMidType;
-        Arn?: IAMarnType;
-        CreateDate?: IAMdateType;
-        GroupPolicyList?: IAMpolicyDetailListType;
-        AttachedManagedPolicies?: IAMattachedPoliciesListType;
-    }
-
-    export interface IAMInstanceProfile {
-        Path: IAMpathType;
-        InstanceProfileName: IAMinstanceProfileNameType;
-        InstanceProfileId: IAMidType;
-        Arn: IAMarnType;
-        CreateDate: IAMdateType;
-        Roles: IAMroleListType;
-    }
-
-    export interface IAMInvalidAuthenticationCodeException {
-        message?: IAMinvalidAuthenticationCodeMessage;
-    }
-
-    export interface IAMInvalidCertificateException {
-        message?: IAMinvalidCertificateMessage;
-    }
-
-    export interface IAMInvalidInputException {
-        message?: IAMinvalidInputMessage;
-    }
+      addClientIDToOpenIDConnectProvider(params: IAM.AddClientIDToOpenIDConnectProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      addRoleToInstanceProfile(params: IAM.AddRoleToInstanceProfileRequest, callback?: (err: IAM.NoSuchEntityException|IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      addUserToGroup(params: IAM.AddUserToGroupRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      attachGroupPolicy(params: IAM.AttachGroupPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      attachRolePolicy(params: IAM.AttachRolePolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      attachUserPolicy(params: IAM.AttachUserPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      changePassword(params: IAM.ChangePasswordRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidUserTypeException|IAM.LimitExceededException|IAM.EntityTemporarilyUnmodifiableException|IAM.PasswordPolicyViolationException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      createAccessKey(params: IAM.CreateAccessKeyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.CreateAccessKeyResponse|any) => void): Request;
+      createAccountAlias(params: IAM.CreateAccountAliasRequest, callback?: (err: IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      createGroup(params: IAM.CreateGroupRequest, callback?: (err: IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.CreateGroupResponse|any) => void): Request;
+      createInstanceProfile(params: IAM.CreateInstanceProfileRequest, callback?: (err: IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.CreateInstanceProfileResponse|any) => void): Request;
+      createLoginProfile(params: IAM.CreateLoginProfileRequest, callback?: (err: IAM.EntityAlreadyExistsException|IAM.NoSuchEntityException|IAM.PasswordPolicyViolationException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.CreateLoginProfileResponse|any) => void): Request;
+      createOpenIDConnectProvider(params: IAM.CreateOpenIDConnectProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.CreateOpenIDConnectProviderResponse|any) => void): Request;
+      createPolicy(params: IAM.CreatePolicyRequest, callback?: (err: IAM.InvalidInputException|IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.MalformedPolicyDocumentException|IAM.ServiceFailureException|any, data: IAM.CreatePolicyResponse|any) => void): Request;
+      createPolicyVersion(params: IAM.CreatePolicyVersionRequest, callback?: (err: IAM.NoSuchEntityException|IAM.MalformedPolicyDocumentException|IAM.InvalidInputException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.CreatePolicyVersionResponse|any) => void): Request;
+      createRole(params: IAM.CreateRoleRequest, callback?: (err: IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.MalformedPolicyDocumentException|IAM.ServiceFailureException|any, data: IAM.CreateRoleResponse|any) => void): Request;
+      createSAMLProvider(params: IAM.CreateSAMLProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.CreateSAMLProviderResponse|any) => void): Request;
+      createUser(params: IAM.CreateUserRequest, callback?: (err: IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.CreateUserResponse|any) => void): Request;
+      createVirtualMFADevice(params: IAM.CreateVirtualMFADeviceRequest, callback?: (err: IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.ServiceFailureException|any, data: IAM.CreateVirtualMFADeviceResponse|any) => void): Request;
+      deactivateMFADevice(params: IAM.DeactivateMFADeviceRequest, callback?: (err: IAM.EntityTemporarilyUnmodifiableException|IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteAccessKey(params: IAM.DeleteAccessKeyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteAccountAlias(params: IAM.DeleteAccountAliasRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteAccountPasswordPolicy(callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteGroup(params: IAM.DeleteGroupRequest, callback?: (err: IAM.NoSuchEntityException|IAM.DeleteConflictException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteGroupPolicy(params: IAM.DeleteGroupPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteInstanceProfile(params: IAM.DeleteInstanceProfileRequest, callback?: (err: IAM.NoSuchEntityException|IAM.DeleteConflictException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteLoginProfile(params: IAM.DeleteLoginProfileRequest, callback?: (err: IAM.EntityTemporarilyUnmodifiableException|IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteOpenIDConnectProvider(params: IAM.DeleteOpenIDConnectProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deletePolicy(params: IAM.DeletePolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.DeleteConflictException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deletePolicyVersion(params: IAM.DeletePolicyVersionRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.DeleteConflictException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteRole(params: IAM.DeleteRoleRequest, callback?: (err: IAM.NoSuchEntityException|IAM.DeleteConflictException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteRolePolicy(params: IAM.DeleteRolePolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteSAMLProvider(params: IAM.DeleteSAMLProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.LimitExceededException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteSSHPublicKey(params: IAM.DeleteSSHPublicKeyRequest, callback?: (err: IAM.NoSuchEntityException|any, data: any) => void): Request;
+      deleteServerCertificate(params: IAM.DeleteServerCertificateRequest, callback?: (err: IAM.NoSuchEntityException|IAM.DeleteConflictException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteSigningCertificate(params: IAM.DeleteSigningCertificateRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteUser(params: IAM.DeleteUserRequest, callback?: (err: IAM.LimitExceededException|IAM.NoSuchEntityException|IAM.DeleteConflictException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteUserPolicy(params: IAM.DeleteUserPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      deleteVirtualMFADevice(params: IAM.DeleteVirtualMFADeviceRequest, callback?: (err: IAM.NoSuchEntityException|IAM.DeleteConflictException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      detachGroupPolicy(params: IAM.DetachGroupPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      detachRolePolicy(params: IAM.DetachRolePolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      detachUserPolicy(params: IAM.DetachUserPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      enableMFADevice(params: IAM.EnableMFADeviceRequest, callback?: (err: IAM.EntityAlreadyExistsException|IAM.EntityTemporarilyUnmodifiableException|IAM.InvalidAuthenticationCodeException|IAM.LimitExceededException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      generateCredentialReport(callback?: (err: IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.GenerateCredentialReportResponse|any) => void): Request;
+      getAccessKeyLastUsed(params: IAM.GetAccessKeyLastUsedRequest, callback?: (err: IAM.NoSuchEntityException|any, data: IAM.GetAccessKeyLastUsedResponse|any) => void): Request;
+      getAccountAuthorizationDetails(params: IAM.GetAccountAuthorizationDetailsRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.GetAccountAuthorizationDetailsResponse|any) => void): Request;
+      getAccountPasswordPolicy(callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetAccountPasswordPolicyResponse|any) => void): Request;
+      getAccountSummary(callback?: (err: IAM.ServiceFailureException|any, data: IAM.GetAccountSummaryResponse|any) => void): Request;
+      getContextKeysForCustomPolicy(params: IAM.GetContextKeysForCustomPolicyRequest, callback?: (err: IAM.InvalidInputException|any, data: IAM.GetContextKeysForPolicyResponse|any) => void): Request;
+      getContextKeysForPrincipalPolicy(params: IAM.GetContextKeysForPrincipalPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|any, data: IAM.GetContextKeysForPolicyResponse|any) => void): Request;
+      getCredentialReport(callback?: (err: IAM.CredentialReportNotPresentException|IAM.CredentialReportExpiredException|IAM.CredentialReportNotReadyException|IAM.ServiceFailureException|any, data: IAM.GetCredentialReportResponse|any) => void): Request;
+      getGroup(params: IAM.GetGroupRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetGroupResponse|any) => void): Request;
+      getGroupPolicy(params: IAM.GetGroupPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetGroupPolicyResponse|any) => void): Request;
+      getInstanceProfile(params: IAM.GetInstanceProfileRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetInstanceProfileResponse|any) => void): Request;
+      getLoginProfile(params: IAM.GetLoginProfileRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetLoginProfileResponse|any) => void): Request;
+      getOpenIDConnectProvider(params: IAM.GetOpenIDConnectProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetOpenIDConnectProviderResponse|any) => void): Request;
+      getPolicy(params: IAM.GetPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.GetPolicyResponse|any) => void): Request;
+      getPolicyVersion(params: IAM.GetPolicyVersionRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.GetPolicyVersionResponse|any) => void): Request;
+      getRole(params: IAM.GetRoleRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetRoleResponse|any) => void): Request;
+      getRolePolicy(params: IAM.GetRolePolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetRolePolicyResponse|any) => void): Request;
+      getSAMLProvider(params: IAM.GetSAMLProviderRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.GetSAMLProviderResponse|any) => void): Request;
+      getSSHPublicKey(params: IAM.GetSSHPublicKeyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.UnrecognizedPublicKeyEncodingException|any, data: IAM.GetSSHPublicKeyResponse|any) => void): Request;
+      getServerCertificate(params: IAM.GetServerCertificateRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetServerCertificateResponse|any) => void): Request;
+      getUser(params: IAM.GetUserRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetUserResponse|any) => void): Request;
+      getUserPolicy(params: IAM.GetUserPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.GetUserPolicyResponse|any) => void): Request;
+      listAccessKeys(params: IAM.ListAccessKeysRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListAccessKeysResponse|any) => void): Request;
+      listAccountAliases(params: IAM.ListAccountAliasesRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListAccountAliasesResponse|any) => void): Request;
+      listAttachedGroupPolicies(params: IAM.ListAttachedGroupPoliciesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.ListAttachedGroupPoliciesResponse|any) => void): Request;
+      listAttachedRolePolicies(params: IAM.ListAttachedRolePoliciesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.ListAttachedRolePoliciesResponse|any) => void): Request;
+      listAttachedUserPolicies(params: IAM.ListAttachedUserPoliciesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.ListAttachedUserPoliciesResponse|any) => void): Request;
+      listEntitiesForPolicy(params: IAM.ListEntitiesForPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.ListEntitiesForPolicyResponse|any) => void): Request;
+      listGroupPolicies(params: IAM.ListGroupPoliciesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListGroupPoliciesResponse|any) => void): Request;
+      listGroups(params: IAM.ListGroupsRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListGroupsResponse|any) => void): Request;
+      listGroupsForUser(params: IAM.ListGroupsForUserRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListGroupsForUserResponse|any) => void): Request;
+      listInstanceProfiles(params: IAM.ListInstanceProfilesRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListInstanceProfilesResponse|any) => void): Request;
+      listInstanceProfilesForRole(params: IAM.ListInstanceProfilesForRoleRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListInstanceProfilesForRoleResponse|any) => void): Request;
+      listMFADevices(params: IAM.ListMFADevicesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListMFADevicesResponse|any) => void): Request;
+      listOpenIDConnectProviders(params: IAM.ListOpenIDConnectProvidersRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListOpenIDConnectProvidersResponse|any) => void): Request;
+      listPolicies(params: IAM.ListPoliciesRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListPoliciesResponse|any) => void): Request;
+      listPolicyVersions(params: IAM.ListPolicyVersionsRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.ServiceFailureException|any, data: IAM.ListPolicyVersionsResponse|any) => void): Request;
+      listRolePolicies(params: IAM.ListRolePoliciesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListRolePoliciesResponse|any) => void): Request;
+      listRoles(params: IAM.ListRolesRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListRolesResponse|any) => void): Request;
+      listSAMLProviders(params: IAM.ListSAMLProvidersRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListSAMLProvidersResponse|any) => void): Request;
+      listSSHPublicKeys(params: IAM.ListSSHPublicKeysRequest, callback?: (err: IAM.NoSuchEntityException|any, data: IAM.ListSSHPublicKeysResponse|any) => void): Request;
+      listServerCertificates(params: IAM.ListServerCertificatesRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListServerCertificatesResponse|any) => void): Request;
+      listSigningCertificates(params: IAM.ListSigningCertificatesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListSigningCertificatesResponse|any) => void): Request;
+      listUserPolicies(params: IAM.ListUserPoliciesRequest, callback?: (err: IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.ListUserPoliciesResponse|any) => void): Request;
+      listUsers(params: IAM.ListUsersRequest, callback?: (err: IAM.ServiceFailureException|any, data: IAM.ListUsersResponse|any) => void): Request;
+      listVirtualMFADevices(params: IAM.ListVirtualMFADevicesRequest, callback?: (err: any, data: IAM.ListVirtualMFADevicesResponse|any) => void): Request;
+      putGroupPolicy(params: IAM.PutGroupPolicyRequest, callback?: (err: IAM.LimitExceededException|IAM.MalformedPolicyDocumentException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      putRolePolicy(params: IAM.PutRolePolicyRequest, callback?: (err: IAM.LimitExceededException|IAM.MalformedPolicyDocumentException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      putUserPolicy(params: IAM.PutUserPolicyRequest, callback?: (err: IAM.LimitExceededException|IAM.MalformedPolicyDocumentException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      removeClientIDFromOpenIDConnectProvider(params: IAM.RemoveClientIDFromOpenIDConnectProviderRequest, callback?: (err: IAM.InvalidInputException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      removeRoleFromInstanceProfile(params: IAM.RemoveRoleFromInstanceProfileRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      removeUserFromGroup(params: IAM.RemoveUserFromGroupRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      resyncMFADevice(params: IAM.ResyncMFADeviceRequest, callback?: (err: IAM.InvalidAuthenticationCodeException|IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      setDefaultPolicyVersion(params: IAM.SetDefaultPolicyVersionRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      simulateCustomPolicy(params: IAM.SimulateCustomPolicyRequest, callback?: (err: IAM.InvalidInputException|IAM.PolicyEvaluationException|any, data: IAM.SimulatePolicyResponse|any) => void): Request;
+      simulatePrincipalPolicy(params: IAM.SimulatePrincipalPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.PolicyEvaluationException|any, data: IAM.SimulatePolicyResponse|any) => void): Request;
+      updateAccessKey(params: IAM.UpdateAccessKeyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateAccountPasswordPolicy(params: IAM.UpdateAccountPasswordPolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.MalformedPolicyDocumentException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateAssumeRolePolicy(params: IAM.UpdateAssumeRolePolicyRequest, callback?: (err: IAM.NoSuchEntityException|IAM.MalformedPolicyDocumentException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateGroup(params: IAM.UpdateGroupRequest, callback?: (err: IAM.NoSuchEntityException|IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateLoginProfile(params: IAM.UpdateLoginProfileRequest, callback?: (err: IAM.EntityTemporarilyUnmodifiableException|IAM.NoSuchEntityException|IAM.PasswordPolicyViolationException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateOpenIDConnectProviderThumbprint(params: IAM.UpdateOpenIDConnectProviderThumbprintRequest, callback?: (err: IAM.InvalidInputException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateSAMLProvider(params: IAM.UpdateSAMLProviderRequest, callback?: (err: IAM.NoSuchEntityException|IAM.InvalidInputException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: IAM.UpdateSAMLProviderResponse|any) => void): Request;
+      updateSSHPublicKey(params: IAM.UpdateSSHPublicKeyRequest, callback?: (err: IAM.NoSuchEntityException|any, data: any) => void): Request;
+      updateServerCertificate(params: IAM.UpdateServerCertificateRequest, callback?: (err: IAM.NoSuchEntityException|IAM.EntityAlreadyExistsException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateSigningCertificate(params: IAM.UpdateSigningCertificateRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      updateUser(params: IAM.UpdateUserRequest, callback?: (err: IAM.NoSuchEntityException|IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.EntityTemporarilyUnmodifiableException|IAM.ServiceFailureException|any, data: any) => void): Request;
+      uploadSSHPublicKey(params: IAM.UploadSSHPublicKeyRequest, callback?: (err: IAM.LimitExceededException|IAM.NoSuchEntityException|IAM.InvalidPublicKeyException|IAM.DuplicateSSHPublicKeyException|IAM.UnrecognizedPublicKeyEncodingException|any, data: IAM.UploadSSHPublicKeyResponse|any) => void): Request;
+      uploadServerCertificate(params: IAM.UploadServerCertificateRequest, callback?: (err: IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.MalformedCertificateException|IAM.KeyPairMismatchException|IAM.ServiceFailureException|any, data: IAM.UploadServerCertificateResponse|any) => void): Request;
+      uploadSigningCertificate(params: IAM.UploadSigningCertificateRequest, callback?: (err: IAM.LimitExceededException|IAM.EntityAlreadyExistsException|IAM.MalformedCertificateException|IAM.InvalidCertificateException|IAM.DuplicateCertificateException|IAM.NoSuchEntityException|IAM.ServiceFailureException|any, data: IAM.UploadSigningCertificateResponse|any) => void): Request;
+    }
+    
+    export module IAM {
+        export type ActionNameListType = ActionNameType[];
+        export type ActionNameType = string;    // max: 128, min: 3
+        export type BootstrapDatum = any;    // type: blob
+        export type ColumnNumber = number;
+        export type ContextEntryListType = ContextEntry[];
+        export type ContextKeyNameType = string;    // max: 256, min: 5
+        export type ContextKeyNamesResultListType = ContextKeyNameType[];
+        export type ContextKeyTypeEnum = string;
+        export type ContextKeyValueListType = ContextKeyValueType[];
+        export type ContextKeyValueType = string;
+        export type EntityType = string;
+        export type EvalDecisionDetailsType = {[key:string]: PolicyEvaluationDecisionType};
+        export type EvalDecisionSourceType = string;    // max: 256, min: 3
+        export type EvaluationResultsListType = EvaluationResult[];
+        export type LineNumber = number;
+        export type ManagedPolicyDetailListType = ManagedPolicyDetail[];
+        export type OpenIDConnectProviderListType = OpenIDConnectProviderListEntry[];
+        export type OpenIDConnectProviderUrlType = string;    // max: 255, min: 1
+        export type PolicyEvaluationDecisionType = string;
+        export type PolicyGroupListType = PolicyGroup[];
+        export type PolicyIdentifierType = string;
+        export type PolicyRoleListType = PolicyRole[];
+        export type PolicySourceType = string;
+        export type PolicyUserListType = PolicyUser[];
+        export type ReportContentType = any;    // type: blob
+        export type ReportFormatType = string;
+        export type ReportStateDescriptionType = string;
+        export type ReportStateType = string;
+        export type ResourceHandlingOptionType = string;    // max: 64, min: 1
+        export type ResourceNameListType = ResourceNameType[];
+        export type ResourceNameType = string;    // max: 2048, min: 1
+        export type ResourceSpecificResultListType = ResourceSpecificResult[];
+        export type SAMLMetadataDocumentType = string;    // max: 10000000, min: 1000
+        export type SAMLProviderListType = SAMLProviderListEntry[];
+        export type SAMLProviderNameType = string;    // pattern: &quot;[\w._-]+&quot;, max: 128, min: 1
+        export type SSHPublicKeyListType = SSHPublicKeyMetadata[];
+        export type SimulationPolicyListType = policyDocumentType[];
+        export type StatementListType = Statement[];
+        export type accessKeyIdType = string;    // pattern: &quot;[\w]+&quot;, max: 32, min: 16
+        export type accessKeyMetadataListType = AccessKeyMetadata[];
+        export type accessKeySecretType = string;
+        export type accountAliasListType = accountAliasType[];
+        export type accountAliasType = string;    // pattern: &quot;^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$&quot;, max: 63, min: 3
+        export type arnType = string;    // max: 2048, min: 20
+        export type assignmentStatusType = string;
+        export type attachedPoliciesListType = AttachedPolicy[];
+        export type attachmentCountType = number;
+        export type authenticationCodeType = string;    // pattern: &quot;[\d]+&quot;, max: 6, min: 6
+        export type booleanObjectType = boolean;
+        export type booleanType = boolean;
+        export type certificateBodyType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 16384, min: 1
+        export type certificateChainType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 2097152, min: 1
+        export type certificateIdType = string;    // pattern: &quot;[\w]+&quot;, max: 128, min: 24
+        export type certificateListType = SigningCertificate[];
+        export type clientIDListType = clientIDType[];
+        export type clientIDType = string;    // max: 255, min: 1
+        export type credentialReportExpiredExceptionMessage = string;
+        export type credentialReportNotPresentExceptionMessage = string;
+        export type credentialReportNotReadyExceptionMessage = string;
+        export type dateType = number;
+        export type deleteConflictMessage = string;
+        export type duplicateCertificateMessage = string;
+        export type duplicateSSHPublicKeyMessage = string;
+        export type encodingType = string;
+        export type entityAlreadyExistsMessage = string;
+        export type entityListType = EntityType[];
+        export type entityTemporarilyUnmodifiableMessage = string;
+        export type existingUserNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 128, min: 1
+        export type groupDetailListType = GroupDetail[];
+        export type groupListType = Group[];
+        export type groupNameListType = groupNameType[];
+        export type groupNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 128, min: 1
+        export type idType = string;    // pattern: &quot;[\w]+&quot;, max: 32, min: 16
+        export type instanceProfileListType = InstanceProfile[];
+        export type instanceProfileNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 128, min: 1
+        export type invalidAuthenticationCodeMessage = string;
+        export type invalidCertificateMessage = string;
+        export type invalidInputMessage = string;
+        export type invalidPublicKeyMessage = string;
+        export type invalidUserTypeMessage = string;
+        export type keyPairMismatchMessage = string;
+        export type limitExceededMessage = string;
+        export type malformedCertificateMessage = string;
+        export type malformedPolicyDocumentMessage = string;
+        export type markerType = string;    // pattern: &quot;[\u0020-\u00FF]+&quot;, max: 320, min: 1
+        export type maxItemsType = number;    // max: 1000, min: 1
+        export type maxPasswordAgeType = number;    // max: 1095, min: 1
+        export type mfaDeviceListType = MFADevice[];
+        export type minimumPasswordLengthType = number;    // max: 128, min: 6
+        export type noSuchEntityMessage = string;
+        export type passwordPolicyViolationMessage = string;
+        export type passwordReusePreventionType = number;    // max: 24, min: 1
+        export type passwordType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 128, min: 1
+        export type pathPrefixType = string;    // pattern: &quot;\u002F[\u0021-\u007F]*&quot;, max: 512, min: 1
+        export type pathType = string;    // pattern: &quot;(\u002F)|(\u002F[\u0021-\u007F]+\u002F)&quot;, max: 512, min: 1
+        export type policyDescriptionType = string;    // max: 1000
+        export type policyDetailListType = PolicyDetail[];
+        export type policyDocumentType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 131072, min: 1
+        export type policyDocumentVersionListType = PolicyVersion[];
+        export type policyEvaluationErrorMessage = string;
+        export type policyListType = Policy[];
+        export type policyNameListType = policyNameType[];
+        export type policyNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 128, min: 1
+        export type policyPathType = string;    // pattern: &quot;((/[A-Za-z0-9\.,\+@=_-]+)*)/&quot;
+        export type policyScopeType = string;
+        export type policyVersionIdType = string;    // pattern: &quot;v[1-9][0-9]*(\.[A-Za-z0-9-]*)?&quot;
+        export type privateKeyType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 16384, min: 1
+        export type publicKeyFingerprintType = string;    // pattern: &quot;[:\w]+&quot;, max: 48, min: 48
+        export type publicKeyIdType = string;    // pattern: &quot;[\w]+&quot;, max: 128, min: 20
+        export type publicKeyMaterialType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 16384, min: 1
+        export type roleDetailListType = RoleDetail[];
+        export type roleListType = Role[];
+        export type roleNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 64, min: 1
+        export type serialNumberType = string;    // pattern: &quot;[\w+=/:,.@-]+&quot;, max: 256, min: 9
+        export type serverCertificateMetadataListType = ServerCertificateMetadata[];
+        export type serverCertificateNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 128, min: 1
+        export type serviceFailureExceptionMessage = string;
+        export type statusType = string;
+        export type stringType = string;
+        export type summaryKeyType = string;
+        export type summaryMapType = {[key:string]: summaryValueType};
+        export type summaryValueType = number;
+        export type thumbprintListType = thumbprintType[];
+        export type thumbprintType = string;    // max: 40, min: 40
+        export type unrecognizedPublicKeyEncodingMessage = string;
+        export type userDetailListType = UserDetail[];
+        export type userListType = User[];
+        export type userNameType = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 64, min: 1
+        export type virtualMFADeviceListType = VirtualMFADevice[];
+        export type virtualMFADeviceName = string;    // pattern: &quot;[\w+=,.@-]+&quot;, min: 1
+
+        export interface AccessKey {
+            UserName: userNameType;            
+            AccessKeyId: accessKeyIdType;            
+            Status: statusType;            
+            SecretAccessKey: accessKeySecretType;            
+            CreateDate?: dateType;            
+        }
+        export interface AccessKeyLastUsed {
+            LastUsedDate: dateType;            
+            ServiceName: stringType;            
+            Region: stringType;            
+        }
+        export interface AccessKeyMetadata {
+            UserName?: userNameType;            
+            AccessKeyId?: accessKeyIdType;            
+            Status?: statusType;            
+            CreateDate?: dateType;            
+        }
+        export interface AddClientIDToOpenIDConnectProviderRequest {
+            OpenIDConnectProviderArn: arnType;            
+            ClientID: clientIDType;            
+        }
+        export interface AddRoleToInstanceProfileRequest {
+            InstanceProfileName: instanceProfileNameType;            
+            RoleName: roleNameType;            
+        }
+        export interface AddUserToGroupRequest {
+            GroupName: groupNameType;            
+            UserName: existingUserNameType;            
+        }
+        export interface AttachGroupPolicyRequest {
+            GroupName: groupNameType;            
+            PolicyArn: arnType;            
+        }
+        export interface AttachRolePolicyRequest {
+            RoleName: roleNameType;            
+            PolicyArn: arnType;            
+        }
+        export interface AttachUserPolicyRequest {
+            UserName: userNameType;            
+            PolicyArn: arnType;            
+        }
+        export interface AttachedPolicy {
+            PolicyName?: policyNameType;            
+            PolicyArn?: arnType;            
+        }
+        export interface ChangePasswordRequest {
+            OldPassword: passwordType;            
+            NewPassword: passwordType;            
+        }
+        export interface ContextEntry {
+            ContextKeyName?: ContextKeyNameType;            
+            ContextKeyValues?: ContextKeyValueListType;            
+            ContextKeyType?: ContextKeyTypeEnum;            
+        }
+        export interface CreateAccessKeyRequest {
+            UserName?: existingUserNameType;            
+        }
+        export interface CreateAccessKeyResponse {
+            AccessKey: AccessKey;            
+        }
+        export interface CreateAccountAliasRequest {
+            AccountAlias: accountAliasType;            
+        }
+        export interface CreateGroupRequest {
+            Path?: pathType;            
+            GroupName: groupNameType;            
+        }
+        export interface CreateGroupResponse {
+            Group: Group;            
+        }
+        export interface CreateInstanceProfileRequest {
+            InstanceProfileName: instanceProfileNameType;            
+            Path?: pathType;            
+        }
+        export interface CreateInstanceProfileResponse {
+            InstanceProfile: InstanceProfile;            
+        }
+        export interface CreateLoginProfileRequest {
+            UserName: userNameType;            
+            Password: passwordType;            
+            PasswordResetRequired?: booleanType;            
+        }
+        export interface CreateLoginProfileResponse {
+            LoginProfile: LoginProfile;            
+        }
+        export interface CreateOpenIDConnectProviderRequest {
+            Url: OpenIDConnectProviderUrlType;            
+            ClientIDList?: clientIDListType;            
+            ThumbprintList: thumbprintListType;            
+        }
+        export interface CreateOpenIDConnectProviderResponse {
+            OpenIDConnectProviderArn?: arnType;            
+        }
+        export interface CreatePolicyRequest {
+            PolicyName: policyNameType;            
+            Path?: policyPathType;            
+            PolicyDocument: policyDocumentType;            
+            Description?: policyDescriptionType;            
+        }
+        export interface CreatePolicyResponse {
+            Policy?: Policy;            
+        }
+        export interface CreatePolicyVersionRequest {
+            PolicyArn: arnType;            
+            PolicyDocument: policyDocumentType;            
+            SetAsDefault?: booleanType;            
+        }
+        export interface CreatePolicyVersionResponse {
+            PolicyVersion?: PolicyVersion;            
+        }
+        export interface CreateRoleRequest {
+            Path?: pathType;            
+            RoleName: roleNameType;            
+            AssumeRolePolicyDocument: policyDocumentType;            
+        }
+        export interface CreateRoleResponse {
+            Role: Role;            
+        }
+        export interface CreateSAMLProviderRequest {
+            SAMLMetadataDocument: SAMLMetadataDocumentType;            
+            Name: SAMLProviderNameType;            
+        }
+        export interface CreateSAMLProviderResponse {
+            SAMLProviderArn?: arnType;            
+        }
+        export interface CreateUserRequest {
+            Path?: pathType;            
+            UserName: userNameType;            
+        }
+        export interface CreateUserResponse {
+            User?: User;            
+        }
+        export interface CreateVirtualMFADeviceRequest {
+            Path?: pathType;            
+            VirtualMFADeviceName: virtualMFADeviceName;            
+        }
+        export interface CreateVirtualMFADeviceResponse {
+            VirtualMFADevice: VirtualMFADevice;            
+        }
+        export interface CredentialReportExpiredException {
+            message?: credentialReportExpiredExceptionMessage;            
+        }
+        export interface CredentialReportNotPresentException {
+            message?: credentialReportNotPresentExceptionMessage;            
+        }
+        export interface CredentialReportNotReadyException {
+            message?: credentialReportNotReadyExceptionMessage;            
+        }
+        export interface DeactivateMFADeviceRequest {
+            UserName: existingUserNameType;            
+            SerialNumber: serialNumberType;            
+        }
+        export interface DeleteAccessKeyRequest {
+            UserName?: existingUserNameType;            
+            AccessKeyId: accessKeyIdType;            
+        }
+        export interface DeleteAccountAliasRequest {
+            AccountAlias: accountAliasType;            
+        }
+        export interface DeleteConflictException {
+            message?: deleteConflictMessage;            
+        }
+        export interface DeleteGroupPolicyRequest {
+            GroupName: groupNameType;            
+            PolicyName: policyNameType;            
+        }
+        export interface DeleteGroupRequest {
+            GroupName: groupNameType;            
+        }
+        export interface DeleteInstanceProfileRequest {
+            InstanceProfileName: instanceProfileNameType;            
+        }
+        export interface DeleteLoginProfileRequest {
+            UserName: userNameType;            
+        }
+        export interface DeleteOpenIDConnectProviderRequest {
+            OpenIDConnectProviderArn: arnType;            
+        }
+        export interface DeletePolicyRequest {
+            PolicyArn: arnType;            
+        }
+        export interface DeletePolicyVersionRequest {
+            PolicyArn: arnType;            
+            VersionId: policyVersionIdType;            
+        }
+        export interface DeleteRolePolicyRequest {
+            RoleName: roleNameType;            
+            PolicyName: policyNameType;            
+        }
+        export interface DeleteRoleRequest {
+            RoleName: roleNameType;            
+        }
+        export interface DeleteSAMLProviderRequest {
+            SAMLProviderArn: arnType;            
+        }
+        export interface DeleteSSHPublicKeyRequest {
+            UserName: userNameType;            
+            SSHPublicKeyId: publicKeyIdType;            
+        }
+        export interface DeleteServerCertificateRequest {
+            ServerCertificateName: serverCertificateNameType;            
+        }
+        export interface DeleteSigningCertificateRequest {
+            UserName?: existingUserNameType;            
+            CertificateId: certificateIdType;            
+        }
+        export interface DeleteUserPolicyRequest {
+            UserName: existingUserNameType;            
+            PolicyName: policyNameType;            
+        }
+        export interface DeleteUserRequest {
+            UserName: existingUserNameType;            
+        }
+        export interface DeleteVirtualMFADeviceRequest {
+            SerialNumber: serialNumberType;            
+        }
+        export interface DetachGroupPolicyRequest {
+            GroupName: groupNameType;            
+            PolicyArn: arnType;            
+        }
+        export interface DetachRolePolicyRequest {
+            RoleName: roleNameType;            
+            PolicyArn: arnType;            
+        }
+        export interface DetachUserPolicyRequest {
+            UserName: userNameType;            
+            PolicyArn: arnType;            
+        }
+        export interface DuplicateCertificateException {
+            message?: duplicateCertificateMessage;            
+        }
+        export interface DuplicateSSHPublicKeyException {
+            message?: duplicateSSHPublicKeyMessage;            
+        }
+        export interface EnableMFADeviceRequest {
+            UserName: existingUserNameType;            
+            SerialNumber: serialNumberType;            
+            AuthenticationCode1: authenticationCodeType;            
+            AuthenticationCode2: authenticationCodeType;            
+        }
+        export interface EntityAlreadyExistsException {
+            message?: entityAlreadyExistsMessage;            
+        }
+        export interface EntityTemporarilyUnmodifiableException {
+            message?: entityTemporarilyUnmodifiableMessage;            
+        }
+        export interface EvaluationResult {
+            EvalActionName: ActionNameType;            
+            EvalResourceName?: ResourceNameType;            
+            EvalDecision: PolicyEvaluationDecisionType;            
+            MatchedStatements?: StatementListType;            
+            MissingContextValues?: ContextKeyNamesResultListType;            
+            EvalDecisionDetails?: EvalDecisionDetailsType;            
+            ResourceSpecificResults?: ResourceSpecificResultListType;            
+        }
+        export interface GenerateCredentialReportResponse {
+            State?: ReportStateType;            
+            Description?: ReportStateDescriptionType;            
+        }
+        export interface GetAccessKeyLastUsedRequest {
+            AccessKeyId: accessKeyIdType;            
+        }
+        export interface GetAccessKeyLastUsedResponse {
+            UserName?: existingUserNameType;            
+            AccessKeyLastUsed?: AccessKeyLastUsed;            
+        }
+        export interface GetAccountAuthorizationDetailsRequest {
+            Filter?: entityListType;            
+            MaxItems?: maxItemsType;            
+            Marker?: markerType;            
+        }
+        export interface GetAccountAuthorizationDetailsResponse {
+            UserDetailList?: userDetailListType;            
+            GroupDetailList?: groupDetailListType;            
+            RoleDetailList?: roleDetailListType;            
+            Policies?: ManagedPolicyDetailListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface GetAccountPasswordPolicyResponse {
+            PasswordPolicy: PasswordPolicy;            
+        }
+        export interface GetAccountSummaryResponse {
+            SummaryMap?: summaryMapType;            
+        }
+        export interface GetContextKeysForCustomPolicyRequest {
+            PolicyInputList: SimulationPolicyListType;            
+        }
+        export interface GetContextKeysForPolicyResponse {
+            ContextKeyNames?: ContextKeyNamesResultListType;            
+        }
+        export interface GetContextKeysForPrincipalPolicyRequest {
+            PolicySourceArn: arnType;            
+            PolicyInputList?: SimulationPolicyListType;            
+        }
+        export interface GetCredentialReportResponse {
+            Content?: ReportContentType;            
+            ReportFormat?: ReportFormatType;            
+            GeneratedTime?: dateType;            
+        }
+        export interface GetGroupPolicyRequest {
+            GroupName: groupNameType;            
+            PolicyName: policyNameType;            
+        }
+        export interface GetGroupPolicyResponse {
+            GroupName: groupNameType;            
+            PolicyName: policyNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface GetGroupRequest {
+            GroupName: groupNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface GetGroupResponse {
+            Group: Group;            
+            Users: userListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface GetInstanceProfileRequest {
+            InstanceProfileName: instanceProfileNameType;            
+        }
+        export interface GetInstanceProfileResponse {
+            InstanceProfile: InstanceProfile;            
+        }
+        export interface GetLoginProfileRequest {
+            UserName: userNameType;            
+        }
+        export interface GetLoginProfileResponse {
+            LoginProfile: LoginProfile;            
+        }
+        export interface GetOpenIDConnectProviderRequest {
+            OpenIDConnectProviderArn: arnType;            
+        }
+        export interface GetOpenIDConnectProviderResponse {
+            Url?: OpenIDConnectProviderUrlType;            
+            ClientIDList?: clientIDListType;            
+            ThumbprintList?: thumbprintListType;            
+            CreateDate?: dateType;            
+        }
+        export interface GetPolicyRequest {
+            PolicyArn: arnType;            
+        }
+        export interface GetPolicyResponse {
+            Policy?: Policy;            
+        }
+        export interface GetPolicyVersionRequest {
+            PolicyArn: arnType;            
+            VersionId: policyVersionIdType;            
+        }
+        export interface GetPolicyVersionResponse {
+            PolicyVersion?: PolicyVersion;            
+        }
+        export interface GetRolePolicyRequest {
+            RoleName: roleNameType;            
+            PolicyName: policyNameType;            
+        }
+        export interface GetRolePolicyResponse {
+            RoleName: roleNameType;            
+            PolicyName: policyNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface GetRoleRequest {
+            RoleName: roleNameType;            
+        }
+        export interface GetRoleResponse {
+            Role: Role;            
+        }
+        export interface GetSAMLProviderRequest {
+            SAMLProviderArn: arnType;            
+        }
+        export interface GetSAMLProviderResponse {
+            SAMLMetadataDocument?: SAMLMetadataDocumentType;            
+            CreateDate?: dateType;            
+            ValidUntil?: dateType;            
+        }
+        export interface GetSSHPublicKeyRequest {
+            UserName: userNameType;            
+            SSHPublicKeyId: publicKeyIdType;            
+            Encoding: encodingType;            
+        }
+        export interface GetSSHPublicKeyResponse {
+            SSHPublicKey?: SSHPublicKey;            
+        }
+        export interface GetServerCertificateRequest {
+            ServerCertificateName: serverCertificateNameType;            
+        }
+        export interface GetServerCertificateResponse {
+            ServerCertificate: ServerCertificate;            
+        }
+        export interface GetUserPolicyRequest {
+            UserName: existingUserNameType;            
+            PolicyName: policyNameType;            
+        }
+        export interface GetUserPolicyResponse {
+            UserName: existingUserNameType;            
+            PolicyName: policyNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface GetUserRequest {
+            UserName?: existingUserNameType;            
+        }
+        export interface GetUserResponse {
+            User: User;            
+        }
+        export interface Group {
+            Path: pathType;            
+            GroupName: groupNameType;            
+            GroupId: idType;            
+            Arn: arnType;            
+            CreateDate: dateType;            
+        }
+        export interface GroupDetail {
+            Path?: pathType;            
+            GroupName?: groupNameType;            
+            GroupId?: idType;            
+            Arn?: arnType;            
+            CreateDate?: dateType;            
+            GroupPolicyList?: policyDetailListType;            
+            AttachedManagedPolicies?: attachedPoliciesListType;            
+        }
+        export interface InstanceProfile {
+            Path: pathType;            
+            InstanceProfileName: instanceProfileNameType;            
+            InstanceProfileId: idType;            
+            Arn: arnType;            
+            CreateDate: dateType;            
+            Roles: roleListType;            
+        }
+        export interface InvalidAuthenticationCodeException {
+            message?: invalidAuthenticationCodeMessage;            
+        }
+        export interface InvalidCertificateException {
+            message?: invalidCertificateMessage;            
+        }
+        export interface InvalidInputException {
+            message?: invalidInputMessage;            
+        }
+        export interface InvalidPublicKeyException {
+            message?: invalidPublicKeyMessage;            
+        }
+        export interface InvalidUserTypeException {
+            message?: invalidUserTypeMessage;            
+        }
+        export interface KeyPairMismatchException {
+            message?: keyPairMismatchMessage;            
+        }
+        export interface LimitExceededException {
+            message?: limitExceededMessage;            
+        }
+        export interface ListAccessKeysRequest {
+            UserName?: existingUserNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListAccessKeysResponse {
+            AccessKeyMetadata: accessKeyMetadataListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListAccountAliasesRequest {
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListAccountAliasesResponse {
+            AccountAliases: accountAliasListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListAttachedGroupPoliciesRequest {
+            GroupName: groupNameType;            
+            PathPrefix?: policyPathType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListAttachedGroupPoliciesResponse {
+            AttachedPolicies?: attachedPoliciesListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListAttachedRolePoliciesRequest {
+            RoleName: roleNameType;            
+            PathPrefix?: policyPathType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListAttachedRolePoliciesResponse {
+            AttachedPolicies?: attachedPoliciesListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListAttachedUserPoliciesRequest {
+            UserName: userNameType;            
+            PathPrefix?: policyPathType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListAttachedUserPoliciesResponse {
+            AttachedPolicies?: attachedPoliciesListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListEntitiesForPolicyRequest {
+            PolicyArn: arnType;            
+            EntityFilter?: EntityType;            
+            PathPrefix?: pathType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListEntitiesForPolicyResponse {
+            PolicyGroups?: PolicyGroupListType;            
+            PolicyUsers?: PolicyUserListType;            
+            PolicyRoles?: PolicyRoleListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListGroupPoliciesRequest {
+            GroupName: groupNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListGroupPoliciesResponse {
+            PolicyNames: policyNameListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListGroupsForUserRequest {
+            UserName: existingUserNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListGroupsForUserResponse {
+            Groups: groupListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListGroupsRequest {
+            PathPrefix?: pathPrefixType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListGroupsResponse {
+            Groups: groupListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListInstanceProfilesForRoleRequest {
+            RoleName: roleNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListInstanceProfilesForRoleResponse {
+            InstanceProfiles: instanceProfileListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListInstanceProfilesRequest {
+            PathPrefix?: pathPrefixType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListInstanceProfilesResponse {
+            InstanceProfiles: instanceProfileListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListMFADevicesRequest {
+            UserName?: existingUserNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListMFADevicesResponse {
+            MFADevices: mfaDeviceListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListOpenIDConnectProvidersRequest {
+        }
+        export interface ListOpenIDConnectProvidersResponse {
+            OpenIDConnectProviderList?: OpenIDConnectProviderListType;            
+        }
+        export interface ListPoliciesRequest {
+            Scope?: policyScopeType;            
+            OnlyAttached?: booleanType;            
+            PathPrefix?: policyPathType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListPoliciesResponse {
+            Policies?: policyListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListPolicyVersionsRequest {
+            PolicyArn: arnType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListPolicyVersionsResponse {
+            Versions?: policyDocumentVersionListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListRolePoliciesRequest {
+            RoleName: roleNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListRolePoliciesResponse {
+            PolicyNames: policyNameListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListRolesRequest {
+            PathPrefix?: pathPrefixType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListRolesResponse {
+            Roles: roleListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListSAMLProvidersRequest {
+        }
+        export interface ListSAMLProvidersResponse {
+            SAMLProviderList?: SAMLProviderListType;            
+        }
+        export interface ListSSHPublicKeysRequest {
+            UserName?: userNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListSSHPublicKeysResponse {
+            SSHPublicKeys?: SSHPublicKeyListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListServerCertificatesRequest {
+            PathPrefix?: pathPrefixType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListServerCertificatesResponse {
+            ServerCertificateMetadataList: serverCertificateMetadataListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListSigningCertificatesRequest {
+            UserName?: existingUserNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListSigningCertificatesResponse {
+            Certificates: certificateListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListUserPoliciesRequest {
+            UserName: existingUserNameType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListUserPoliciesResponse {
+            PolicyNames: policyNameListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListUsersRequest {
+            PathPrefix?: pathPrefixType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListUsersResponse {
+            Users: userListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface ListVirtualMFADevicesRequest {
+            AssignmentStatus?: assignmentStatusType;            
+            Marker?: markerType;            
+            MaxItems?: maxItemsType;            
+        }
+        export interface ListVirtualMFADevicesResponse {
+            VirtualMFADevices: virtualMFADeviceListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface LoginProfile {
+            UserName: userNameType;            
+            CreateDate: dateType;            
+            PasswordResetRequired?: booleanType;            
+        }
+        export interface MFADevice {
+            UserName: userNameType;            
+            SerialNumber: serialNumberType;            
+            EnableDate: dateType;            
+        }
+        export interface MalformedCertificateException {
+            message?: malformedCertificateMessage;            
+        }
+        export interface MalformedPolicyDocumentException {
+            message?: malformedPolicyDocumentMessage;            
+        }
+        export interface ManagedPolicyDetail {
+            PolicyName?: policyNameType;            
+            PolicyId?: idType;            
+            Arn?: arnType;            
+            Path?: policyPathType;            
+            DefaultVersionId?: policyVersionIdType;            
+            AttachmentCount?: attachmentCountType;            
+            IsAttachable?: booleanType;            
+            Description?: policyDescriptionType;            
+            CreateDate?: dateType;            
+            UpdateDate?: dateType;            
+            PolicyVersionList?: policyDocumentVersionListType;            
+        }
+        export interface NoSuchEntityException {
+            message?: noSuchEntityMessage;            
+        }
+        export interface OpenIDConnectProviderListEntry {
+            Arn?: arnType;            
+        }
+        export interface PasswordPolicy {
+            MinimumPasswordLength?: minimumPasswordLengthType;            
+            RequireSymbols?: booleanType;            
+            RequireNumbers?: booleanType;            
+            RequireUppercaseCharacters?: booleanType;            
+            RequireLowercaseCharacters?: booleanType;            
+            AllowUsersToChangePassword?: booleanType;            
+            ExpirePasswords?: booleanType;            
+            MaxPasswordAge?: maxPasswordAgeType;            
+            PasswordReusePrevention?: passwordReusePreventionType;            
+            HardExpiry?: booleanObjectType;            
+        }
+        export interface PasswordPolicyViolationException {
+            message?: passwordPolicyViolationMessage;            
+        }
+        export interface Policy {
+            PolicyName?: policyNameType;            
+            PolicyId?: idType;            
+            Arn?: arnType;            
+            Path?: policyPathType;            
+            DefaultVersionId?: policyVersionIdType;            
+            AttachmentCount?: attachmentCountType;            
+            IsAttachable?: booleanType;            
+            Description?: policyDescriptionType;            
+            CreateDate?: dateType;            
+            UpdateDate?: dateType;            
+        }
+        export interface PolicyDetail {
+            PolicyName?: policyNameType;            
+            PolicyDocument?: policyDocumentType;            
+        }
+        export interface PolicyEvaluationException {
+            message?: policyEvaluationErrorMessage;            
+        }
+        export interface PolicyGroup {
+            GroupName?: groupNameType;            
+        }
+        export interface PolicyRole {
+            RoleName?: roleNameType;            
+        }
+        export interface PolicyUser {
+            UserName?: userNameType;            
+        }
+        export interface PolicyVersion {
+            Document?: policyDocumentType;            
+            VersionId?: policyVersionIdType;            
+            IsDefaultVersion?: booleanType;            
+            CreateDate?: dateType;            
+        }
+        export interface Position {
+            Line?: LineNumber;            
+            Column?: ColumnNumber;            
+        }
+        export interface PutGroupPolicyRequest {
+            GroupName: groupNameType;            
+            PolicyName: policyNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface PutRolePolicyRequest {
+            RoleName: roleNameType;            
+            PolicyName: policyNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface PutUserPolicyRequest {
+            UserName: existingUserNameType;            
+            PolicyName: policyNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface RemoveClientIDFromOpenIDConnectProviderRequest {
+            OpenIDConnectProviderArn: arnType;            
+            ClientID: clientIDType;            
+        }
+        export interface RemoveRoleFromInstanceProfileRequest {
+            InstanceProfileName: instanceProfileNameType;            
+            RoleName: roleNameType;            
+        }
+        export interface RemoveUserFromGroupRequest {
+            GroupName: groupNameType;            
+            UserName: existingUserNameType;            
+        }
+        export interface ResourceSpecificResult {
+            EvalResourceName: ResourceNameType;            
+            EvalResourceDecision: PolicyEvaluationDecisionType;            
+            MatchedStatements?: StatementListType;            
+            MissingContextValues?: ContextKeyNamesResultListType;            
+            EvalDecisionDetails?: EvalDecisionDetailsType;            
+        }
+        export interface ResyncMFADeviceRequest {
+            UserName: existingUserNameType;            
+            SerialNumber: serialNumberType;            
+            AuthenticationCode1: authenticationCodeType;            
+            AuthenticationCode2: authenticationCodeType;            
+        }
+        export interface Role {
+            Path: pathType;            
+            RoleName: roleNameType;            
+            RoleId: idType;            
+            Arn: arnType;            
+            CreateDate: dateType;            
+            AssumeRolePolicyDocument?: policyDocumentType;            
+        }
+        export interface RoleDetail {
+            Path?: pathType;            
+            RoleName?: roleNameType;            
+            RoleId?: idType;            
+            Arn?: arnType;            
+            CreateDate?: dateType;            
+            AssumeRolePolicyDocument?: policyDocumentType;            
+            InstanceProfileList?: instanceProfileListType;            
+            RolePolicyList?: policyDetailListType;            
+            AttachedManagedPolicies?: attachedPoliciesListType;            
+        }
+        export interface SAMLProviderListEntry {
+            Arn?: arnType;            
+            ValidUntil?: dateType;            
+            CreateDate?: dateType;            
+        }
+        export interface SSHPublicKey {
+            UserName: userNameType;            
+            SSHPublicKeyId: publicKeyIdType;            
+            Fingerprint: publicKeyFingerprintType;            
+            SSHPublicKeyBody: publicKeyMaterialType;            
+            Status: statusType;            
+            UploadDate?: dateType;            
+        }
+        export interface SSHPublicKeyMetadata {
+            UserName: userNameType;            
+            SSHPublicKeyId: publicKeyIdType;            
+            Status: statusType;            
+            UploadDate: dateType;            
+        }
+        export interface ServerCertificate {
+            ServerCertificateMetadata: ServerCertificateMetadata;            
+            CertificateBody: certificateBodyType;            
+            CertificateChain?: certificateChainType;            
+        }
+        export interface ServerCertificateMetadata {
+            Path: pathType;            
+            ServerCertificateName: serverCertificateNameType;            
+            ServerCertificateId: idType;            
+            Arn: arnType;            
+            UploadDate?: dateType;            
+            Expiration?: dateType;            
+        }
+        export interface ServiceFailureException {
+            message?: serviceFailureExceptionMessage;            
+        }
+        export interface SetDefaultPolicyVersionRequest {
+            PolicyArn: arnType;            
+            VersionId: policyVersionIdType;            
+        }
+        export interface SigningCertificate {
+            UserName: userNameType;            
+            CertificateId: certificateIdType;            
+            CertificateBody: certificateBodyType;            
+            Status: statusType;            
+            UploadDate?: dateType;            
+        }
+        export interface SimulateCustomPolicyRequest {
+            PolicyInputList: SimulationPolicyListType;            
+            ActionNames: ActionNameListType;            
+            ResourceArns?: ResourceNameListType;            
+            ResourcePolicy?: policyDocumentType;            
+            ResourceOwner?: ResourceNameType;            
+            CallerArn?: ResourceNameType;            
+            ContextEntries?: ContextEntryListType;            
+            ResourceHandlingOption?: ResourceHandlingOptionType;            
+            MaxItems?: maxItemsType;            
+            Marker?: markerType;            
+        }
+        export interface SimulatePolicyResponse {
+            EvaluationResults?: EvaluationResultsListType;            
+            IsTruncated?: booleanType;            
+            Marker?: markerType;            
+        }
+        export interface SimulatePrincipalPolicyRequest {
+            PolicySourceArn: arnType;            
+            PolicyInputList?: SimulationPolicyListType;            
+            ActionNames: ActionNameListType;            
+            ResourceArns?: ResourceNameListType;            
+            ResourcePolicy?: policyDocumentType;            
+            ResourceOwner?: ResourceNameType;            
+            CallerArn?: ResourceNameType;            
+            ContextEntries?: ContextEntryListType;            
+            ResourceHandlingOption?: ResourceHandlingOptionType;            
+            MaxItems?: maxItemsType;            
+            Marker?: markerType;            
+        }
+        export interface Statement {
+            SourcePolicyId?: PolicyIdentifierType;            
+            SourcePolicyType?: PolicySourceType;            
+            StartPosition?: Position;            
+            EndPosition?: Position;            
+        }
+        export interface UnrecognizedPublicKeyEncodingException {
+            message?: unrecognizedPublicKeyEncodingMessage;            
+        }
+        export interface UpdateAccessKeyRequest {
+            UserName?: existingUserNameType;            
+            AccessKeyId: accessKeyIdType;            
+            Status: statusType;            
+        }
+        export interface UpdateAccountPasswordPolicyRequest {
+            MinimumPasswordLength?: minimumPasswordLengthType;            
+            RequireSymbols?: booleanType;            
+            RequireNumbers?: booleanType;            
+            RequireUppercaseCharacters?: booleanType;            
+            RequireLowercaseCharacters?: booleanType;            
+            AllowUsersToChangePassword?: booleanType;            
+            MaxPasswordAge?: maxPasswordAgeType;            
+            PasswordReusePrevention?: passwordReusePreventionType;            
+            HardExpiry?: booleanObjectType;            
+        }
+        export interface UpdateAssumeRolePolicyRequest {
+            RoleName: roleNameType;            
+            PolicyDocument: policyDocumentType;            
+        }
+        export interface UpdateGroupRequest {
+            GroupName: groupNameType;            
+            NewPath?: pathType;            
+            NewGroupName?: groupNameType;            
+        }
+        export interface UpdateLoginProfileRequest {
+            UserName: userNameType;            
+            Password?: passwordType;            
+            PasswordResetRequired?: booleanObjectType;            
+        }
+        export interface UpdateOpenIDConnectProviderThumbprintRequest {
+            OpenIDConnectProviderArn: arnType;            
+            ThumbprintList: thumbprintListType;            
+        }
+        export interface UpdateSAMLProviderRequest {
+            SAMLMetadataDocument: SAMLMetadataDocumentType;            
+            SAMLProviderArn: arnType;            
+        }
+        export interface UpdateSAMLProviderResponse {
+            SAMLProviderArn?: arnType;            
+        }
+        export interface UpdateSSHPublicKeyRequest {
+            UserName: userNameType;            
+            SSHPublicKeyId: publicKeyIdType;            
+            Status: statusType;            
+        }
+        export interface UpdateServerCertificateRequest {
+            ServerCertificateName: serverCertificateNameType;            
+            NewPath?: pathType;            
+            NewServerCertificateName?: serverCertificateNameType;            
+        }
+        export interface UpdateSigningCertificateRequest {
+            UserName?: existingUserNameType;            
+            CertificateId: certificateIdType;            
+            Status: statusType;            
+        }
+        export interface UpdateUserRequest {
+            UserName: existingUserNameType;            
+            NewPath?: pathType;            
+            NewUserName?: userNameType;            
+        }
+        export interface UploadSSHPublicKeyRequest {
+            UserName: userNameType;            
+            SSHPublicKeyBody: publicKeyMaterialType;            
+        }
+        export interface UploadSSHPublicKeyResponse {
+            SSHPublicKey?: SSHPublicKey;            
+        }
+        export interface UploadServerCertificateRequest {
+            Path?: pathType;            
+            ServerCertificateName: serverCertificateNameType;            
+            CertificateBody: certificateBodyType;            
+            PrivateKey: privateKeyType;            
+            CertificateChain?: certificateChainType;            
+        }
+        export interface UploadServerCertificateResponse {
+            ServerCertificateMetadata?: ServerCertificateMetadata;            
+        }
+        export interface UploadSigningCertificateRequest {
+            UserName?: existingUserNameType;            
+            CertificateBody: certificateBodyType;            
+        }
+        export interface UploadSigningCertificateResponse {
+            Certificate: SigningCertificate;            
+        }
+        export interface User {
+            Path: pathType;            
+            UserName: userNameType;            
+            UserId: idType;            
+            Arn: arnType;            
+            CreateDate: dateType;            
+            PasswordLastUsed?: dateType;            
+        }
+        export interface UserDetail {
+            Path?: pathType;            
+            UserName?: userNameType;            
+            UserId?: idType;            
+            Arn?: arnType;            
+            CreateDate?: dateType;            
+            UserPolicyList?: policyDetailListType;            
+            GroupList?: groupNameListType;            
+            AttachedManagedPolicies?: attachedPoliciesListType;            
+        }
+        export interface VirtualMFADevice {
+            SerialNumber: serialNumberType;            
+            Base32StringSeed?: BootstrapDatum;            
+            QRCodePNG?: BootstrapDatum;            
+            User?: User;            
+            EnableDate?: dateType;            
+        }
 
-    export interface IAMInvalidPublicKeyException {
-        message?: IAMinvalidPublicKeyMessage;
     }
-
-    export interface IAMInvalidUserTypeException {
-        message?: IAMinvalidUserTypeMessage;
-    }
-
-    export interface IAMKeyPairMismatchException {
-        message?: IAMkeyPairMismatchMessage;
-    }
-
-    export interface IAMLimitExceededException {
-        message?: IAMlimitExceededMessage;
-    }
-
-    export type IAMLineNumber = number;
-    export interface IAMListAccessKeysRequest {
-        UserName?: IAMexistingUserNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListAccessKeysResponse {
-        AccessKeyMetadata: IAMaccessKeyMetadataListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListAccountAliasesRequest {
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListAccountAliasesResponse {
-        AccountAliases: IAMaccountAliasListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListAttachedGroupPoliciesRequest {
-        GroupName: IAMgroupNameType;
-        PathPrefix?: IAMpolicyPathType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListAttachedGroupPoliciesResponse {
-        AttachedPolicies?: IAMattachedPoliciesListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListAttachedRolePoliciesRequest {
-        RoleName: IAMroleNameType;
-        PathPrefix?: IAMpolicyPathType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListAttachedRolePoliciesResponse {
-        AttachedPolicies?: IAMattachedPoliciesListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListAttachedUserPoliciesRequest {
-        UserName: IAMuserNameType;
-        PathPrefix?: IAMpolicyPathType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListAttachedUserPoliciesResponse {
-        AttachedPolicies?: IAMattachedPoliciesListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListEntitiesForPolicyRequest {
-        PolicyArn: IAMarnType;
-        EntityFilter?: IAMEntityType;
-        PathPrefix?: IAMpathType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListEntitiesForPolicyResponse {
-        PolicyGroups?: IAMPolicyGroupListType;
-        PolicyUsers?: IAMPolicyUserListType;
-        PolicyRoles?: IAMPolicyRoleListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListGroupPoliciesRequest {
-        GroupName: IAMgroupNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListGroupPoliciesResponse {
-        PolicyNames: IAMpolicyNameListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListGroupsForUserRequest {
-        UserName: IAMexistingUserNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListGroupsForUserResponse {
-        Groups: IAMgroupListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListGroupsRequest {
-        PathPrefix?: IAMpathPrefixType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListGroupsResponse {
-        Groups: IAMgroupListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListInstanceProfilesForRoleRequest {
-        RoleName: IAMroleNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListInstanceProfilesForRoleResponse {
-        InstanceProfiles: IAMinstanceProfileListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListInstanceProfilesRequest {
-        PathPrefix?: IAMpathPrefixType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListInstanceProfilesResponse {
-        InstanceProfiles: IAMinstanceProfileListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListMFADevicesRequest {
-        UserName?: IAMexistingUserNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListMFADevicesResponse {
-        MFADevices: IAMmfaDeviceListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListOpenIDConnectProvidersRequest {
-    }
-
-    export interface IAMListOpenIDConnectProvidersResponse {
-        OpenIDConnectProviderList?: IAMOpenIDConnectProviderListType;
-    }
-
-    export interface IAMListPoliciesRequest {
-        Scope?: IAMpolicyScopeType;
-        OnlyAttached?: IAMbooleanType;
-        PathPrefix?: IAMpolicyPathType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListPoliciesResponse {
-        Policies?: IAMpolicyListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListPolicyVersionsRequest {
-        PolicyArn: IAMarnType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListPolicyVersionsResponse {
-        Versions?: IAMpolicyDocumentVersionListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListRolePoliciesRequest {
-        RoleName: IAMroleNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListRolePoliciesResponse {
-        PolicyNames: IAMpolicyNameListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListRolesRequest {
-        PathPrefix?: IAMpathPrefixType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListRolesResponse {
-        Roles: IAMroleListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListSAMLProvidersRequest {
-    }
-
-    export interface IAMListSAMLProvidersResponse {
-        SAMLProviderList?: IAMSAMLProviderListType;
-    }
-
-    export interface IAMListSSHPublicKeysRequest {
-        UserName?: IAMuserNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListSSHPublicKeysResponse {
-        SSHPublicKeys?: IAMSSHPublicKeyListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListServerCertificatesRequest {
-        PathPrefix?: IAMpathPrefixType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListServerCertificatesResponse {
-        ServerCertificateMetadataList: IAMserverCertificateMetadataListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListSigningCertificatesRequest {
-        UserName?: IAMexistingUserNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListSigningCertificatesResponse {
-        Certificates: IAMcertificateListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListUserPoliciesRequest {
-        UserName: IAMexistingUserNameType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListUserPoliciesResponse {
-        PolicyNames: IAMpolicyNameListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListUsersRequest {
-        PathPrefix?: IAMpathPrefixType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListUsersResponse {
-        Users: IAMuserListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMListVirtualMFADevicesRequest {
-        AssignmentStatus?: IAMassignmentStatusType;
-        Marker?: IAMmarkerType;
-        MaxItems?: IAMmaxItemsType;
-    }
-
-    export interface IAMListVirtualMFADevicesResponse {
-        VirtualMFADevices: IAMvirtualMFADeviceListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMLoginProfile {
-        UserName: IAMuserNameType;
-        CreateDate: IAMdateType;
-        PasswordResetRequired?: IAMbooleanType;
-    }
-
-    export interface IAMMFADevice {
-        UserName: IAMuserNameType;
-        SerialNumber: IAMserialNumberType;
-        EnableDate: IAMdateType;
-    }
-
-    export interface IAMMalformedCertificateException {
-        message?: IAMmalformedCertificateMessage;
-    }
-
-    export interface IAMMalformedPolicyDocumentException {
-        message?: IAMmalformedPolicyDocumentMessage;
-    }
-
-    export interface IAMManagedPolicyDetail {
-        PolicyName?: IAMpolicyNameType;
-        PolicyId?: IAMidType;
-        Arn?: IAMarnType;
-        Path?: IAMpolicyPathType;
-        DefaultVersionId?: IAMpolicyVersionIdType;
-        AttachmentCount?: IAMattachmentCountType;
-        IsAttachable?: IAMbooleanType;
-        Description?: IAMpolicyDescriptionType;
-        CreateDate?: IAMdateType;
-        UpdateDate?: IAMdateType;
-        PolicyVersionList?: IAMpolicyDocumentVersionListType;
-    }
-
-    export type IAMManagedPolicyDetailListType = Array<IAMManagedPolicyDetail>;
-    export interface IAMNoSuchEntityException {
-        message?: IAMnoSuchEntityMessage;
-    }
-
-    export interface IAMOpenIDConnectProviderListEntry {
-        Arn?: IAMarnType;
-    }
-
-    export type IAMOpenIDConnectProviderListType = Array<IAMOpenIDConnectProviderListEntry>;
-    export type IAMOpenIDConnectProviderUrlType = string;
-    export interface IAMPasswordPolicy {
-        MinimumPasswordLength?: IAMminimumPasswordLengthType;
-        RequireSymbols?: IAMbooleanType;
-        RequireNumbers?: IAMbooleanType;
-        RequireUppercaseCharacters?: IAMbooleanType;
-        RequireLowercaseCharacters?: IAMbooleanType;
-        AllowUsersToChangePassword?: IAMbooleanType;
-        ExpirePasswords?: IAMbooleanType;
-        MaxPasswordAge?: IAMmaxPasswordAgeType;
-        PasswordReusePrevention?: IAMpasswordReusePreventionType;
-        HardExpiry?: IAMbooleanObjectType;
-    }
-
-    export interface IAMPasswordPolicyViolationException {
-        message?: IAMpasswordPolicyViolationMessage;
-    }
-
-    export interface IAMPolicy {
-        PolicyName?: IAMpolicyNameType;
-        PolicyId?: IAMidType;
-        Arn?: IAMarnType;
-        Path?: IAMpolicyPathType;
-        DefaultVersionId?: IAMpolicyVersionIdType;
-        AttachmentCount?: IAMattachmentCountType;
-        IsAttachable?: IAMbooleanType;
-        Description?: IAMpolicyDescriptionType;
-        CreateDate?: IAMdateType;
-        UpdateDate?: IAMdateType;
-    }
-
-    export interface IAMPolicyDetail {
-        PolicyName?: IAMpolicyNameType;
-        PolicyDocument?: IAMpolicyDocumentType;
-    }
-
-    export type IAMPolicyEvaluationDecisionType = string;
-    export interface IAMPolicyEvaluationException {
-        message?: IAMpolicyEvaluationErrorMessage;
-    }
-
-    export interface IAMPolicyGroup {
-        GroupName?: IAMgroupNameType;
-    }
-
-    export type IAMPolicyGroupListType = Array<IAMPolicyGroup>;
-    export type IAMPolicyIdentifierType = string;
-    export interface IAMPolicyRole {
-        RoleName?: IAMroleNameType;
-    }
-
-    export type IAMPolicyRoleListType = Array<IAMPolicyRole>;
-    export type IAMPolicySourceType = string;
-    export interface IAMPolicyUser {
-        UserName?: IAMuserNameType;
-    }
-
-    export type IAMPolicyUserListType = Array<IAMPolicyUser>;
-    export interface IAMPolicyVersion {
-        Document?: IAMpolicyDocumentType;
-        VersionId?: IAMpolicyVersionIdType;
-        IsDefaultVersion?: IAMbooleanType;
-        CreateDate?: IAMdateType;
-    }
-
-    export interface IAMPosition {
-        Line?: IAMLineNumber;
-        Column?: IAMColumnNumber;
-    }
-
-    export interface IAMPutGroupPolicyRequest {
-        GroupName: IAMgroupNameType;
-        PolicyName: IAMpolicyNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMPutRolePolicyRequest {
-        RoleName: IAMroleNameType;
-        PolicyName: IAMpolicyNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMPutUserPolicyRequest {
-        UserName: IAMexistingUserNameType;
-        PolicyName: IAMpolicyNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMRemoveClientIDFromOpenIDConnectProviderRequest {
-        OpenIDConnectProviderArn: IAMarnType;
-        ClientID: IAMclientIDType;
-    }
-
-    export interface IAMRemoveRoleFromInstanceProfileRequest {
-        InstanceProfileName: IAMinstanceProfileNameType;
-        RoleName: IAMroleNameType;
-    }
-
-    export interface IAMRemoveUserFromGroupRequest {
-        GroupName: IAMgroupNameType;
-        UserName: IAMexistingUserNameType;
-    }
-
-    export type IAMReportContentType = any; // not really - it was 'blob' instead - must fix this one
-    export type IAMReportFormatType = string;
-    export type IAMReportStateDescriptionType = string;
-    export type IAMReportStateType = string;
-    export type IAMResourceHandlingOptionType = string;
-    export type IAMResourceNameListType = Array<IAMResourceNameType>;
-    export type IAMResourceNameType = string;
-    export interface IAMResourceSpecificResult {
-        EvalResourceName: IAMResourceNameType;
-        EvalResourceDecision: IAMPolicyEvaluationDecisionType;
-        MatchedStatements?: IAMStatementListType;
-        MissingContextValues?: IAMContextKeyNamesResultListType;
-        EvalDecisionDetails?: IAMEvalDecisionDetailsType;
-    }
-
-    export type IAMResourceSpecificResultListType = Array<IAMResourceSpecificResult>;
-    export interface IAMResyncMFADeviceRequest {
-        UserName: IAMexistingUserNameType;
-        SerialNumber: IAMserialNumberType;
-        AuthenticationCode1: IAMauthenticationCodeType;
-        AuthenticationCode2: IAMauthenticationCodeType;
-    }
-
-    export interface IAMRole {
-        Path: IAMpathType;
-        RoleName: IAMroleNameType;
-        RoleId: IAMidType;
-        Arn: IAMarnType;
-        CreateDate: IAMdateType;
-        AssumeRolePolicyDocument?: IAMpolicyDocumentType;
-    }
-
-    export interface IAMRoleDetail {
-        Path?: IAMpathType;
-        RoleName?: IAMroleNameType;
-        RoleId?: IAMidType;
-        Arn?: IAMarnType;
-        CreateDate?: IAMdateType;
-        AssumeRolePolicyDocument?: IAMpolicyDocumentType;
-        InstanceProfileList?: IAMinstanceProfileListType;
-        RolePolicyList?: IAMpolicyDetailListType;
-        AttachedManagedPolicies?: IAMattachedPoliciesListType;
-    }
-
-    export type IAMSAMLMetadataDocumentType = string;
-    export interface IAMSAMLProviderListEntry {
-        Arn?: IAMarnType;
-        ValidUntil?: IAMdateType;
-        CreateDate?: IAMdateType;
-    }
-
-    export type IAMSAMLProviderListType = Array<IAMSAMLProviderListEntry>;
-    export type IAMSAMLProviderNameType = string; // pattern: "[\w._-]+"
-    export interface IAMSSHPublicKey {
-        UserName: IAMuserNameType;
-        SSHPublicKeyId: IAMpublicKeyIdType;
-        Fingerprint: IAMpublicKeyFingerprintType;
-        SSHPublicKeyBody: IAMpublicKeyMaterialType;
-        Status: IAMstatusType;
-        UploadDate?: IAMdateType;
-    }
-
-    export type IAMSSHPublicKeyListType = Array<IAMSSHPublicKeyMetadata>;
-    export interface IAMSSHPublicKeyMetadata {
-        UserName: IAMuserNameType;
-        SSHPublicKeyId: IAMpublicKeyIdType;
-        Status: IAMstatusType;
-        UploadDate: IAMdateType;
-    }
-
-    export interface IAMServerCertificate {
-        ServerCertificateMetadata: IAMServerCertificateMetadata;
-        CertificateBody: IAMcertificateBodyType;
-        CertificateChain?: IAMcertificateChainType;
-    }
-
-    export interface IAMServerCertificateMetadata {
-        Path: IAMpathType;
-        ServerCertificateName: IAMserverCertificateNameType;
-        ServerCertificateId: IAMidType;
-        Arn: IAMarnType;
-        UploadDate?: IAMdateType;
-        Expiration?: IAMdateType;
-    }
-
-    export interface IAMServiceFailureException {
-        message?: IAMserviceFailureExceptionMessage;
-    }
-
-    export interface IAMSetDefaultPolicyVersionRequest {
-        PolicyArn: IAMarnType;
-        VersionId: IAMpolicyVersionIdType;
-    }
-
-    export interface IAMSigningCertificate {
-        UserName: IAMuserNameType;
-        CertificateId: IAMcertificateIdType;
-        CertificateBody: IAMcertificateBodyType;
-        Status: IAMstatusType;
-        UploadDate?: IAMdateType;
-    }
-
-    export interface IAMSimulateCustomPolicyRequest {
-        PolicyInputList: IAMSimulationPolicyListType;
-        ActionNames: IAMActionNameListType;
-        ResourceArns?: IAMResourceNameListType;
-        ResourcePolicy?: IAMpolicyDocumentType;
-        ResourceOwner?: IAMResourceNameType;
-        CallerArn?: IAMResourceNameType;
-        ContextEntries?: IAMContextEntryListType;
-        ResourceHandlingOption?: IAMResourceHandlingOptionType;
-        MaxItems?: IAMmaxItemsType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMSimulatePolicyResponse {
-        EvaluationResults?: IAMEvaluationResultsListType;
-        IsTruncated?: IAMbooleanType;
-        Marker?: IAMmarkerType;
-    }
-
-    export interface IAMSimulatePrincipalPolicyRequest {
-        PolicySourceArn: IAMarnType;
-        PolicyInputList?: IAMSimulationPolicyListType;
-        ActionNames: IAMActionNameListType;
-        ResourceArns?: IAMResourceNameListType;
-        ResourcePolicy?: IAMpolicyDocumentType;
-        ResourceOwner?: IAMResourceNameType;
-        CallerArn?: IAMResourceNameType;
-        ContextEntries?: IAMContextEntryListType;
-        ResourceHandlingOption?: IAMResourceHandlingOptionType;
-        MaxItems?: IAMmaxItemsType;
-        Marker?: IAMmarkerType;
-    }
-
-    export type IAMSimulationPolicyListType = Array<IAMpolicyDocumentType>;
-    export interface IAMStatement {
-        SourcePolicyId?: IAMPolicyIdentifierType;
-        SourcePolicyType?: IAMPolicySourceType;
-        StartPosition?: IAMPosition;
-        EndPosition?: IAMPosition;
-    }
-
-    export type IAMStatementListType = Array<IAMStatement>;
-    export interface IAMUnrecognizedPublicKeyEncodingException {
-        message?: IAMunrecognizedPublicKeyEncodingMessage;
-    }
-
-    export interface IAMUpdateAccessKeyRequest {
-        UserName?: IAMexistingUserNameType;
-        AccessKeyId: IAMaccessKeyIdType;
-        Status: IAMstatusType;
-    }
-
-    export interface IAMUpdateAccountPasswordPolicyRequest {
-        MinimumPasswordLength?: IAMminimumPasswordLengthType;
-        RequireSymbols?: IAMbooleanType;
-        RequireNumbers?: IAMbooleanType;
-        RequireUppercaseCharacters?: IAMbooleanType;
-        RequireLowercaseCharacters?: IAMbooleanType;
-        AllowUsersToChangePassword?: IAMbooleanType;
-        MaxPasswordAge?: IAMmaxPasswordAgeType;
-        PasswordReusePrevention?: IAMpasswordReusePreventionType;
-        HardExpiry?: IAMbooleanObjectType;
-    }
-
-    export interface IAMUpdateAssumeRolePolicyRequest {
-        RoleName: IAMroleNameType;
-        PolicyDocument: IAMpolicyDocumentType;
-    }
-
-    export interface IAMUpdateGroupRequest {
-        GroupName: IAMgroupNameType;
-        NewPath?: IAMpathType;
-        NewGroupName?: IAMgroupNameType;
-    }
-
-    export interface IAMUpdateLoginProfileRequest {
-        UserName: IAMuserNameType;
-        Password?: IAMpasswordType;
-        PasswordResetRequired?: IAMbooleanObjectType;
-    }
-
-    export interface IAMUpdateOpenIDConnectProviderThumbprintRequest {
-        OpenIDConnectProviderArn: IAMarnType;
-        ThumbprintList: IAMthumbprintListType;
-    }
-
-    export interface IAMUpdateSAMLProviderRequest {
-        SAMLMetadataDocument: IAMSAMLMetadataDocumentType;
-        SAMLProviderArn: IAMarnType;
-    }
-
-    export interface IAMUpdateSAMLProviderResponse {
-        SAMLProviderArn?: IAMarnType;
-    }
-
-    export interface IAMUpdateSSHPublicKeyRequest {
-        UserName: IAMuserNameType;
-        SSHPublicKeyId: IAMpublicKeyIdType;
-        Status: IAMstatusType;
-    }
-
-    export interface IAMUpdateServerCertificateRequest {
-        ServerCertificateName: IAMserverCertificateNameType;
-        NewPath?: IAMpathType;
-        NewServerCertificateName?: IAMserverCertificateNameType;
-    }
-
-    export interface IAMUpdateSigningCertificateRequest {
-        UserName?: IAMexistingUserNameType;
-        CertificateId: IAMcertificateIdType;
-        Status: IAMstatusType;
-    }
-
-    export interface IAMUpdateUserRequest {
-        UserName: IAMexistingUserNameType;
-        NewPath?: IAMpathType;
-        NewUserName?: IAMuserNameType;
-    }
-
-    export interface IAMUploadSSHPublicKeyRequest {
-        UserName: IAMuserNameType;
-        SSHPublicKeyBody: IAMpublicKeyMaterialType;
-    }
-
-    export interface IAMUploadSSHPublicKeyResponse {
-        SSHPublicKey?: IAMSSHPublicKey;
-    }
-
-    export interface IAMUploadServerCertificateRequest {
-        Path?: IAMpathType;
-        ServerCertificateName: IAMserverCertificateNameType;
-        CertificateBody: IAMcertificateBodyType;
-        PrivateKey: IAMprivateKeyType;
-        CertificateChain?: IAMcertificateChainType;
-    }
-
-    export interface IAMUploadServerCertificateResponse {
-        ServerCertificateMetadata?: IAMServerCertificateMetadata;
-    }
-
-    export interface IAMUploadSigningCertificateRequest {
-        UserName?: IAMexistingUserNameType;
-        CertificateBody: IAMcertificateBodyType;
-    }
-
-    export interface IAMUploadSigningCertificateResponse {
-        Certificate: IAMSigningCertificate;
-    }
-
-    export interface IAMUser {
-        Path: IAMpathType;
-        UserName: IAMuserNameType;
-        UserId: IAMidType;
-        Arn: IAMarnType;
-        CreateDate: IAMdateType;
-        PasswordLastUsed?: IAMdateType;
-    }
-
-    export interface IAMUserDetail {
-        Path?: IAMpathType;
-        UserName?: IAMuserNameType;
-        UserId?: IAMidType;
-        Arn?: IAMarnType;
-        CreateDate?: IAMdateType;
-        UserPolicyList?: IAMpolicyDetailListType;
-        GroupList?: IAMgroupNameListType;
-        AttachedManagedPolicies?: IAMattachedPoliciesListType;
-    }
-
-    export interface IAMVirtualMFADevice {
-        SerialNumber: IAMserialNumberType;
-        Base32StringSeed?: IAMBootstrapDatum;
-        QRCodePNG?: IAMBootstrapDatum;
-        User?: IAMUser;
-        EnableDate?: IAMdateType;
-    }
-
-    export type IAMaccessKeyIdType = string; // pattern: "[\w]+"
-    export type IAMaccessKeyMetadataListType = Array<IAMAccessKeyMetadata>;
-    export type IAMaccessKeySecretType = string;
-    export type IAMaccountAliasListType = Array<IAMaccountAliasType>;
-    export type IAMaccountAliasType = string; // pattern: "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$"
-    export type IAMarnType = string;
-    export type IAMassignmentStatusType = string;
-    export type IAMattachedPoliciesListType = Array<IAMAttachedPolicy>;
-    export type IAMattachmentCountType = number;
-    export type IAMauthenticationCodeType = string; // pattern: "[\d]+"
-    export type IAMbooleanObjectType = boolean;
-    export type IAMbooleanType = boolean;
-    export type IAMcertificateBodyType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type IAMcertificateChainType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type IAMcertificateIdType = string; // pattern: "[\w]+"
-    export type IAMcertificateListType = Array<IAMSigningCertificate>;
-    export type IAMclientIDListType = Array<IAMclientIDType>;
-    export type IAMclientIDType = string;
-    export type IAMcredentialReportExpiredExceptionMessage = string;
-    export type IAMcredentialReportNotPresentExceptionMessage = string;
-    export type IAMcredentialReportNotReadyExceptionMessage = string;
-    export type IAMdateType = number;
-    export type IAMdeleteConflictMessage = string;
-    export type IAMduplicateCertificateMessage = string;
-    export type IAMduplicateSSHPublicKeyMessage = string;
-    export type IAMencodingType = string;
-    export type IAMentityAlreadyExistsMessage = string;
-    export type IAMentityListType = Array<IAMEntityType>;
-    export type IAMentityTemporarilyUnmodifiableMessage = string;
-    export type IAMexistingUserNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMgroupDetailListType = Array<IAMGroupDetail>;
-    export type IAMgroupListType = Array<IAMGroup>;
-    export type IAMgroupNameListType = Array<IAMgroupNameType>;
-    export type IAMgroupNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMidType = string; // pattern: "[\w]+"
-    export type IAMinstanceProfileListType = Array<IAMInstanceProfile>;
-    export type IAMinstanceProfileNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMinvalidAuthenticationCodeMessage = string;
-    export type IAMinvalidCertificateMessage = string;
-    export type IAMinvalidInputMessage = string;
-    export type IAMinvalidPublicKeyMessage = string;
-    export type IAMinvalidUserTypeMessage = string;
-    export type IAMkeyPairMismatchMessage = string;
-    export type IAMlimitExceededMessage = string;
-    export type IAMmalformedCertificateMessage = string;
-    export type IAMmalformedPolicyDocumentMessage = string;
-    export type IAMmarkerType = string; // pattern: "[\u0020-\u00FF]+"
-    export type IAMmaxItemsType = number;
-    export type IAMmaxPasswordAgeType = number;
-    export type IAMmfaDeviceListType = Array<IAMMFADevice>;
-    export type IAMminimumPasswordLengthType = number;
-    export type IAMnoSuchEntityMessage = string;
-    export type IAMpasswordPolicyViolationMessage = string;
-    export type IAMpasswordReusePreventionType = number;
-    export type IAMpasswordType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type IAMpathPrefixType = string; // pattern: "\u002F[\u0021-\u007F]*"
-    export type IAMpathType = string; // pattern: "(\u002F)|(\u002F[\u0021-\u007F]+\u002F)"
-    export type IAMpolicyDescriptionType = string;
-    export type IAMpolicyDetailListType = Array<IAMPolicyDetail>;
-    export type IAMpolicyDocumentType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type IAMpolicyDocumentVersionListType = Array<IAMPolicyVersion>;
-    export type IAMpolicyEvaluationErrorMessage = string;
-    export type IAMpolicyListType = Array<IAMPolicy>;
-    export type IAMpolicyNameListType = Array<IAMpolicyNameType>;
-    export type IAMpolicyNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMpolicyPathType = string; // pattern: "((/[A-Za-z0-9\.,\+@=_-]+)*)/"
-    export type IAMpolicyScopeType = string;
-    export type IAMpolicyVersionIdType = string; // pattern: "v[1-9][0-9]*(\.[A-Za-z0-9-]*)?"
-    export type IAMprivateKeyType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type IAMpublicKeyFingerprintType = string; // pattern: "[:\w]+"
-    export type IAMpublicKeyIdType = string; // pattern: "[\w]+"
-    export type IAMpublicKeyMaterialType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type IAMroleDetailListType = Array<IAMRoleDetail>;
-    export type IAMroleListType = Array<IAMRole>;
-    export type IAMroleNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMserialNumberType = string; // pattern: "[\w+=/:,.@-]+"
-    export type IAMserverCertificateMetadataListType = Array<IAMServerCertificateMetadata>;
-    export type IAMserverCertificateNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMserviceFailureExceptionMessage = string;
-    export type IAMstatusType = string;
-    export type IAMstringType = string;
-    export type IAMsummaryKeyType = string;
-    export type IAMsummaryMapType = any; // not really - it was 'map' instead - must fix this one
-    export type IAMsummaryValueType = number;
-    export type IAMthumbprintListType = Array<IAMthumbprintType>;
-    export type IAMthumbprintType = string;
-    export type IAMunrecognizedPublicKeyEncodingMessage = string;
-    export type IAMuserDetailListType = Array<IAMUserDetail>;
-    export type IAMuserListType = Array<IAMUser>;
-    export type IAMuserNameType = string; // pattern: "[\w+=,.@-]+"
-    export type IAMvirtualMFADeviceListType = Array<IAMVirtualMFADevice>;
-    export type IAMvirtualMFADeviceName = string; // pattern: "[\w+=,.@-]+"
 }

--- a/output/aws-importexport.d.ts
+++ b/output/aws-importexport.d.ts
@@ -6,241 +6,211 @@ declare module "aws-sdk" {
 
     export class ImportExport extends Service {
       constructor(options?: any);
-      cancelJob(params: ImportExportCancelJobInput, callback?: (err: ImportExportInvalidJobIdException|ImportExportExpiredJobIdException|ImportExportCanceledJobIdException|ImportExportUnableToCancelJobIdException|ImportExportInvalidAccessKeyIdException|ImportExportInvalidVersionException|any, data: ImportExportCancelJobOutput|any) => void): Request;
-      createJob(params: ImportExportCreateJobInput, callback?: (err: ImportExportMissingParameterException|ImportExportInvalidParameterException|ImportExportInvalidAccessKeyIdException|ImportExportInvalidAddressException|ImportExportInvalidManifestFieldException|ImportExportMissingManifestFieldException|ImportExportNoSuchBucketException|ImportExportMissingCustomsException|ImportExportInvalidCustomsException|ImportExportInvalidFileSystemException|ImportExportMultipleRegionsException|ImportExportBucketPermissionException|ImportExportMalformedManifestException|ImportExportCreateJobQuotaExceededException|ImportExportInvalidJobIdException|ImportExportInvalidVersionException|any, data: ImportExportCreateJobOutput|any) => void): Request;
-      getShippingLabel(params: ImportExportGetShippingLabelInput, callback?: (err: ImportExportInvalidJobIdException|ImportExportExpiredJobIdException|ImportExportCanceledJobIdException|ImportExportInvalidAccessKeyIdException|ImportExportInvalidAddressException|ImportExportInvalidVersionException|ImportExportInvalidParameterException|any, data: ImportExportGetShippingLabelOutput|any) => void): Request;
-      getStatus(params: ImportExportGetStatusInput, callback?: (err: ImportExportInvalidJobIdException|ImportExportExpiredJobIdException|ImportExportCanceledJobIdException|ImportExportInvalidAccessKeyIdException|ImportExportInvalidVersionException|any, data: ImportExportGetStatusOutput|any) => void): Request;
-      listJobs(params: ImportExportListJobsInput, callback?: (err: ImportExportInvalidParameterException|ImportExportInvalidAccessKeyIdException|ImportExportInvalidVersionException|any, data: ImportExportListJobsOutput|any) => void): Request;
-      updateJob(params: ImportExportUpdateJobInput, callback?: (err: ImportExportMissingParameterException|ImportExportInvalidParameterException|ImportExportInvalidAccessKeyIdException|ImportExportInvalidAddressException|ImportExportInvalidManifestFieldException|ImportExportInvalidJobIdException|ImportExportMissingManifestFieldException|ImportExportNoSuchBucketException|ImportExportExpiredJobIdException|ImportExportCanceledJobIdException|ImportExportMissingCustomsException|ImportExportInvalidCustomsException|ImportExportInvalidFileSystemException|ImportExportMultipleRegionsException|ImportExportBucketPermissionException|ImportExportMalformedManifestException|ImportExportUnableToUpdateJobIdException|ImportExportInvalidVersionException|any, data: ImportExportUpdateJobOutput|any) => void): Request;
+      cancelJob(params: ImportExport.CancelJobInput, callback?: (err: ImportExport.InvalidJobIdException|ImportExport.ExpiredJobIdException|ImportExport.CanceledJobIdException|ImportExport.UnableToCancelJobIdException|ImportExport.InvalidAccessKeyIdException|ImportExport.InvalidVersionException|any, data: ImportExport.CancelJobOutput|any) => void): Request;
+      createJob(params: ImportExport.CreateJobInput, callback?: (err: ImportExport.MissingParameterException|ImportExport.InvalidParameterException|ImportExport.InvalidAccessKeyIdException|ImportExport.InvalidAddressException|ImportExport.InvalidManifestFieldException|ImportExport.MissingManifestFieldException|ImportExport.NoSuchBucketException|ImportExport.MissingCustomsException|ImportExport.InvalidCustomsException|ImportExport.InvalidFileSystemException|ImportExport.MultipleRegionsException|ImportExport.BucketPermissionException|ImportExport.MalformedManifestException|ImportExport.CreateJobQuotaExceededException|ImportExport.InvalidJobIdException|ImportExport.InvalidVersionException|any, data: ImportExport.CreateJobOutput|any) => void): Request;
+      getShippingLabel(params: ImportExport.GetShippingLabelInput, callback?: (err: ImportExport.InvalidJobIdException|ImportExport.ExpiredJobIdException|ImportExport.CanceledJobIdException|ImportExport.InvalidAccessKeyIdException|ImportExport.InvalidAddressException|ImportExport.InvalidVersionException|ImportExport.InvalidParameterException|any, data: ImportExport.GetShippingLabelOutput|any) => void): Request;
+      getStatus(params: ImportExport.GetStatusInput, callback?: (err: ImportExport.InvalidJobIdException|ImportExport.ExpiredJobIdException|ImportExport.CanceledJobIdException|ImportExport.InvalidAccessKeyIdException|ImportExport.InvalidVersionException|any, data: ImportExport.GetStatusOutput|any) => void): Request;
+      listJobs(params: ImportExport.ListJobsInput, callback?: (err: ImportExport.InvalidParameterException|ImportExport.InvalidAccessKeyIdException|ImportExport.InvalidVersionException|any, data: ImportExport.ListJobsOutput|any) => void): Request;
+      updateJob(params: ImportExport.UpdateJobInput, callback?: (err: ImportExport.MissingParameterException|ImportExport.InvalidParameterException|ImportExport.InvalidAccessKeyIdException|ImportExport.InvalidAddressException|ImportExport.InvalidManifestFieldException|ImportExport.InvalidJobIdException|ImportExport.MissingManifestFieldException|ImportExport.NoSuchBucketException|ImportExport.ExpiredJobIdException|ImportExport.CanceledJobIdException|ImportExport.MissingCustomsException|ImportExport.InvalidCustomsException|ImportExport.InvalidFileSystemException|ImportExport.MultipleRegionsException|ImportExport.BucketPermissionException|ImportExport.MalformedManifestException|ImportExport.UnableToUpdateJobIdException|ImportExport.InvalidVersionException|any, data: ImportExport.UpdateJobOutput|any) => void): Request;
     }
+    
+    export module ImportExport {
+        export type APIVersion = string;
+        export type ArtifactList = Artifact[];
+        export type Carrier = string;
+        export type CreationDate = number;
+        export type CurrentManifest = string;
+        export type Description = string;
+        export type ErrorCount = number;
+        export type ErrorMessage = string;
+        export type GenericString = string;
+        export type IsCanceled = boolean;
+        export type IsTruncated = boolean;
+        export type JobId = string;
+        export type JobIdList = GenericString[];
+        export type JobType = string;
+        export type JobsList = Job[];
+        export type LocationCode = string;
+        export type LocationMessage = string;
+        export type LogBucket = string;
+        export type LogKey = string;
+        export type Manifest = string;
+        export type ManifestAddendum = string;
+        export type Marker = string;
+        export type MaxJobs = number;
+        export type ProgressCode = string;
+        export type ProgressMessage = string;
+        export type Signature = string;
+        export type SignatureFileContents = string;
+        export type Success = boolean;
+        export type TrackingNumber = string;
+        export type URL = string;
+        export type ValidateOnly = boolean;
+        export type WarningMessage = string;
+        export type city = string;
+        export type company = string;
+        export type country = string;
+        export type name = string;
+        export type phoneNumber = string;
+        export type postalCode = string;
+        export type stateOrProvince = string;
+        export type street1 = string;
+        export type street2 = string;
+        export type street3 = string;
 
-    export type ImportExportAPIVersion = string;
-    export interface ImportExportArtifact {
-        Description?: ImportExportDescription;
-        URL?: ImportExportURL;
+        export interface Artifact {
+            Description?: Description;            
+            URL?: URL;            
+        }
+        export interface BucketPermissionException {
+            message?: ErrorMessage;            
+        }
+        export interface CancelJobInput {
+            JobId: JobId;            
+            APIVersion?: APIVersion;            
+        }
+        export interface CancelJobOutput {
+            Success?: Success;            
+        }
+        export interface CanceledJobIdException {
+            message?: ErrorMessage;            
+        }
+        export interface CreateJobInput {
+            JobType: JobType;            
+            Manifest: Manifest;            
+            ManifestAddendum?: ManifestAddendum;            
+            ValidateOnly: ValidateOnly;            
+            APIVersion?: APIVersion;            
+        }
+        export interface CreateJobOutput {
+            JobId?: JobId;            
+            JobType?: JobType;            
+            Signature?: Signature;            
+            SignatureFileContents?: SignatureFileContents;            
+            WarningMessage?: WarningMessage;            
+            ArtifactList?: ArtifactList;            
+        }
+        export interface CreateJobQuotaExceededException {
+            message?: ErrorMessage;            
+        }
+        export interface ExpiredJobIdException {
+            message?: ErrorMessage;            
+        }
+        export interface GetShippingLabelInput {
+            jobIds: JobIdList;            
+            name?: name;            
+            company?: company;            
+            phoneNumber?: phoneNumber;            
+            country?: country;            
+            stateOrProvince?: stateOrProvince;            
+            city?: city;            
+            postalCode?: postalCode;            
+            street1?: street1;            
+            street2?: street2;            
+            street3?: street3;            
+            APIVersion?: APIVersion;            
+        }
+        export interface GetShippingLabelOutput {
+            ShippingLabelURL?: GenericString;            
+            Warning?: GenericString;            
+        }
+        export interface GetStatusInput {
+            JobId: JobId;            
+            APIVersion?: APIVersion;            
+        }
+        export interface GetStatusOutput {
+            JobId?: JobId;            
+            JobType?: JobType;            
+            LocationCode?: LocationCode;            
+            LocationMessage?: LocationMessage;            
+            ProgressCode?: ProgressCode;            
+            ProgressMessage?: ProgressMessage;            
+            Carrier?: Carrier;            
+            TrackingNumber?: TrackingNumber;            
+            LogBucket?: LogBucket;            
+            LogKey?: LogKey;            
+            ErrorCount?: ErrorCount;            
+            Signature?: Signature;            
+            SignatureFileContents?: Signature;            
+            CurrentManifest?: CurrentManifest;            
+            CreationDate?: CreationDate;            
+            ArtifactList?: ArtifactList;            
+        }
+        export interface InvalidAccessKeyIdException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidAddressException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidCustomsException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidFileSystemException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidJobIdException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidManifestFieldException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidParameterException {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidVersionException {
+            message?: ErrorMessage;            
+        }
+        export interface Job {
+            JobId?: JobId;            
+            CreationDate?: CreationDate;            
+            IsCanceled?: IsCanceled;            
+            JobType?: JobType;            
+        }
+        export interface ListJobsInput {
+            MaxJobs?: MaxJobs;            
+            Marker?: Marker;            
+            APIVersion?: APIVersion;            
+        }
+        export interface ListJobsOutput {
+            Jobs?: JobsList;            
+            IsTruncated?: IsTruncated;            
+        }
+        export interface MalformedManifestException {
+            message?: ErrorMessage;            
+        }
+        export interface MissingCustomsException {
+            message?: ErrorMessage;            
+        }
+        export interface MissingManifestFieldException {
+            message?: ErrorMessage;            
+        }
+        export interface MissingParameterException {
+            message?: ErrorMessage;            
+        }
+        export interface MultipleRegionsException {
+            message?: ErrorMessage;            
+        }
+        export interface NoSuchBucketException {
+            message?: ErrorMessage;            
+        }
+        export interface UnableToCancelJobIdException {
+            message?: ErrorMessage;            
+        }
+        export interface UnableToUpdateJobIdException {
+            message?: ErrorMessage;            
+        }
+        export interface UpdateJobInput {
+            JobId: JobId;            
+            Manifest: Manifest;            
+            JobType: JobType;            
+            ValidateOnly: ValidateOnly;            
+            APIVersion?: APIVersion;            
+        }
+        export interface UpdateJobOutput {
+            Success?: Success;            
+            WarningMessage?: WarningMessage;            
+            ArtifactList?: ArtifactList;            
+        }
+
     }
-
-    export type ImportExportArtifactList = Array<ImportExportArtifact>;
-    export interface ImportExportBucketPermissionException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportCancelJobInput {
-        JobId: ImportExportJobId;
-        APIVersion?: ImportExportAPIVersion;
-    }
-
-    export interface ImportExportCancelJobOutput {
-        Success?: ImportExportSuccess;
-    }
-
-    export interface ImportExportCanceledJobIdException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export type ImportExportCarrier = string;
-    export interface ImportExportCreateJobInput {
-        JobType: ImportExportJobType;
-        Manifest: ImportExportManifest;
-        ManifestAddendum?: ImportExportManifestAddendum;
-        ValidateOnly: ImportExportValidateOnly;
-        APIVersion?: ImportExportAPIVersion;
-    }
-
-    export interface ImportExportCreateJobOutput {
-        JobId?: ImportExportJobId;
-        JobType?: ImportExportJobType;
-        Signature?: ImportExportSignature;
-        SignatureFileContents?: ImportExportSignatureFileContents;
-        WarningMessage?: ImportExportWarningMessage;
-        ArtifactList?: ImportExportArtifactList;
-    }
-
-    export interface ImportExportCreateJobQuotaExceededException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export type ImportExportCreationDate = number;
-    export type ImportExportCurrentManifest = string;
-    export type ImportExportDescription = string;
-    export type ImportExportErrorCount = number;
-    export type ImportExportErrorMessage = string;
-    export interface ImportExportExpiredJobIdException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export type ImportExportGenericString = string;
-    export interface ImportExportGetShippingLabelInput {
-        jobIds: ImportExportJobIdList;
-        name?: ImportExportname;
-        company?: ImportExportcompany;
-        phoneNumber?: ImportExportphoneNumber;
-        country?: ImportExportcountry;
-        stateOrProvince?: ImportExportstateOrProvince;
-        city?: ImportExportcity;
-        postalCode?: ImportExportpostalCode;
-        street1?: ImportExportstreet1;
-        street2?: ImportExportstreet2;
-        street3?: ImportExportstreet3;
-        APIVersion?: ImportExportAPIVersion;
-    }
-
-    export interface ImportExportGetShippingLabelOutput {
-        ShippingLabelURL?: ImportExportGenericString;
-        Warning?: ImportExportGenericString;
-    }
-
-    export interface ImportExportGetStatusInput {
-        JobId: ImportExportJobId;
-        APIVersion?: ImportExportAPIVersion;
-    }
-
-    export interface ImportExportGetStatusOutput {
-        JobId?: ImportExportJobId;
-        JobType?: ImportExportJobType;
-        LocationCode?: ImportExportLocationCode;
-        LocationMessage?: ImportExportLocationMessage;
-        ProgressCode?: ImportExportProgressCode;
-        ProgressMessage?: ImportExportProgressMessage;
-        Carrier?: ImportExportCarrier;
-        TrackingNumber?: ImportExportTrackingNumber;
-        LogBucket?: ImportExportLogBucket;
-        LogKey?: ImportExportLogKey;
-        ErrorCount?: ImportExportErrorCount;
-        Signature?: ImportExportSignature;
-        SignatureFileContents?: ImportExportSignature;
-        CurrentManifest?: ImportExportCurrentManifest;
-        CreationDate?: ImportExportCreationDate;
-        ArtifactList?: ImportExportArtifactList;
-    }
-
-    export interface ImportExportInvalidAccessKeyIdException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidAddressException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidCustomsException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidFileSystemException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidJobIdException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidManifestFieldException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidParameterException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportInvalidVersionException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export type ImportExportIsCanceled = boolean;
-    export type ImportExportIsTruncated = boolean;
-    export interface ImportExportJob {
-        JobId?: ImportExportJobId;
-        CreationDate?: ImportExportCreationDate;
-        IsCanceled?: ImportExportIsCanceled;
-        JobType?: ImportExportJobType;
-    }
-
-    export type ImportExportJobId = string;
-    export type ImportExportJobIdList = Array<ImportExportGenericString>;
-    export type ImportExportJobType = string;
-    export type ImportExportJobsList = Array<ImportExportJob>;
-    export interface ImportExportListJobsInput {
-        MaxJobs?: ImportExportMaxJobs;
-        Marker?: ImportExportMarker;
-        APIVersion?: ImportExportAPIVersion;
-    }
-
-    export interface ImportExportListJobsOutput {
-        Jobs?: ImportExportJobsList;
-        IsTruncated?: ImportExportIsTruncated;
-    }
-
-    export type ImportExportLocationCode = string;
-    export type ImportExportLocationMessage = string;
-    export type ImportExportLogBucket = string;
-    export type ImportExportLogKey = string;
-    export interface ImportExportMalformedManifestException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export type ImportExportManifest = string;
-    export type ImportExportManifestAddendum = string;
-    export type ImportExportMarker = string;
-    export type ImportExportMaxJobs = number;
-    export interface ImportExportMissingCustomsException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportMissingManifestFieldException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportMissingParameterException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportMultipleRegionsException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportNoSuchBucketException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export type ImportExportProgressCode = string;
-    export type ImportExportProgressMessage = string;
-    export type ImportExportSignature = string;
-    export type ImportExportSignatureFileContents = string;
-    export type ImportExportSuccess = boolean;
-    export type ImportExportTrackingNumber = string;
-    export type ImportExportURL = string;
-    export interface ImportExportUnableToCancelJobIdException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportUnableToUpdateJobIdException {
-        message?: ImportExportErrorMessage;
-    }
-
-    export interface ImportExportUpdateJobInput {
-        JobId: ImportExportJobId;
-        Manifest: ImportExportManifest;
-        JobType: ImportExportJobType;
-        ValidateOnly: ImportExportValidateOnly;
-        APIVersion?: ImportExportAPIVersion;
-    }
-
-    export interface ImportExportUpdateJobOutput {
-        Success?: ImportExportSuccess;
-        WarningMessage?: ImportExportWarningMessage;
-        ArtifactList?: ImportExportArtifactList;
-    }
-
-    export type ImportExportValidateOnly = boolean;
-    export type ImportExportWarningMessage = string;
-    export type ImportExportcity = string;
-    export type ImportExportcompany = string;
-    export type ImportExportcountry = string;
-    export type ImportExportname = string;
-    export type ImportExportphoneNumber = string;
-    export type ImportExportpostalCode = string;
-    export type ImportExportstateOrProvince = string;
-    export type ImportExportstreet1 = string;
-    export type ImportExportstreet2 = string;
-    export type ImportExportstreet3 = string;
 }

--- a/output/aws-inspector.d.ts
+++ b/output/aws-inspector.d.ts
@@ -6,595 +6,500 @@ declare module "aws-sdk" {
 
     export class Inspector extends Service {
       constructor(options?: any);
-      addAttributesToFindings(params: InspectorAddAttributesToFindingsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorAddAttributesToFindingsResponse|any) => void): Request;
-      attachAssessmentAndRulesPackage(params: InspectorAttachAssessmentAndRulesPackageRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorAttachAssessmentAndRulesPackageResponse|any) => void): Request;
-      createApplication(params: InspectorCreateApplicationRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorCreateApplicationResponse|any) => void): Request;
-      createAssessment(params: InspectorCreateAssessmentRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorCreateAssessmentResponse|any) => void): Request;
-      createResourceGroup(params: InspectorCreateResourceGroupRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|any, data: InspectorCreateResourceGroupResponse|any) => void): Request;
-      deleteApplication(params: InspectorDeleteApplicationRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorOperationInProgressException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDeleteApplicationResponse|any) => void): Request;
-      deleteAssessment(params: InspectorDeleteAssessmentRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorOperationInProgressException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDeleteAssessmentResponse|any) => void): Request;
-      deleteRun(params: InspectorDeleteRunRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDeleteRunResponse|any) => void): Request;
-      describeApplication(params: InspectorDescribeApplicationRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDescribeApplicationResponse|any) => void): Request;
-      describeAssessment(params: InspectorDescribeAssessmentRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDescribeAssessmentResponse|any) => void): Request;
-      describeCrossAccountAccessRole(callback?: (err: InspectorInternalException|InspectorAccessDeniedException|any, data: InspectorDescribeCrossAccountAccessRoleResponse|any) => void): Request;
-      describeFinding(params: InspectorDescribeFindingRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDescribeFindingResponse|any) => void): Request;
-      describeResourceGroup(params: InspectorDescribeResourceGroupRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDescribeResourceGroupResponse|any) => void): Request;
-      describeRulesPackage(params: InspectorDescribeRulesPackageRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDescribeRulesPackageResponse|any) => void): Request;
-      describeRun(params: InspectorDescribeRunRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDescribeRunResponse|any) => void): Request;
-      detachAssessmentAndRulesPackage(params: InspectorDetachAssessmentAndRulesPackageRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorDetachAssessmentAndRulesPackageResponse|any) => void): Request;
-      getAssessmentTelemetry(params: InspectorGetAssessmentTelemetryRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorGetAssessmentTelemetryResponse|any) => void): Request;
-      listApplications(params: InspectorListApplicationsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|any, data: InspectorListApplicationsResponse|any) => void): Request;
-      listAssessmentAgents(params: InspectorListAssessmentAgentsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListAssessmentAgentsResponse|any) => void): Request;
-      listAssessments(params: InspectorListAssessmentsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListAssessmentsResponse|any) => void): Request;
-      listAttachedAssessments(params: InspectorListAttachedAssessmentsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListAttachedAssessmentsResponse|any) => void): Request;
-      listAttachedRulesPackages(params: InspectorListAttachedRulesPackagesRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListAttachedRulesPackagesResponse|any) => void): Request;
-      listFindings(params: InspectorListFindingsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListFindingsResponse|any) => void): Request;
-      listRulesPackages(params: InspectorListRulesPackagesRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|any, data: InspectorListRulesPackagesResponse|any) => void): Request;
-      listRuns(params: InspectorListRunsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListRunsResponse|any) => void): Request;
-      listTagsForResource(params: InspectorListTagsForResourceRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorListTagsForResourceResponse|any) => void): Request;
-      localizeText(params: InspectorLocalizeTextRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorLocalizeTextResponse|any) => void): Request;
-      previewAgentsForResourceGroup(params: InspectorPreviewAgentsForResourceGroupRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|InspectorInvalidCrossAccountRoleException|any, data: InspectorPreviewAgentsForResourceGroupResponse|any) => void): Request;
-      registerCrossAccountAccessRole(params: InspectorRegisterCrossAccountAccessRoleRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorInvalidCrossAccountRoleException|any, data: InspectorRegisterCrossAccountAccessRoleResponse|any) => void): Request;
-      removeAttributesFromFindings(params: InspectorRemoveAttributesFromFindingsRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorRemoveAttributesFromFindingsResponse|any) => void): Request;
-      runAssessment(params: InspectorRunAssessmentRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorRunAssessmentResponse|any) => void): Request;
-      setTagsForResource(params: InspectorSetTagsForResourceRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorSetTagsForResourceResponse|any) => void): Request;
-      startDataCollection(params: InspectorStartDataCollectionRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|InspectorInvalidCrossAccountRoleException|any, data: InspectorStartDataCollectionResponse|any) => void): Request;
-      stopDataCollection(params: InspectorStopDataCollectionRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorStopDataCollectionResponse|any) => void): Request;
-      updateApplication(params: InspectorUpdateApplicationRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorUpdateApplicationResponse|any) => void): Request;
-      updateAssessment(params: InspectorUpdateAssessmentRequest, callback?: (err: InspectorInternalException|InspectorInvalidInputException|InspectorAccessDeniedException|InspectorNoSuchEntityException|any, data: InspectorUpdateAssessmentResponse|any) => void): Request;
-    }
-
-    export interface InspectorAccessDeniedException {
-    }
-
-    export interface InspectorAddAttributesToFindingsRequest {
-        findingArns?: InspectorArnList;
-        attributes?: InspectorAttributeList;
-    }
-
-    export interface InspectorAddAttributesToFindingsResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorAgent {
-        agentId?: InspectorAgentId;
-        assessmentArn?: InspectorArn;
-        agentHealth?: InspectorAgentHealth;
-        agentHealthCode?: InspectorAgentHealthCode;
-        agentHealthDetails?: InspectorAgentHealthDetails;
-        autoScalingGroup?: InspectorAutoScalingGroup;
-        accountId?: InspectorAwsAccount;
-        telemetry?: InspectorTelemetryList;
-    }
-
-    export type InspectorAgentHealth = string;
-    export type InspectorAgentHealthCode = string;
-    export type InspectorAgentHealthDetails = string;
-    export type InspectorAgentHealthList = Array<InspectorAgentHealth>;
-    export type InspectorAgentId = string;
-    export type InspectorAgentList = Array<InspectorAgent>;
-    export interface InspectorAgentPreview {
-        agentId?: InspectorAgentId;
-        autoScalingGroup?: InspectorAutoScalingGroup;
-    }
-
-    export type InspectorAgentPreviewList = Array<InspectorAgentPreview>;
-    export interface InspectorAgentsFilter {
-        agentHealthList?: InspectorAgentHealthList;
-    }
-
-    export interface InspectorApplication {
-        applicationArn?: InspectorArn;
-        applicationName?: InspectorName;
-        resourceGroupArn?: InspectorArn;
-    }
-
-    export interface InspectorApplicationsFilter {
-        applicationNamePatterns?: InspectorNamePatternList;
-    }
-
-    export type InspectorArn = string;
-    export type InspectorArnList = Array<InspectorArn>;
-    export interface InspectorAssessment {
-        assessmentArn?: InspectorArn;
-        assessmentName?: InspectorName;
-        applicationArn?: InspectorArn;
-        assessmentState?: InspectorAssessmentState;
-        failureMessage?: InspectorFailureMessage;
-        dataCollected?: InspectorBool;
-        startTime?: InspectorTimestamp;
-        endTime?: InspectorTimestamp;
-        durationInSeconds?: InspectorDuration;
-        userAttributesForFindings?: InspectorAttributeList;
-    }
-
-    export type InspectorAssessmentState = string;
-    export type InspectorAssessmentStateList = Array<InspectorAssessmentState>;
-    export interface InspectorAssessmentsFilter {
-        assessmentNamePatterns?: InspectorNamePatternList;
-        assessmentStates?: InspectorAssessmentStateList;
-        dataCollected?: InspectorBool;
-        startTimeRange?: InspectorTimestampRange;
-        endTimeRange?: InspectorTimestampRange;
-        durationRange?: InspectorDurationRange;
-    }
-
-    export interface InspectorAttachAssessmentAndRulesPackageRequest {
-        assessmentArn?: InspectorArn;
-        rulesPackageArn?: InspectorArn;
-    }
-
-    export interface InspectorAttachAssessmentAndRulesPackageResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorAttribute {
-        key?: InspectorAttributeKey;
-        value?: InspectorAttributeValue;
-    }
-
-    export type InspectorAttributeKey = string;
-    export type InspectorAttributeKeyList = Array<InspectorAttributeKey>;
-    export type InspectorAttributeList = Array<InspectorAttribute>;
-    export type InspectorAttributeValue = string;
-    export type InspectorAutoScalingGroup = string;
-    export type InspectorAwsAccount = string;
-    export type InspectorBool = boolean;
-    export interface InspectorCreateApplicationRequest {
-        applicationName?: InspectorName;
-        resourceGroupArn?: InspectorArn;
-    }
-
-    export interface InspectorCreateApplicationResponse {
-        applicationArn?: InspectorArn;
-    }
-
-    export interface InspectorCreateAssessmentRequest {
-        applicationArn?: InspectorArn;
-        assessmentName?: InspectorName;
-        durationInSeconds?: InspectorDuration;
-        userAttributesForFindings?: InspectorAttributeList;
-    }
-
-    export interface InspectorCreateAssessmentResponse {
-        assessmentArn?: InspectorArn;
-    }
-
-    export interface InspectorCreateResourceGroupRequest {
-        resourceGroupTags?: InspectorResourceGroupTags;
-    }
-
-    export interface InspectorCreateResourceGroupResponse {
-        resourceGroupArn?: InspectorArn;
-    }
-
-    export interface InspectorDeleteApplicationRequest {
-        applicationArn?: InspectorArn;
-    }
-
-    export interface InspectorDeleteApplicationResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorDeleteAssessmentRequest {
-        assessmentArn?: InspectorArn;
-    }
-
-    export interface InspectorDeleteAssessmentResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorDeleteRunRequest {
-        runArn?: InspectorArn;
-    }
-
-    export interface InspectorDeleteRunResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorDescribeApplicationRequest {
-        applicationArn?: InspectorArn;
-    }
-
-    export interface InspectorDescribeApplicationResponse {
-        application?: InspectorApplication;
-    }
-
-    export interface InspectorDescribeAssessmentRequest {
-        assessmentArn?: InspectorArn;
-    }
-
-    export interface InspectorDescribeAssessmentResponse {
-        assessment?: InspectorAssessment;
-    }
-
-    export interface InspectorDescribeCrossAccountAccessRoleResponse {
-        roleArn?: InspectorArn;
-        valid?: InspectorBool;
-    }
-
-    export interface InspectorDescribeFindingRequest {
-        findingArn?: InspectorArn;
-    }
-
-    export interface InspectorDescribeFindingResponse {
-        finding?: InspectorFinding;
-    }
-
-    export interface InspectorDescribeResourceGroupRequest {
-        resourceGroupArn?: InspectorArn;
-    }
-
-    export interface InspectorDescribeResourceGroupResponse {
-        resourceGroup?: InspectorResourceGroup;
-    }
-
-    export interface InspectorDescribeRulesPackageRequest {
-        rulesPackageArn?: InspectorArn;
-    }
-
-    export interface InspectorDescribeRulesPackageResponse {
-        rulesPackage?: InspectorRulesPackage;
-    }
-
-    export interface InspectorDescribeRunRequest {
-        runArn?: InspectorArn;
-    }
-
-    export interface InspectorDescribeRunResponse {
-        run?: InspectorRun;
-    }
-
-    export interface InspectorDetachAssessmentAndRulesPackageRequest {
-        assessmentArn?: InspectorArn;
-        rulesPackageArn?: InspectorArn;
-    }
-
-    export interface InspectorDetachAssessmentAndRulesPackageResponse {
-        message?: InspectorMessage;
-    }
-
-    export type InspectorDuration = number;
-    export interface InspectorDurationRange {
-        minimum?: InspectorDuration;
-        maximum?: InspectorDuration;
-    }
-
-    export type InspectorFailureMessage = string;
-    export interface InspectorFinding {
-        findingArn?: InspectorArn;
-        runArn?: InspectorArn;
-        rulesPackageArn?: InspectorArn;
-        ruleName?: InspectorName;
-        agentId?: InspectorAgentId;
-        autoScalingGroup?: InspectorAutoScalingGroup;
-        severity?: InspectorSeverity;
-        finding?: InspectorLocalizedText;
-        description?: InspectorLocalizedText;
-        recommendation?: InspectorLocalizedText;
-        attributes?: InspectorAttributeList;
-        userAttributes?: InspectorAttributeList;
-    }
-
-    export interface InspectorFindingsFilter {
-        rulesPackageArns?: InspectorArnList;
-        ruleNames?: InspectorNameList;
-        severities?: InspectorSeverityList;
-        attributes?: InspectorAttributeList;
-        userAttributes?: InspectorAttributeList;
-    }
-
-    export interface InspectorGetAssessmentTelemetryRequest {
-        assessmentArn?: InspectorArn;
-    }
-
-    export interface InspectorGetAssessmentTelemetryResponse {
-        telemetry?: InspectorTelemetryList;
-    }
-
-    export type InspectorInteger = number;
-    export interface InspectorInternalException {
-    }
-
-    export interface InspectorInvalidCrossAccountRoleException {
-    }
-
-    export interface InspectorInvalidInputException {
-    }
-
-    export interface InspectorListApplicationsRequest {
-        filter?: InspectorApplicationsFilter;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
+      addAttributesToFindings(params: Inspector.AddAttributesToFindingsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.AddAttributesToFindingsResponse|any) => void): Request;
+      attachAssessmentAndRulesPackage(params: Inspector.AttachAssessmentAndRulesPackageRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.AttachAssessmentAndRulesPackageResponse|any) => void): Request;
+      createApplication(params: Inspector.CreateApplicationRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.CreateApplicationResponse|any) => void): Request;
+      createAssessment(params: Inspector.CreateAssessmentRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.CreateAssessmentResponse|any) => void): Request;
+      createResourceGroup(params: Inspector.CreateResourceGroupRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|any, data: Inspector.CreateResourceGroupResponse|any) => void): Request;
+      deleteApplication(params: Inspector.DeleteApplicationRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.OperationInProgressException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DeleteApplicationResponse|any) => void): Request;
+      deleteAssessment(params: Inspector.DeleteAssessmentRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.OperationInProgressException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DeleteAssessmentResponse|any) => void): Request;
+      deleteRun(params: Inspector.DeleteRunRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DeleteRunResponse|any) => void): Request;
+      describeApplication(params: Inspector.DescribeApplicationRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DescribeApplicationResponse|any) => void): Request;
+      describeAssessment(params: Inspector.DescribeAssessmentRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DescribeAssessmentResponse|any) => void): Request;
+      describeCrossAccountAccessRole(callback?: (err: Inspector.InternalException|Inspector.AccessDeniedException|any, data: Inspector.DescribeCrossAccountAccessRoleResponse|any) => void): Request;
+      describeFinding(params: Inspector.DescribeFindingRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DescribeFindingResponse|any) => void): Request;
+      describeResourceGroup(params: Inspector.DescribeResourceGroupRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DescribeResourceGroupResponse|any) => void): Request;
+      describeRulesPackage(params: Inspector.DescribeRulesPackageRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DescribeRulesPackageResponse|any) => void): Request;
+      describeRun(params: Inspector.DescribeRunRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DescribeRunResponse|any) => void): Request;
+      detachAssessmentAndRulesPackage(params: Inspector.DetachAssessmentAndRulesPackageRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.DetachAssessmentAndRulesPackageResponse|any) => void): Request;
+      getAssessmentTelemetry(params: Inspector.GetAssessmentTelemetryRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.GetAssessmentTelemetryResponse|any) => void): Request;
+      listApplications(params: Inspector.ListApplicationsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|any, data: Inspector.ListApplicationsResponse|any) => void): Request;
+      listAssessmentAgents(params: Inspector.ListAssessmentAgentsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListAssessmentAgentsResponse|any) => void): Request;
+      listAssessments(params: Inspector.ListAssessmentsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListAssessmentsResponse|any) => void): Request;
+      listAttachedAssessments(params: Inspector.ListAttachedAssessmentsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListAttachedAssessmentsResponse|any) => void): Request;
+      listAttachedRulesPackages(params: Inspector.ListAttachedRulesPackagesRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListAttachedRulesPackagesResponse|any) => void): Request;
+      listFindings(params: Inspector.ListFindingsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListFindingsResponse|any) => void): Request;
+      listRulesPackages(params: Inspector.ListRulesPackagesRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|any, data: Inspector.ListRulesPackagesResponse|any) => void): Request;
+      listRuns(params: Inspector.ListRunsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListRunsResponse|any) => void): Request;
+      listTagsForResource(params: Inspector.ListTagsForResourceRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.ListTagsForResourceResponse|any) => void): Request;
+      localizeText(params: Inspector.LocalizeTextRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.LocalizeTextResponse|any) => void): Request;
+      previewAgentsForResourceGroup(params: Inspector.PreviewAgentsForResourceGroupRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|Inspector.InvalidCrossAccountRoleException|any, data: Inspector.PreviewAgentsForResourceGroupResponse|any) => void): Request;
+      registerCrossAccountAccessRole(params: Inspector.RegisterCrossAccountAccessRoleRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.InvalidCrossAccountRoleException|any, data: Inspector.RegisterCrossAccountAccessRoleResponse|any) => void): Request;
+      removeAttributesFromFindings(params: Inspector.RemoveAttributesFromFindingsRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.RemoveAttributesFromFindingsResponse|any) => void): Request;
+      runAssessment(params: Inspector.RunAssessmentRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.RunAssessmentResponse|any) => void): Request;
+      setTagsForResource(params: Inspector.SetTagsForResourceRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.SetTagsForResourceResponse|any) => void): Request;
+      startDataCollection(params: Inspector.StartDataCollectionRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|Inspector.InvalidCrossAccountRoleException|any, data: Inspector.StartDataCollectionResponse|any) => void): Request;
+      stopDataCollection(params: Inspector.StopDataCollectionRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.StopDataCollectionResponse|any) => void): Request;
+      updateApplication(params: Inspector.UpdateApplicationRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.UpdateApplicationResponse|any) => void): Request;
+      updateAssessment(params: Inspector.UpdateAssessmentRequest, callback?: (err: Inspector.InternalException|Inspector.InvalidInputException|Inspector.AccessDeniedException|Inspector.NoSuchEntityException|any, data: Inspector.UpdateAssessmentResponse|any) => void): Request;
+    }
+    
+    export module Inspector {
+        export type AgentHealth = string;
+        export type AgentHealthCode = string;
+        export type AgentHealthDetails = string;
+        export type AgentHealthList = AgentHealth[];
+        export type AgentId = string;
+        export type AgentList = Agent[];
+        export type AgentPreviewList = AgentPreview[];
+        export type Arn = string;
+        export type ArnList = Arn[];
+        export type AssessmentState = string;
+        export type AssessmentStateList = AssessmentState[];
+        export type AttributeKey = string;
+        export type AttributeKeyList = AttributeKey[];
+        export type AttributeList = Attribute[];
+        export type AttributeValue = string;
+        export type AutoScalingGroup = string;
+        export type AwsAccount = string;
+        export type Bool = boolean;
+        export type Duration = number;
+        export type FailureMessage = string;
+        export type Integer = number;
+        export type Locale = string;
+        export type LocalizedFacility = string;
+        export type LocalizedTextId = string;
+        export type LocalizedTextList = LocalizedText[];
+        export type Long = number;
+        export type Message = string;
+        export type MessageType = string;
+        export type MessageTypeTelemetryList = MessageTypeTelemetry[];
+        export type Name = string;
+        export type NameList = Name[];
+        export type NamePattern = string;
+        export type NamePatternList = NamePattern[];
+        export type PaginationToken = string;
+        export type ParameterList = Parameter[];
+        export type ParameterName = string;
+        export type ParameterValue = string;
+        export type ResourceGroupTags = string;
+        export type RunState = string;
+        export type RunStateList = RunState[];
+        export type Severity = string;
+        export type SeverityList = Severity[];
+        export type TagKey = string;
+        export type TagList = Tag[];
+        export type TagValue = string;
+        export type TelemetryList = Telemetry[];
+        export type TelemetryStatus = string;
+        export type Text = string;
+        export type TextList = Text[];
+        export type Timestamp = number;
+        export type Version = string;
+
+        export interface AccessDeniedException {
+        }
+        export interface AddAttributesToFindingsRequest {
+            findingArns?: ArnList;            
+            attributes?: AttributeList;            
+        }
+        export interface AddAttributesToFindingsResponse {
+            message?: Message;            
+        }
+        export interface Agent {
+            agentId?: AgentId;            
+            assessmentArn?: Arn;            
+            agentHealth?: AgentHealth;            
+            agentHealthCode?: AgentHealthCode;            
+            agentHealthDetails?: AgentHealthDetails;            
+            autoScalingGroup?: AutoScalingGroup;            
+            accountId?: AwsAccount;            
+            telemetry?: TelemetryList;            
+        }
+        export interface AgentPreview {
+            agentId?: AgentId;            
+            autoScalingGroup?: AutoScalingGroup;            
+        }
+        export interface AgentsFilter {
+            agentHealthList?: AgentHealthList;            
+        }
+        export interface Application {
+            applicationArn?: Arn;            
+            applicationName?: Name;            
+            resourceGroupArn?: Arn;            
+        }
+        export interface ApplicationsFilter {
+            applicationNamePatterns?: NamePatternList;            
+        }
+        export interface Assessment {
+            assessmentArn?: Arn;            
+            assessmentName?: Name;            
+            applicationArn?: Arn;            
+            assessmentState?: AssessmentState;            
+            failureMessage?: FailureMessage;            
+            dataCollected?: Bool;            
+            startTime?: Timestamp;            
+            endTime?: Timestamp;            
+            durationInSeconds?: Duration;            
+            userAttributesForFindings?: AttributeList;            
+        }
+        export interface AssessmentsFilter {
+            assessmentNamePatterns?: NamePatternList;            
+            assessmentStates?: AssessmentStateList;            
+            dataCollected?: Bool;            
+            startTimeRange?: TimestampRange;            
+            endTimeRange?: TimestampRange;            
+            durationRange?: DurationRange;            
+        }
+        export interface AttachAssessmentAndRulesPackageRequest {
+            assessmentArn?: Arn;            
+            rulesPackageArn?: Arn;            
+        }
+        export interface AttachAssessmentAndRulesPackageResponse {
+            message?: Message;            
+        }
+        export interface Attribute {
+            key?: AttributeKey;            
+            value?: AttributeValue;            
+        }
+        export interface CreateApplicationRequest {
+            applicationName?: Name;            
+            resourceGroupArn?: Arn;            
+        }
+        export interface CreateApplicationResponse {
+            applicationArn?: Arn;            
+        }
+        export interface CreateAssessmentRequest {
+            applicationArn?: Arn;            
+            assessmentName?: Name;            
+            durationInSeconds?: Duration;            
+            userAttributesForFindings?: AttributeList;            
+        }
+        export interface CreateAssessmentResponse {
+            assessmentArn?: Arn;            
+        }
+        export interface CreateResourceGroupRequest {
+            resourceGroupTags?: ResourceGroupTags;            
+        }
+        export interface CreateResourceGroupResponse {
+            resourceGroupArn?: Arn;            
+        }
+        export interface DeleteApplicationRequest {
+            applicationArn?: Arn;            
+        }
+        export interface DeleteApplicationResponse {
+            message?: Message;            
+        }
+        export interface DeleteAssessmentRequest {
+            assessmentArn?: Arn;            
+        }
+        export interface DeleteAssessmentResponse {
+            message?: Message;            
+        }
+        export interface DeleteRunRequest {
+            runArn?: Arn;            
+        }
+        export interface DeleteRunResponse {
+            message?: Message;            
+        }
+        export interface DescribeApplicationRequest {
+            applicationArn?: Arn;            
+        }
+        export interface DescribeApplicationResponse {
+            application?: Application;            
+        }
+        export interface DescribeAssessmentRequest {
+            assessmentArn?: Arn;            
+        }
+        export interface DescribeAssessmentResponse {
+            assessment?: Assessment;            
+        }
+        export interface DescribeCrossAccountAccessRoleResponse {
+            roleArn?: Arn;            
+            valid?: Bool;            
+        }
+        export interface DescribeFindingRequest {
+            findingArn?: Arn;            
+        }
+        export interface DescribeFindingResponse {
+            finding?: Finding;            
+        }
+        export interface DescribeResourceGroupRequest {
+            resourceGroupArn?: Arn;            
+        }
+        export interface DescribeResourceGroupResponse {
+            resourceGroup?: ResourceGroup;            
+        }
+        export interface DescribeRulesPackageRequest {
+            rulesPackageArn?: Arn;            
+        }
+        export interface DescribeRulesPackageResponse {
+            rulesPackage?: RulesPackage;            
+        }
+        export interface DescribeRunRequest {
+            runArn?: Arn;            
+        }
+        export interface DescribeRunResponse {
+            run?: Run;            
+        }
+        export interface DetachAssessmentAndRulesPackageRequest {
+            assessmentArn?: Arn;            
+            rulesPackageArn?: Arn;            
+        }
+        export interface DetachAssessmentAndRulesPackageResponse {
+            message?: Message;            
+        }
+        export interface DurationRange {
+            minimum?: Duration;            
+            maximum?: Duration;            
+        }
+        export interface Finding {
+            findingArn?: Arn;            
+            runArn?: Arn;            
+            rulesPackageArn?: Arn;            
+            ruleName?: Name;            
+            agentId?: AgentId;            
+            autoScalingGroup?: AutoScalingGroup;            
+            severity?: Severity;            
+            finding?: LocalizedText;            
+            description?: LocalizedText;            
+            recommendation?: LocalizedText;            
+            attributes?: AttributeList;            
+            userAttributes?: AttributeList;            
+        }
+        export interface FindingsFilter {
+            rulesPackageArns?: ArnList;            
+            ruleNames?: NameList;            
+            severities?: SeverityList;            
+            attributes?: AttributeList;            
+            userAttributes?: AttributeList;            
+        }
+        export interface GetAssessmentTelemetryRequest {
+            assessmentArn?: Arn;            
+        }
+        export interface GetAssessmentTelemetryResponse {
+            telemetry?: TelemetryList;            
+        }
+        export interface InternalException {
+        }
+        export interface InvalidCrossAccountRoleException {
+        }
+        export interface InvalidInputException {
+        }
+        export interface ListApplicationsRequest {
+            filter?: ApplicationsFilter;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListApplicationsResponse {
+            applicationArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListAssessmentAgentsRequest {
+            assessmentArn?: Arn;            
+            filter?: AgentsFilter;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListAssessmentAgentsResponse {
+            agentList?: AgentList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListAssessmentsRequest {
+            applicationArns?: ArnList;            
+            filter?: AssessmentsFilter;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListAssessmentsResponse {
+            assessmentArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListAttachedAssessmentsRequest {
+            rulesPackageArn?: Arn;            
+            filter?: AssessmentsFilter;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListAttachedAssessmentsResponse {
+            assessmentArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListAttachedRulesPackagesRequest {
+            assessmentArn?: Arn;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListAttachedRulesPackagesResponse {
+            rulesPackageArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListFindingsRequest {
+            runArns?: ArnList;            
+            filter?: FindingsFilter;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListFindingsResponse {
+            findingArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListRulesPackagesRequest {
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListRulesPackagesResponse {
+            rulesPackageArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListRunsRequest {
+            assessmentArns?: ArnList;            
+            filter?: RunsFilter;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface ListRunsResponse {
+            runArnList?: ArnList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface ListTagsForResourceRequest {
+            resourceArn?: Arn;            
+        }
+        export interface ListTagsForResourceResponse {
+            tagList?: TagList;            
+        }
+        export interface LocalizeTextRequest {
+            localizedTexts?: LocalizedTextList;            
+            locale?: Locale;            
+        }
+        export interface LocalizeTextResponse {
+            message?: Message;            
+            results?: TextList;            
+        }
+        export interface LocalizedText {
+            key?: LocalizedTextKey;            
+            parameters?: ParameterList;            
+        }
+        export interface LocalizedTextKey {
+            facility?: LocalizedFacility;            
+            id?: LocalizedTextId;            
+        }
+        export interface MessageTypeTelemetry {
+            messageType?: MessageType;            
+            count?: Long;            
+            dataSize?: Long;            
+        }
+        export interface NoSuchEntityException {
+        }
+        export interface OperationInProgressException {
+        }
+        export interface Parameter {
+            name?: ParameterName;            
+            value?: ParameterValue;            
+        }
+        export interface PreviewAgentsForResourceGroupRequest {
+            resourceGroupArn?: Arn;            
+            nextToken?: PaginationToken;            
+            maxResults?: Integer;            
+        }
+        export interface PreviewAgentsForResourceGroupResponse {
+            agentPreviewList?: AgentPreviewList;            
+            nextToken?: PaginationToken;            
+        }
+        export interface RegisterCrossAccountAccessRoleRequest {
+            roleArn?: Arn;            
+        }
+        export interface RegisterCrossAccountAccessRoleResponse {
+            message?: Message;            
+        }
+        export interface RemoveAttributesFromFindingsRequest {
+            findingArns?: ArnList;            
+            attributeKeys?: AttributeKeyList;            
+        }
+        export interface RemoveAttributesFromFindingsResponse {
+            message?: Message;            
+        }
+        export interface ResourceGroup {
+            resourceGroupArn?: Arn;            
+            resourceGroupTags?: ResourceGroupTags;            
+        }
+        export interface RulesPackage {
+            rulesPackageArn?: Arn;            
+            rulesPackageName?: Name;            
+            version?: Version;            
+            provider?: Name;            
+            description?: LocalizedText;            
+        }
+        export interface Run {
+            runArn?: Arn;            
+            runName?: Name;            
+            assessmentArn?: Arn;            
+            runState?: RunState;            
+            rulesPackages?: ArnList;            
+            creationTime?: Timestamp;            
+            completionTime?: Timestamp;            
+        }
+        export interface RunAssessmentRequest {
+            assessmentArn?: Arn;            
+            runName?: Name;            
+        }
+        export interface RunAssessmentResponse {
+            runArn?: Arn;            
+        }
+        export interface RunsFilter {
+            runNamePatterns?: NamePatternList;            
+            runStates?: RunStateList;            
+            rulesPackages?: ArnList;            
+            creationTime?: TimestampRange;            
+            completionTime?: TimestampRange;            
+        }
+        export interface SetTagsForResourceRequest {
+            resourceArn?: Arn;            
+            tags?: TagList;            
+        }
+        export interface SetTagsForResourceResponse {
+            message?: Message;            
+        }
+        export interface StartDataCollectionRequest {
+            assessmentArn?: Arn;            
+        }
+        export interface StartDataCollectionResponse {
+            message?: Message;            
+        }
+        export interface StopDataCollectionRequest {
+            assessmentArn?: Arn;            
+        }
+        export interface StopDataCollectionResponse {
+            message?: Message;            
+        }
+        export interface Tag {
+            Key?: TagKey;            
+            Value?: TagValue;            
+        }
+        export interface Telemetry {
+            status?: TelemetryStatus;            
+            messageTypeTelemetries?: MessageTypeTelemetryList;            
+        }
+        export interface TimestampRange {
+            minimum?: Timestamp;            
+            maximum?: Timestamp;            
+        }
+        export interface UpdateApplicationRequest {
+            applicationArn?: Arn;            
+            applicationName?: Name;            
+            resourceGroupArn?: Arn;            
+        }
+        export interface UpdateApplicationResponse {
+            message?: Message;            
+        }
+        export interface UpdateAssessmentRequest {
+            assessmentArn?: Arn;            
+            assessmentName?: Name;            
+            durationInSeconds?: Duration;            
+        }
+        export interface UpdateAssessmentResponse {
+            message?: Message;            
+        }
 
-    export interface InspectorListApplicationsResponse {
-        applicationArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
     }
-
-    export interface InspectorListAssessmentAgentsRequest {
-        assessmentArn?: InspectorArn;
-        filter?: InspectorAgentsFilter;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListAssessmentAgentsResponse {
-        agentList?: InspectorAgentList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListAssessmentsRequest {
-        applicationArns?: InspectorArnList;
-        filter?: InspectorAssessmentsFilter;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListAssessmentsResponse {
-        assessmentArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListAttachedAssessmentsRequest {
-        rulesPackageArn?: InspectorArn;
-        filter?: InspectorAssessmentsFilter;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListAttachedAssessmentsResponse {
-        assessmentArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListAttachedRulesPackagesRequest {
-        assessmentArn?: InspectorArn;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListAttachedRulesPackagesResponse {
-        rulesPackageArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListFindingsRequest {
-        runArns?: InspectorArnList;
-        filter?: InspectorFindingsFilter;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListFindingsResponse {
-        findingArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListRulesPackagesRequest {
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListRulesPackagesResponse {
-        rulesPackageArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListRunsRequest {
-        assessmentArns?: InspectorArnList;
-        filter?: InspectorRunsFilter;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorListRunsResponse {
-        runArnList?: InspectorArnList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorListTagsForResourceRequest {
-        resourceArn?: InspectorArn;
-    }
-
-    export interface InspectorListTagsForResourceResponse {
-        tagList?: InspectorTagList;
-    }
-
-    export type InspectorLocale = string;
-    export interface InspectorLocalizeTextRequest {
-        localizedTexts?: InspectorLocalizedTextList;
-        locale?: InspectorLocale;
-    }
-
-    export interface InspectorLocalizeTextResponse {
-        message?: InspectorMessage;
-        results?: InspectorTextList;
-    }
-
-    export type InspectorLocalizedFacility = string;
-    export interface InspectorLocalizedText {
-        key?: InspectorLocalizedTextKey;
-        parameters?: InspectorParameterList;
-    }
-
-    export type InspectorLocalizedTextId = string;
-    export interface InspectorLocalizedTextKey {
-        facility?: InspectorLocalizedFacility;
-        id?: InspectorLocalizedTextId;
-    }
-
-    export type InspectorLocalizedTextList = Array<InspectorLocalizedText>;
-    export type InspectorLong = number;
-    export type InspectorMessage = string;
-    export type InspectorMessageType = string;
-    export interface InspectorMessageTypeTelemetry {
-        messageType?: InspectorMessageType;
-        count?: InspectorLong;
-        dataSize?: InspectorLong;
-    }
-
-    export type InspectorMessageTypeTelemetryList = Array<InspectorMessageTypeTelemetry>;
-    export type InspectorName = string;
-    export type InspectorNameList = Array<InspectorName>;
-    export type InspectorNamePattern = string;
-    export type InspectorNamePatternList = Array<InspectorNamePattern>;
-    export interface InspectorNoSuchEntityException {
-    }
-
-    export interface InspectorOperationInProgressException {
-    }
-
-    export type InspectorPaginationToken = string;
-    export interface InspectorParameter {
-        name?: InspectorParameterName;
-        value?: InspectorParameterValue;
-    }
-
-    export type InspectorParameterList = Array<InspectorParameter>;
-    export type InspectorParameterName = string;
-    export type InspectorParameterValue = string;
-    export interface InspectorPreviewAgentsForResourceGroupRequest {
-        resourceGroupArn?: InspectorArn;
-        nextToken?: InspectorPaginationToken;
-        maxResults?: InspectorInteger;
-    }
-
-    export interface InspectorPreviewAgentsForResourceGroupResponse {
-        agentPreviewList?: InspectorAgentPreviewList;
-        nextToken?: InspectorPaginationToken;
-    }
-
-    export interface InspectorRegisterCrossAccountAccessRoleRequest {
-        roleArn?: InspectorArn;
-    }
-
-    export interface InspectorRegisterCrossAccountAccessRoleResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorRemoveAttributesFromFindingsRequest {
-        findingArns?: InspectorArnList;
-        attributeKeys?: InspectorAttributeKeyList;
-    }
-
-    export interface InspectorRemoveAttributesFromFindingsResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorResourceGroup {
-        resourceGroupArn?: InspectorArn;
-        resourceGroupTags?: InspectorResourceGroupTags;
-    }
-
-    export type InspectorResourceGroupTags = string;
-    export interface InspectorRulesPackage {
-        rulesPackageArn?: InspectorArn;
-        rulesPackageName?: InspectorName;
-        version?: InspectorVersion;
-        provider?: InspectorName;
-        description?: InspectorLocalizedText;
-    }
-
-    export interface InspectorRun {
-        runArn?: InspectorArn;
-        runName?: InspectorName;
-        assessmentArn?: InspectorArn;
-        runState?: InspectorRunState;
-        rulesPackages?: InspectorArnList;
-        creationTime?: InspectorTimestamp;
-        completionTime?: InspectorTimestamp;
-    }
-
-    export interface InspectorRunAssessmentRequest {
-        assessmentArn?: InspectorArn;
-        runName?: InspectorName;
-    }
-
-    export interface InspectorRunAssessmentResponse {
-        runArn?: InspectorArn;
-    }
-
-    export type InspectorRunState = string;
-    export type InspectorRunStateList = Array<InspectorRunState>;
-    export interface InspectorRunsFilter {
-        runNamePatterns?: InspectorNamePatternList;
-        runStates?: InspectorRunStateList;
-        rulesPackages?: InspectorArnList;
-        creationTime?: InspectorTimestampRange;
-        completionTime?: InspectorTimestampRange;
-    }
-
-    export interface InspectorSetTagsForResourceRequest {
-        resourceArn?: InspectorArn;
-        tags?: InspectorTagList;
-    }
-
-    export interface InspectorSetTagsForResourceResponse {
-        message?: InspectorMessage;
-    }
-
-    export type InspectorSeverity = string;
-    export type InspectorSeverityList = Array<InspectorSeverity>;
-    export interface InspectorStartDataCollectionRequest {
-        assessmentArn?: InspectorArn;
-    }
-
-    export interface InspectorStartDataCollectionResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorStopDataCollectionRequest {
-        assessmentArn?: InspectorArn;
-    }
-
-    export interface InspectorStopDataCollectionResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorTag {
-        Key?: InspectorTagKey;
-        Value?: InspectorTagValue;
-    }
-
-    export type InspectorTagKey = string;
-    export type InspectorTagList = Array<InspectorTag>;
-    export type InspectorTagValue = string;
-    export interface InspectorTelemetry {
-        status?: InspectorTelemetryStatus;
-        messageTypeTelemetries?: InspectorMessageTypeTelemetryList;
-    }
-
-    export type InspectorTelemetryList = Array<InspectorTelemetry>;
-    export type InspectorTelemetryStatus = string;
-    export type InspectorText = string;
-    export type InspectorTextList = Array<InspectorText>;
-    export type InspectorTimestamp = number;
-    export interface InspectorTimestampRange {
-        minimum?: InspectorTimestamp;
-        maximum?: InspectorTimestamp;
-    }
-
-    export interface InspectorUpdateApplicationRequest {
-        applicationArn?: InspectorArn;
-        applicationName?: InspectorName;
-        resourceGroupArn?: InspectorArn;
-    }
-
-    export interface InspectorUpdateApplicationResponse {
-        message?: InspectorMessage;
-    }
-
-    export interface InspectorUpdateAssessmentRequest {
-        assessmentArn?: InspectorArn;
-        assessmentName?: InspectorName;
-        durationInSeconds?: InspectorDuration;
-    }
-
-    export interface InspectorUpdateAssessmentResponse {
-        message?: InspectorMessage;
-    }
-
-    export type InspectorVersion = string;
 }

--- a/output/aws-iot.d.ts
+++ b/output/aws-iot.d.ts
@@ -6,610 +6,514 @@ declare module "aws-sdk" {
 
     export class Iot extends Service {
       constructor(options?: any);
-      acceptCertificateTransfer(params: IotAcceptCertificateTransferRequest, callback?: (err: IotResourceNotFoundException|IotTransferAlreadyCompletedException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      attachPrincipalPolicy(params: IotAttachPrincipalPolicyRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|IotLimitExceededException|any, data: any) => void): Request;
-      attachThingPrincipal(params: IotAttachThingPrincipalRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotAttachThingPrincipalResponse|any) => void): Request;
-      cancelCertificateTransfer(params: IotCancelCertificateTransferRequest, callback?: (err: IotResourceNotFoundException|IotTransferAlreadyCompletedException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      createCertificateFromCsr(params: IotCreateCertificateFromCsrRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotCreateCertificateFromCsrResponse|any) => void): Request;
-      createKeysAndCertificate(params: IotCreateKeysAndCertificateRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotCreateKeysAndCertificateResponse|any) => void): Request;
-      createPolicy(params: IotCreatePolicyRequest, callback?: (err: IotResourceAlreadyExistsException|IotMalformedPolicyException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotCreatePolicyResponse|any) => void): Request;
-      createPolicyVersion(params: IotCreatePolicyVersionRequest, callback?: (err: IotResourceNotFoundException|IotMalformedPolicyException|IotVersionsLimitExceededException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotCreatePolicyVersionResponse|any) => void): Request;
-      createThing(params: IotCreateThingRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|IotResourceAlreadyExistsException|any, data: IotCreateThingResponse|any) => void): Request;
-      createTopicRule(params: IotCreateTopicRuleRequest, callback?: (err: IotSqlParseException|IotInternalException|IotInvalidRequestException|IotResourceAlreadyExistsException|IotServiceUnavailableException|any, data: any) => void): Request;
-      deleteCertificate(params: IotDeleteCertificateRequest, callback?: (err: IotDeleteConflictException|IotResourceNotFoundException|IotCertificateStateException|any, data: any) => void): Request;
-      deletePolicy(params: IotDeletePolicyRequest, callback?: (err: IotDeleteConflictException|IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      deletePolicyVersion(params: IotDeletePolicyVersionRequest, callback?: (err: IotDeleteConflictException|IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      deleteThing(params: IotDeleteThingRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotDeleteThingResponse|any) => void): Request;
-      deleteTopicRule(params: IotDeleteTopicRuleRequest, callback?: (err: IotInternalException|IotInvalidRequestException|IotServiceUnavailableException|IotUnauthorizedException|any, data: any) => void): Request;
-      describeCertificate(params: IotDescribeCertificateRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|IotResourceNotFoundException|any, data: IotDescribeCertificateResponse|any) => void): Request;
-      describeEndpoint(params: IotDescribeEndpointRequest, callback?: (err: IotInternalFailureException|IotUnauthorizedException|any, data: IotDescribeEndpointResponse|any) => void): Request;
-      describeThing(params: IotDescribeThingRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotDescribeThingResponse|any) => void): Request;
-      detachPrincipalPolicy(params: IotDetachPrincipalPolicyRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      detachThingPrincipal(params: IotDetachThingPrincipalRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotDetachThingPrincipalResponse|any) => void): Request;
-      getLoggingOptions(params: IotGetLoggingOptionsRequest, callback?: (err: IotInternalException|IotInvalidRequestException|IotServiceUnavailableException|any, data: IotGetLoggingOptionsResponse|any) => void): Request;
-      getPolicy(params: IotGetPolicyRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotGetPolicyResponse|any) => void): Request;
-      getPolicyVersion(params: IotGetPolicyVersionRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotGetPolicyVersionResponse|any) => void): Request;
-      getTopicRule(params: IotGetTopicRuleRequest, callback?: (err: IotInternalException|IotInvalidRequestException|IotServiceUnavailableException|IotUnauthorizedException|any, data: IotGetTopicRuleResponse|any) => void): Request;
-      listCertificates(params: IotListCertificatesRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListCertificatesResponse|any) => void): Request;
-      listPolicies(params: IotListPoliciesRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListPoliciesResponse|any) => void): Request;
-      listPolicyVersions(params: IotListPolicyVersionsRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListPolicyVersionsResponse|any) => void): Request;
-      listPrincipalPolicies(params: IotListPrincipalPoliciesRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListPrincipalPoliciesResponse|any) => void): Request;
-      listPrincipalThings(params: IotListPrincipalThingsRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListPrincipalThingsResponse|any) => void): Request;
-      listThingPrincipals(params: IotListThingPrincipalsRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListThingPrincipalsResponse|any) => void): Request;
-      listThings(params: IotListThingsRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotListThingsResponse|any) => void): Request;
-      listTopicRules(params: IotListTopicRulesRequest, callback?: (err: IotInternalException|IotInvalidRequestException|IotServiceUnavailableException|any, data: IotListTopicRulesResponse|any) => void): Request;
-      rejectCertificateTransfer(params: IotRejectCertificateTransferRequest, callback?: (err: IotResourceNotFoundException|IotTransferAlreadyCompletedException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      replaceTopicRule(params: IotReplaceTopicRuleRequest, callback?: (err: IotSqlParseException|IotInternalException|IotInvalidRequestException|IotServiceUnavailableException|IotUnauthorizedException|any, data: any) => void): Request;
-      setDefaultPolicyVersion(params: IotSetDefaultPolicyVersionRequest, callback?: (err: IotResourceNotFoundException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      setLoggingOptions(params: IotSetLoggingOptionsRequest, callback?: (err: IotInternalException|IotInvalidRequestException|IotServiceUnavailableException|any, data: any) => void): Request;
-      transferCertificate(params: IotTransferCertificateRequest, callback?: (err: IotInvalidRequestException|IotResourceNotFoundException|IotCertificateStateException|IotTransferConflictException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: IotTransferCertificateResponse|any) => void): Request;
-      updateCertificate(params: IotUpdateCertificateRequest, callback?: (err: IotResourceNotFoundException|IotCertificateStateException|IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|any, data: any) => void): Request;
-      updateThing(params: IotUpdateThingRequest, callback?: (err: IotInvalidRequestException|IotThrottlingException|IotUnauthorizedException|IotServiceUnavailableException|IotInternalFailureException|IotResourceNotFoundException|any, data: IotUpdateThingResponse|any) => void): Request;
-    }
-
-    export interface IotAcceptCertificateTransferRequest {
-        certificateId: IotCertificateId;
-        setAsActive?: IotSetAsActive;
-    }
-
-    export interface IotAction {
-        dynamoDB?: IotDynamoDBAction;
-        lambda?: IotLambdaAction;
-        sns?: IotSnsAction;
-        sqs?: IotSqsAction;
-        kinesis?: IotKinesisAction;
-        republish?: IotRepublishAction;
-        s3?: IotS3Action;
-        firehose?: IotFirehoseAction;
-    }
-
-    export type IotActionList = Array<IotAction>; // max: 10
-    export type IotAscendingOrder = boolean;
-    export interface IotAttachPrincipalPolicyRequest {
-        policyName: IotPolicyName;
-        principal: IotPrincipal;
-    }
-
-    export interface IotAttachThingPrincipalRequest {
-        thingName: IotThingName;
-        principal: IotPrincipal;
-    }
-
-    export interface IotAttachThingPrincipalResponse {
-    }
-
-    export type IotAttributeName = string; // pattern: "[a-zA-Z0-9_.,@/:#-]+"
-    export interface IotAttributePayload {
-        attributes?: IotAttributes;
-    }
-
-    export type IotAttributeValue = string; // pattern: "[a-zA-Z0-9_.,@/:#-]+"
-    export type IotAttributes = any; // not really - it was 'map' instead - must fix this one
-    export type IotAwsAccountId = string; // pattern: "[0-9]{12}"
-    export type IotAwsArn = string;
-    export type IotBucketName = string;
-    export interface IotCancelCertificateTransferRequest {
-        certificateId: IotCertificateId;
-    }
-
-    export interface IotCertificate {
-        certificateArn?: IotCertificateArn;
-        certificateId?: IotCertificateId;
-        status?: IotCertificateStatus;
-        creationDate?: IotDateType;
-    }
-
-    export type IotCertificateArn = string;
-    export interface IotCertificateDescription {
-        certificateArn?: IotCertificateArn;
-        certificateId?: IotCertificateId;
-        status?: IotCertificateStatus;
-        certificatePem?: IotCertificatePem;
-        ownedBy?: IotAwsAccountId;
-        creationDate?: IotDateType;
-        lastModifiedDate?: IotDateType;
-    }
-
-    export type IotCertificateId = string; // pattern: "(0x)?[a-fA-F0-9]+"
-    export type IotCertificatePem = string;
-    export type IotCertificateSigningRequest = string;
-    export interface IotCertificateStateException {
-        message?: IoterrorMessage;
-    }
-
-    export type IotCertificateStatus = string;
-    export type IotCertificates = Array<IotCertificate>;
-    export type IotClientId = string;
-    export interface IotCreateCertificateFromCsrRequest {
-        certificateSigningRequest: IotCertificateSigningRequest;
-        setAsActive?: IotSetAsActive;
-    }
-
-    export interface IotCreateCertificateFromCsrResponse {
-        certificateArn?: IotCertificateArn;
-        certificateId?: IotCertificateId;
-        certificatePem?: IotCertificatePem;
-    }
-
-    export interface IotCreateKeysAndCertificateRequest {
-        setAsActive?: IotSetAsActive;
-    }
-
-    export interface IotCreateKeysAndCertificateResponse {
-        certificateArn?: IotCertificateArn;
-        certificateId?: IotCertificateId;
-        certificatePem?: IotCertificatePem;
-        keyPair?: IotKeyPair;
-    }
-
-    export interface IotCreatePolicyRequest {
-        policyName: IotPolicyName;
-        policyDocument: IotPolicyDocument;
-    }
-
-    export interface IotCreatePolicyResponse {
-        policyName?: IotPolicyName;
-        policyArn?: IotPolicyArn;
-        policyDocument?: IotPolicyDocument;
-        policyVersionId?: IotPolicyVersionId;
-    }
-
-    export interface IotCreatePolicyVersionRequest {
-        policyName: IotPolicyName;
-        policyDocument: IotPolicyDocument;
-        setAsDefault?: IotSetAsDefault;
-    }
-
-    export interface IotCreatePolicyVersionResponse {
-        policyArn?: IotPolicyArn;
-        policyDocument?: IotPolicyDocument;
-        policyVersionId?: IotPolicyVersionId;
-        isDefaultVersion?: IotIsDefaultVersion;
-    }
-
-    export interface IotCreateThingRequest {
-        thingName: IotThingName;
-        attributePayload?: IotAttributePayload;
-    }
-
-    export interface IotCreateThingResponse {
-        thingName?: IotThingName;
-        thingArn?: IotThingArn;
-    }
-
-    export interface IotCreateTopicRuleRequest {
-        ruleName: IotRuleName;
-        topicRulePayload: IotTopicRulePayload;
-    }
-
-    export type IotCreatedAtDate = number;
-    export type IotDateType = number;
-    export interface IotDeleteCertificateRequest {
-        certificateId: IotCertificateId;
-    }
-
-    export interface IotDeleteConflictException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotDeletePolicyRequest {
-        policyName: IotPolicyName;
-    }
-
-    export interface IotDeletePolicyVersionRequest {
-        policyName: IotPolicyName;
-        policyVersionId: IotPolicyVersionId;
-    }
-
-    export interface IotDeleteThingRequest {
-        thingName: IotThingName;
-    }
-
-    export interface IotDeleteThingResponse {
-    }
-
-    export interface IotDeleteTopicRuleRequest {
-        ruleName: IotRuleName;
-    }
-
-    export type IotDeliveryStreamName = string;
-    export interface IotDescribeCertificateRequest {
-        certificateId: IotCertificateId;
-    }
-
-    export interface IotDescribeCertificateResponse {
-        certificateDescription?: IotCertificateDescription;
-    }
-
-    export interface IotDescribeEndpointRequest {
-    }
-
-    export interface IotDescribeEndpointResponse {
-        endpointAddress?: IotEndpointAddress;
-    }
-
-    export interface IotDescribeThingRequest {
-        thingName: IotThingName;
-    }
-
-    export interface IotDescribeThingResponse {
-        defaultClientId?: IotClientId;
-        thingName?: IotThingName;
-        attributes?: IotAttributes;
-    }
-
-    export type IotDescription = string;
-    export interface IotDetachPrincipalPolicyRequest {
-        policyName: IotPolicyName;
-        principal: IotPrincipal;
-    }
-
-    export interface IotDetachThingPrincipalRequest {
-        thingName: IotThingName;
-        principal: IotPrincipal;
-    }
-
-    export interface IotDetachThingPrincipalResponse {
-    }
-
-    export interface IotDynamoDBAction {
-        tableName: IotTableName;
-        roleArn: IotAwsArn;
-        hashKeyField: IotHashKeyField;
-        hashKeyValue: IotHashKeyValue;
-        rangeKeyField: IotRangeKeyField;
-        rangeKeyValue: IotRangeKeyValue;
-        payloadField?: IotPayloadField;
-    }
-
-    export type IotEndpointAddress = string;
-    export interface IotFirehoseAction {
-        roleArn: IotAwsArn;
-        deliveryStreamName: IotDeliveryStreamName;
-    }
-
-    export type IotFunctionArn = string;
-    export interface IotGetLoggingOptionsRequest {
-    }
-
-    export interface IotGetLoggingOptionsResponse {
-        roleArn?: IotAwsArn;
-        logLevel?: IotLogLevel;
-    }
-
-    export interface IotGetPolicyRequest {
-        policyName: IotPolicyName;
-    }
-
-    export interface IotGetPolicyResponse {
-        policyName?: IotPolicyName;
-        policyArn?: IotPolicyArn;
-        policyDocument?: IotPolicyDocument;
-        defaultVersionId?: IotPolicyVersionId;
-    }
-
-    export interface IotGetPolicyVersionRequest {
-        policyName: IotPolicyName;
-        policyVersionId: IotPolicyVersionId;
-    }
-
-    export interface IotGetPolicyVersionResponse {
-        policyArn?: IotPolicyArn;
-        policyName?: IotPolicyName;
-        policyDocument?: IotPolicyDocument;
-        policyVersionId?: IotPolicyVersionId;
-        isDefaultVersion?: IotIsDefaultVersion;
-    }
-
-    export interface IotGetTopicRuleRequest {
-        ruleName: IotRuleName;
-    }
-
-    export interface IotGetTopicRuleResponse {
-        rule?: IotTopicRule;
-    }
-
-    export type IotHashKeyField = string;
-    export type IotHashKeyValue = string;
-    export interface IotInternalException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotInternalFailureException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotInvalidRequestException {
-        message?: IoterrorMessage;
-    }
-
-    export type IotIsDefaultVersion = boolean;
-    export type IotIsDisabled = boolean;
-    export type IotKey = string;
-    export interface IotKeyPair {
-        PublicKey?: IotPublicKey;
-        PrivateKey?: IotPrivateKey;
-    }
-
-    export interface IotKinesisAction {
-        roleArn: IotAwsArn;
-        streamName: IotStreamName;
-        partitionKey?: IotPartitionKey;
-    }
-
-    export interface IotLambdaAction {
-        functionArn: IotFunctionArn;
-    }
-
-    export interface IotLimitExceededException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotListCertificatesRequest {
-        pageSize?: IotPageSize;
-        marker?: IotMarker;
-        ascendingOrder?: IotAscendingOrder;
-    }
-
-    export interface IotListCertificatesResponse {
-        certificates?: IotCertificates;
-        nextMarker?: IotMarker;
-    }
-
-    export interface IotListPoliciesRequest {
-        marker?: IotMarker;
-        pageSize?: IotPageSize;
-        ascendingOrder?: IotAscendingOrder;
-    }
-
-    export interface IotListPoliciesResponse {
-        policies?: IotPolicies;
-        nextMarker?: IotMarker;
-    }
-
-    export interface IotListPolicyVersionsRequest {
-        policyName: IotPolicyName;
-    }
-
-    export interface IotListPolicyVersionsResponse {
-        policyVersions?: IotPolicyVersions;
-    }
-
-    export interface IotListPrincipalPoliciesRequest {
-        principal: IotPrincipal;
-        marker?: IotMarker;
-        pageSize?: IotPageSize;
-        ascendingOrder?: IotAscendingOrder;
-    }
-
-    export interface IotListPrincipalPoliciesResponse {
-        policies?: IotPolicies;
-        nextMarker?: IotMarker;
-    }
-
-    export interface IotListPrincipalThingsRequest {
-        nextToken?: IotNextToken;
-        maxResults?: IotMaxResults;
-        principal: IotPrincipal;
-    }
-
-    export interface IotListPrincipalThingsResponse {
-        things?: IotThingNameList;
-        nextToken?: IotNextToken;
-    }
-
-    export interface IotListThingPrincipalsRequest {
-        thingName: IotThingName;
-    }
-
-    export interface IotListThingPrincipalsResponse {
-        principals?: IotPrincipals;
-    }
-
-    export interface IotListThingsRequest {
-        nextToken?: IotNextToken;
-        maxResults?: IotMaxResults;
-        attributeName?: IotAttributeName;
-        attributeValue?: IotAttributeValue;
-    }
-
-    export interface IotListThingsResponse {
-        things?: IotThingAttributeList;
-        nextToken?: IotNextToken;
-    }
-
-    export interface IotListTopicRulesRequest {
-        topic?: IotTopic;
-        maxResults?: IotMaxResults;
-        nextToken?: IotNextToken;
-        ruleDisabled?: IotIsDisabled;
-    }
-
-    export interface IotListTopicRulesResponse {
-        rules?: IotTopicRuleList;
-        nextToken?: IotNextToken;
-    }
-
-    export type IotLogLevel = string;
-    export interface IotLoggingOptionsPayload {
-        roleArn: IotAwsArn;
-        logLevel?: IotLogLevel;
-    }
-
-    export interface IotMalformedPolicyException {
-        message?: IoterrorMessage;
-    }
-
-    export type IotMarker = string;
-    export type IotMaxResults = number;
-    export type IotNextToken = string;
-    export type IotPageSize = number;
-    export type IotPartitionKey = string;
-    export type IotPayloadField = string;
-    export type IotPolicies = Array<IotPolicy>;
-    export interface IotPolicy {
-        policyName?: IotPolicyName;
-        policyArn?: IotPolicyArn;
-    }
-
-    export type IotPolicyArn = string;
-    export type IotPolicyDocument = string;
-    export type IotPolicyName = string; // pattern: "[\w+=,.@-]+"
-    export interface IotPolicyVersion {
-        versionId?: IotPolicyVersionId;
-        isDefaultVersion?: IotIsDefaultVersion;
-        createDate?: IotDateType;
-    }
-
-    export type IotPolicyVersionId = string; // pattern: "[0-9]+"
-    export type IotPolicyVersions = Array<IotPolicyVersion>;
-    export type IotPrincipal = string;
-    export type IotPrincipalArn = string;
-    export type IotPrincipals = Array<IotPrincipalArn>;
-    export type IotPrivateKey = string;
-    export type IotPublicKey = string;
-    export type IotQueueUrl = string;
-    export type IotRangeKeyField = string;
-    export type IotRangeKeyValue = string;
-    export interface IotRejectCertificateTransferRequest {
-        certificateId: IotCertificateId;
-    }
-
-    export interface IotReplaceTopicRuleRequest {
-        ruleName: IotRuleName;
-        topicRulePayload: IotTopicRulePayload;
-    }
-
-    export interface IotRepublishAction {
-        roleArn: IotAwsArn;
-        topic: IotTopicPattern;
-    }
-
-    export interface IotResourceAlreadyExistsException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotResourceNotFoundException {
-        message?: IoterrorMessage;
-    }
-
-    export type IotRuleName = string; // pattern: "^[a-zA-Z0-9_]+$"
-    export interface IotS3Action {
-        roleArn: IotAwsArn;
-        bucketName: IotBucketName;
-        key: IotKey;
-    }
-
-    export type IotSQL = string;
-    export interface IotServiceUnavailableException {
-        message?: IoterrorMessage;
-    }
-
-    export type IotSetAsActive = boolean;
-    export type IotSetAsDefault = boolean;
-    export interface IotSetDefaultPolicyVersionRequest {
-        policyName: IotPolicyName;
-        policyVersionId: IotPolicyVersionId;
-    }
-
-    export interface IotSetLoggingOptionsRequest {
-        loggingOptionsPayload?: IotLoggingOptionsPayload;
-    }
-
-    export interface IotSnsAction {
-        targetArn: IotAwsArn;
-        roleArn: IotAwsArn;
-    }
-
-    export interface IotSqlParseException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotSqsAction {
-        roleArn: IotAwsArn;
-        queueUrl: IotQueueUrl;
-        useBase64?: IotUseBase64;
-    }
-
-    export type IotStreamName = string;
-    export type IotTableName = string;
-    export type IotThingArn = string;
-    export interface IotThingAttribute {
-        thingName?: IotThingName;
-        attributes?: IotAttributes;
-    }
+      acceptCertificateTransfer(params: Iot.AcceptCertificateTransferRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.TransferAlreadyCompletedException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      attachPrincipalPolicy(params: Iot.AttachPrincipalPolicyRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|Iot.LimitExceededException|any, data: any) => void): Request;
+      attachThingPrincipal(params: Iot.AttachThingPrincipalRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.AttachThingPrincipalResponse|any) => void): Request;
+      cancelCertificateTransfer(params: Iot.CancelCertificateTransferRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.TransferAlreadyCompletedException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      createCertificateFromCsr(params: Iot.CreateCertificateFromCsrRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.CreateCertificateFromCsrResponse|any) => void): Request;
+      createKeysAndCertificate(params: Iot.CreateKeysAndCertificateRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.CreateKeysAndCertificateResponse|any) => void): Request;
+      createPolicy(params: Iot.CreatePolicyRequest, callback?: (err: Iot.ResourceAlreadyExistsException|Iot.MalformedPolicyException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.CreatePolicyResponse|any) => void): Request;
+      createPolicyVersion(params: Iot.CreatePolicyVersionRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.MalformedPolicyException|Iot.VersionsLimitExceededException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.CreatePolicyVersionResponse|any) => void): Request;
+      createThing(params: Iot.CreateThingRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|Iot.ResourceAlreadyExistsException|any, data: Iot.CreateThingResponse|any) => void): Request;
+      createTopicRule(params: Iot.CreateTopicRuleRequest, callback?: (err: Iot.SqlParseException|Iot.InternalException|Iot.InvalidRequestException|Iot.ResourceAlreadyExistsException|Iot.ServiceUnavailableException|any, data: any) => void): Request;
+      deleteCertificate(params: Iot.DeleteCertificateRequest, callback?: (err: Iot.DeleteConflictException|Iot.ResourceNotFoundException|Iot.CertificateStateException|any, data: any) => void): Request;
+      deletePolicy(params: Iot.DeletePolicyRequest, callback?: (err: Iot.DeleteConflictException|Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      deletePolicyVersion(params: Iot.DeletePolicyVersionRequest, callback?: (err: Iot.DeleteConflictException|Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      deleteThing(params: Iot.DeleteThingRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.DeleteThingResponse|any) => void): Request;
+      deleteTopicRule(params: Iot.DeleteTopicRuleRequest, callback?: (err: Iot.InternalException|Iot.InvalidRequestException|Iot.ServiceUnavailableException|Iot.UnauthorizedException|any, data: any) => void): Request;
+      describeCertificate(params: Iot.DescribeCertificateRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|Iot.ResourceNotFoundException|any, data: Iot.DescribeCertificateResponse|any) => void): Request;
+      describeEndpoint(params: Iot.DescribeEndpointRequest, callback?: (err: Iot.InternalFailureException|Iot.UnauthorizedException|any, data: Iot.DescribeEndpointResponse|any) => void): Request;
+      describeThing(params: Iot.DescribeThingRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.DescribeThingResponse|any) => void): Request;
+      detachPrincipalPolicy(params: Iot.DetachPrincipalPolicyRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      detachThingPrincipal(params: Iot.DetachThingPrincipalRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.DetachThingPrincipalResponse|any) => void): Request;
+      getLoggingOptions(params: Iot.GetLoggingOptionsRequest, callback?: (err: Iot.InternalException|Iot.InvalidRequestException|Iot.ServiceUnavailableException|any, data: Iot.GetLoggingOptionsResponse|any) => void): Request;
+      getPolicy(params: Iot.GetPolicyRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.GetPolicyResponse|any) => void): Request;
+      getPolicyVersion(params: Iot.GetPolicyVersionRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.GetPolicyVersionResponse|any) => void): Request;
+      getTopicRule(params: Iot.GetTopicRuleRequest, callback?: (err: Iot.InternalException|Iot.InvalidRequestException|Iot.ServiceUnavailableException|Iot.UnauthorizedException|any, data: Iot.GetTopicRuleResponse|any) => void): Request;
+      listCertificates(params: Iot.ListCertificatesRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListCertificatesResponse|any) => void): Request;
+      listPolicies(params: Iot.ListPoliciesRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListPoliciesResponse|any) => void): Request;
+      listPolicyVersions(params: Iot.ListPolicyVersionsRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListPolicyVersionsResponse|any) => void): Request;
+      listPrincipalPolicies(params: Iot.ListPrincipalPoliciesRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListPrincipalPoliciesResponse|any) => void): Request;
+      listPrincipalThings(params: Iot.ListPrincipalThingsRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListPrincipalThingsResponse|any) => void): Request;
+      listThingPrincipals(params: Iot.ListThingPrincipalsRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListThingPrincipalsResponse|any) => void): Request;
+      listThings(params: Iot.ListThingsRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.ListThingsResponse|any) => void): Request;
+      listTopicRules(params: Iot.ListTopicRulesRequest, callback?: (err: Iot.InternalException|Iot.InvalidRequestException|Iot.ServiceUnavailableException|any, data: Iot.ListTopicRulesResponse|any) => void): Request;
+      rejectCertificateTransfer(params: Iot.RejectCertificateTransferRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.TransferAlreadyCompletedException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      replaceTopicRule(params: Iot.ReplaceTopicRuleRequest, callback?: (err: Iot.SqlParseException|Iot.InternalException|Iot.InvalidRequestException|Iot.ServiceUnavailableException|Iot.UnauthorizedException|any, data: any) => void): Request;
+      setDefaultPolicyVersion(params: Iot.SetDefaultPolicyVersionRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      setLoggingOptions(params: Iot.SetLoggingOptionsRequest, callback?: (err: Iot.InternalException|Iot.InvalidRequestException|Iot.ServiceUnavailableException|any, data: any) => void): Request;
+      transferCertificate(params: Iot.TransferCertificateRequest, callback?: (err: Iot.InvalidRequestException|Iot.ResourceNotFoundException|Iot.CertificateStateException|Iot.TransferConflictException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: Iot.TransferCertificateResponse|any) => void): Request;
+      updateCertificate(params: Iot.UpdateCertificateRequest, callback?: (err: Iot.ResourceNotFoundException|Iot.CertificateStateException|Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|any, data: any) => void): Request;
+      updateThing(params: Iot.UpdateThingRequest, callback?: (err: Iot.InvalidRequestException|Iot.ThrottlingException|Iot.UnauthorizedException|Iot.ServiceUnavailableException|Iot.InternalFailureException|Iot.ResourceNotFoundException|any, data: Iot.UpdateThingResponse|any) => void): Request;
+    }
+    
+    export module Iot {
+        export type ActionList = Action[];    // max: 10
+        export type AscendingOrder = boolean;
+        export type AttributeName = string;    // pattern: &quot;[a-zA-Z0-9_.,@/:#-]+&quot;, max: 128
+        export type AttributeValue = string;    // pattern: &quot;[a-zA-Z0-9_.,@/:#-]+&quot;, max: 1024
+        export type Attributes = {[key:string]: AttributeValue};
+        export type AwsAccountId = string;    // pattern: &quot;[0-9]{12}&quot;
+        export type AwsArn = string;
+        export type BucketName = string;
+        export type CertificateArn = string;
+        export type CertificateId = string;    // pattern: &quot;(0x)?[a-fA-F0-9]+&quot;, max: 64, min: 64
+        export type CertificatePem = string;
+        export type CertificateSigningRequest = string;    // min: 1
+        export type CertificateStatus = string;
+        export type Certificates = Certificate[];
+        export type ClientId = string;
+        export type CreatedAtDate = number;
+        export type DateType = number;
+        export type DeliveryStreamName = string;
+        export type Description = string;
+        export type EndpointAddress = string;
+        export type FunctionArn = string;
+        export type HashKeyField = string;
+        export type HashKeyValue = string;
+        export type IsDefaultVersion = boolean;
+        export type IsDisabled = boolean;
+        export type Key = string;
+        export type LogLevel = string;
+        export type Marker = string;
+        export type MaxResults = number;    // max: 10000, min: 1
+        export type NextToken = string;
+        export type PageSize = number;    // max: 250, min: 1
+        export type PartitionKey = string;
+        export type PayloadField = string;
+        export type Policies = Policy[];
+        export type PolicyArn = string;
+        export type PolicyDocument = string;
+        export type PolicyName = string;    // pattern: &quot;[\w+=,.@-]+&quot;, max: 128, min: 1
+        export type PolicyVersionId = string;    // pattern: &quot;[0-9]+&quot;
+        export type PolicyVersions = PolicyVersion[];
+        export type Principal = string;
+        export type PrincipalArn = string;
+        export type Principals = PrincipalArn[];
+        export type PrivateKey = string;    // min: 1
+        export type PublicKey = string;    // min: 1
+        export type QueueUrl = string;
+        export type RangeKeyField = string;
+        export type RangeKeyValue = string;
+        export type RuleName = string;    // pattern: &quot;^[a-zA-Z0-9_]+$&quot;, max: 128, min: 1
+        export type SQL = string;
+        export type SetAsActive = boolean;
+        export type SetAsDefault = boolean;
+        export type StreamName = string;
+        export type TableName = string;
+        export type ThingArn = string;
+        export type ThingAttributeList = ThingAttribute[];
+        export type ThingName = string;    // pattern: &quot;[a-zA-Z0-9_-]+&quot;, max: 128, min: 1
+        export type ThingNameList = ThingName[];
+        export type Topic = string;
+        export type TopicPattern = string;
+        export type TopicRuleList = TopicRuleListItem[];
+        export type UseBase64 = boolean;
+        export type errorMessage = string;
+
+        export interface AcceptCertificateTransferRequest {
+            certificateId: CertificateId;            
+            setAsActive?: SetAsActive;            
+        }
+        export interface Action {
+            dynamoDB?: DynamoDBAction;            
+            lambda?: LambdaAction;            
+            sns?: SnsAction;            
+            sqs?: SqsAction;            
+            kinesis?: KinesisAction;            
+            republish?: RepublishAction;            
+            s3?: S3Action;            
+            firehose?: FirehoseAction;            
+        }
+        export interface AttachPrincipalPolicyRequest {
+            policyName: PolicyName;            
+            principal: Principal;            
+        }
+        export interface AttachThingPrincipalRequest {
+            thingName: ThingName;            
+            principal: Principal;            
+        }
+        export interface AttachThingPrincipalResponse {
+        }
+        export interface AttributePayload {
+            attributes?: Attributes;            
+        }
+        export interface CancelCertificateTransferRequest {
+            certificateId: CertificateId;            
+        }
+        export interface Certificate {
+            certificateArn?: CertificateArn;            
+            certificateId?: CertificateId;            
+            status?: CertificateStatus;            
+            creationDate?: DateType;            
+        }
+        export interface CertificateDescription {
+            certificateArn?: CertificateArn;            
+            certificateId?: CertificateId;            
+            status?: CertificateStatus;            
+            certificatePem?: CertificatePem;            
+            ownedBy?: AwsAccountId;            
+            creationDate?: DateType;            
+            lastModifiedDate?: DateType;            
+        }
+        export interface CertificateStateException {
+            message?: errorMessage;            
+        }
+        export interface CreateCertificateFromCsrRequest {
+            certificateSigningRequest: CertificateSigningRequest;            
+            setAsActive?: SetAsActive;            
+        }
+        export interface CreateCertificateFromCsrResponse {
+            certificateArn?: CertificateArn;            
+            certificateId?: CertificateId;            
+            certificatePem?: CertificatePem;            
+        }
+        export interface CreateKeysAndCertificateRequest {
+            setAsActive?: SetAsActive;            
+        }
+        export interface CreateKeysAndCertificateResponse {
+            certificateArn?: CertificateArn;            
+            certificateId?: CertificateId;            
+            certificatePem?: CertificatePem;            
+            keyPair?: KeyPair;            
+        }
+        export interface CreatePolicyRequest {
+            policyName: PolicyName;            
+            policyDocument: PolicyDocument;            
+        }
+        export interface CreatePolicyResponse {
+            policyName?: PolicyName;            
+            policyArn?: PolicyArn;            
+            policyDocument?: PolicyDocument;            
+            policyVersionId?: PolicyVersionId;            
+        }
+        export interface CreatePolicyVersionRequest {
+            policyName: PolicyName;            
+            policyDocument: PolicyDocument;            
+            setAsDefault?: SetAsDefault;            
+        }
+        export interface CreatePolicyVersionResponse {
+            policyArn?: PolicyArn;            
+            policyDocument?: PolicyDocument;            
+            policyVersionId?: PolicyVersionId;            
+            isDefaultVersion?: IsDefaultVersion;            
+        }
+        export interface CreateThingRequest {
+            thingName: ThingName;            
+            attributePayload?: AttributePayload;            
+        }
+        export interface CreateThingResponse {
+            thingName?: ThingName;            
+            thingArn?: ThingArn;            
+        }
+        export interface CreateTopicRuleRequest {
+            ruleName: RuleName;            
+            topicRulePayload: TopicRulePayload;            
+        }
+        export interface DeleteCertificateRequest {
+            certificateId: CertificateId;            
+        }
+        export interface DeleteConflictException {
+            message?: errorMessage;            
+        }
+        export interface DeletePolicyRequest {
+            policyName: PolicyName;            
+        }
+        export interface DeletePolicyVersionRequest {
+            policyName: PolicyName;            
+            policyVersionId: PolicyVersionId;            
+        }
+        export interface DeleteThingRequest {
+            thingName: ThingName;            
+        }
+        export interface DeleteThingResponse {
+        }
+        export interface DeleteTopicRuleRequest {
+            ruleName: RuleName;            
+        }
+        export interface DescribeCertificateRequest {
+            certificateId: CertificateId;            
+        }
+        export interface DescribeCertificateResponse {
+            certificateDescription?: CertificateDescription;            
+        }
+        export interface DescribeEndpointRequest {
+        }
+        export interface DescribeEndpointResponse {
+            endpointAddress?: EndpointAddress;            
+        }
+        export interface DescribeThingRequest {
+            thingName: ThingName;            
+        }
+        export interface DescribeThingResponse {
+            defaultClientId?: ClientId;            
+            thingName?: ThingName;            
+            attributes?: Attributes;            
+        }
+        export interface DetachPrincipalPolicyRequest {
+            policyName: PolicyName;            
+            principal: Principal;            
+        }
+        export interface DetachThingPrincipalRequest {
+            thingName: ThingName;            
+            principal: Principal;            
+        }
+        export interface DetachThingPrincipalResponse {
+        }
+        export interface DynamoDBAction {
+            tableName: TableName;            
+            roleArn: AwsArn;            
+            hashKeyField: HashKeyField;            
+            hashKeyValue: HashKeyValue;            
+            rangeKeyField: RangeKeyField;            
+            rangeKeyValue: RangeKeyValue;            
+            payloadField?: PayloadField;            
+        }
+        export interface FirehoseAction {
+            roleArn: AwsArn;            
+            deliveryStreamName: DeliveryStreamName;            
+        }
+        export interface GetLoggingOptionsRequest {
+        }
+        export interface GetLoggingOptionsResponse {
+            roleArn?: AwsArn;            
+            logLevel?: LogLevel;            
+        }
+        export interface GetPolicyRequest {
+            policyName: PolicyName;            
+        }
+        export interface GetPolicyResponse {
+            policyName?: PolicyName;            
+            policyArn?: PolicyArn;            
+            policyDocument?: PolicyDocument;            
+            defaultVersionId?: PolicyVersionId;            
+        }
+        export interface GetPolicyVersionRequest {
+            policyName: PolicyName;            
+            policyVersionId: PolicyVersionId;            
+        }
+        export interface GetPolicyVersionResponse {
+            policyArn?: PolicyArn;            
+            policyName?: PolicyName;            
+            policyDocument?: PolicyDocument;            
+            policyVersionId?: PolicyVersionId;            
+            isDefaultVersion?: IsDefaultVersion;            
+        }
+        export interface GetTopicRuleRequest {
+            ruleName: RuleName;            
+        }
+        export interface GetTopicRuleResponse {
+            rule?: TopicRule;            
+        }
+        export interface InternalException {
+            message?: errorMessage;            
+        }
+        export interface InternalFailureException {
+            message?: errorMessage;            
+        }
+        export interface InvalidRequestException {
+            message?: errorMessage;            
+        }
+        export interface KeyPair {
+            PublicKey?: PublicKey;            
+            PrivateKey?: PrivateKey;            
+        }
+        export interface KinesisAction {
+            roleArn: AwsArn;            
+            streamName: StreamName;            
+            partitionKey?: PartitionKey;            
+        }
+        export interface LambdaAction {
+            functionArn: FunctionArn;            
+        }
+        export interface LimitExceededException {
+            message?: errorMessage;            
+        }
+        export interface ListCertificatesRequest {
+            pageSize?: PageSize;            
+            marker?: Marker;            
+            ascendingOrder?: AscendingOrder;            
+        }
+        export interface ListCertificatesResponse {
+            certificates?: Certificates;            
+            nextMarker?: Marker;            
+        }
+        export interface ListPoliciesRequest {
+            marker?: Marker;            
+            pageSize?: PageSize;            
+            ascendingOrder?: AscendingOrder;            
+        }
+        export interface ListPoliciesResponse {
+            policies?: Policies;            
+            nextMarker?: Marker;            
+        }
+        export interface ListPolicyVersionsRequest {
+            policyName: PolicyName;            
+        }
+        export interface ListPolicyVersionsResponse {
+            policyVersions?: PolicyVersions;            
+        }
+        export interface ListPrincipalPoliciesRequest {
+            principal: Principal;            
+            marker?: Marker;            
+            pageSize?: PageSize;            
+            ascendingOrder?: AscendingOrder;            
+        }
+        export interface ListPrincipalPoliciesResponse {
+            policies?: Policies;            
+            nextMarker?: Marker;            
+        }
+        export interface ListPrincipalThingsRequest {
+            nextToken?: NextToken;            
+            maxResults?: MaxResults;            
+            principal: Principal;            
+        }
+        export interface ListPrincipalThingsResponse {
+            things?: ThingNameList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListThingPrincipalsRequest {
+            thingName: ThingName;            
+        }
+        export interface ListThingPrincipalsResponse {
+            principals?: Principals;            
+        }
+        export interface ListThingsRequest {
+            nextToken?: NextToken;            
+            maxResults?: MaxResults;            
+            attributeName?: AttributeName;            
+            attributeValue?: AttributeValue;            
+        }
+        export interface ListThingsResponse {
+            things?: ThingAttributeList;            
+            nextToken?: NextToken;            
+        }
+        export interface ListTopicRulesRequest {
+            topic?: Topic;            
+            maxResults?: MaxResults;            
+            nextToken?: NextToken;            
+            ruleDisabled?: IsDisabled;            
+        }
+        export interface ListTopicRulesResponse {
+            rules?: TopicRuleList;            
+            nextToken?: NextToken;            
+        }
+        export interface LoggingOptionsPayload {
+            roleArn: AwsArn;            
+            logLevel?: LogLevel;            
+        }
+        export interface MalformedPolicyException {
+            message?: errorMessage;            
+        }
+        export interface Policy {
+            policyName?: PolicyName;            
+            policyArn?: PolicyArn;            
+        }
+        export interface PolicyVersion {
+            versionId?: PolicyVersionId;            
+            isDefaultVersion?: IsDefaultVersion;            
+            createDate?: DateType;            
+        }
+        export interface RejectCertificateTransferRequest {
+            certificateId: CertificateId;            
+        }
+        export interface ReplaceTopicRuleRequest {
+            ruleName: RuleName;            
+            topicRulePayload: TopicRulePayload;            
+        }
+        export interface RepublishAction {
+            roleArn: AwsArn;            
+            topic: TopicPattern;            
+        }
+        export interface ResourceAlreadyExistsException {
+            message?: errorMessage;            
+        }
+        export interface ResourceNotFoundException {
+            message?: errorMessage;            
+        }
+        export interface S3Action {
+            roleArn: AwsArn;            
+            bucketName: BucketName;            
+            key: Key;            
+        }
+        export interface ServiceUnavailableException {
+            message?: errorMessage;            
+        }
+        export interface SetDefaultPolicyVersionRequest {
+            policyName: PolicyName;            
+            policyVersionId: PolicyVersionId;            
+        }
+        export interface SetLoggingOptionsRequest {
+            loggingOptionsPayload?: LoggingOptionsPayload;            
+        }
+        export interface SnsAction {
+            targetArn: AwsArn;            
+            roleArn: AwsArn;            
+        }
+        export interface SqlParseException {
+            message?: errorMessage;            
+        }
+        export interface SqsAction {
+            roleArn: AwsArn;            
+            queueUrl: QueueUrl;            
+            useBase64?: UseBase64;            
+        }
+        export interface ThingAttribute {
+            thingName?: ThingName;            
+            attributes?: Attributes;            
+        }
+        export interface ThrottlingException {
+            message?: errorMessage;            
+        }
+        export interface TopicRule {
+            ruleName?: RuleName;            
+            sql?: SQL;            
+            description?: Description;            
+            createdAt?: CreatedAtDate;            
+            actions?: ActionList;            
+            ruleDisabled?: IsDisabled;            
+        }
+        export interface TopicRuleListItem {
+            ruleName?: RuleName;            
+            topicPattern?: TopicPattern;            
+            createdAt?: CreatedAtDate;            
+            ruleDisabled?: IsDisabled;            
+        }
+        export interface TopicRulePayload {
+            sql: SQL;            
+            description?: Description;            
+            actions: ActionList;            
+            ruleDisabled?: IsDisabled;            
+        }
+        export interface TransferAlreadyCompletedException {
+            message?: errorMessage;            
+        }
+        export interface TransferCertificateRequest {
+            certificateId: CertificateId;            
+            targetAwsAccount: AwsAccountId;            
+        }
+        export interface TransferCertificateResponse {
+            transferredCertificateArn?: CertificateArn;            
+        }
+        export interface TransferConflictException {
+            message?: errorMessage;            
+        }
+        export interface UnauthorizedException {
+            message?: errorMessage;            
+        }
+        export interface UpdateCertificateRequest {
+            certificateId: CertificateId;            
+            newStatus: CertificateStatus;            
+        }
+        export interface UpdateThingRequest {
+            thingName: ThingName;            
+            attributePayload: AttributePayload;            
+        }
+        export interface UpdateThingResponse {
+        }
+        export interface VersionsLimitExceededException {
+            message?: errorMessage;            
+        }
 
-    export type IotThingAttributeList = Array<IotThingAttribute>;
-    export type IotThingName = string; // pattern: "[a-zA-Z0-9_-]+"
-    export type IotThingNameList = Array<IotThingName>;
-    export interface IotThrottlingException {
-        message?: IoterrorMessage;
     }
-
-    export type IotTopic = string;
-    export type IotTopicPattern = string;
-    export interface IotTopicRule {
-        ruleName?: IotRuleName;
-        sql?: IotSQL;
-        description?: IotDescription;
-        createdAt?: IotCreatedAtDate;
-        actions?: IotActionList;
-        ruleDisabled?: IotIsDisabled;
-    }
-
-    export type IotTopicRuleList = Array<IotTopicRuleListItem>;
-    export interface IotTopicRuleListItem {
-        ruleName?: IotRuleName;
-        topicPattern?: IotTopicPattern;
-        createdAt?: IotCreatedAtDate;
-        ruleDisabled?: IotIsDisabled;
-    }
-
-    export interface IotTopicRulePayload {
-        sql: IotSQL;
-        description?: IotDescription;
-        actions: IotActionList;
-        ruleDisabled?: IotIsDisabled;
-    }
-
-    export interface IotTransferAlreadyCompletedException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotTransferCertificateRequest {
-        certificateId: IotCertificateId;
-        targetAwsAccount: IotAwsAccountId;
-    }
-
-    export interface IotTransferCertificateResponse {
-        transferredCertificateArn?: IotCertificateArn;
-    }
-
-    export interface IotTransferConflictException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotUnauthorizedException {
-        message?: IoterrorMessage;
-    }
-
-    export interface IotUpdateCertificateRequest {
-        certificateId: IotCertificateId;
-        newStatus: IotCertificateStatus;
-    }
-
-    export interface IotUpdateThingRequest {
-        thingName: IotThingName;
-        attributePayload: IotAttributePayload;
-    }
-
-    export interface IotUpdateThingResponse {
-    }
-
-    export type IotUseBase64 = boolean;
-    export interface IotVersionsLimitExceededException {
-        message?: IoterrorMessage;
-    }
-
-    export type IoterrorMessage = string;
 }

--- a/output/aws-kinesis.d.ts
+++ b/output/aws-kinesis.d.ts
@@ -6,245 +6,213 @@ declare module "aws-sdk" {
 
     export class Kinesis extends Service {
       constructor(options?: any);
-      addTagsToStream(params: KinesisAddTagsToStreamInput, callback?: (err: KinesisResourceNotFoundException|KinesisResourceInUseException|KinesisInvalidArgumentException|KinesisLimitExceededException|any, data: any) => void): Request;
-      createStream(params: KinesisCreateStreamInput, callback?: (err: KinesisResourceInUseException|KinesisLimitExceededException|KinesisInvalidArgumentException|any, data: any) => void): Request;
-      decreaseStreamRetentionPeriod(params: KinesisDecreaseStreamRetentionPeriodInput, callback?: (err: KinesisResourceInUseException|KinesisResourceNotFoundException|KinesisLimitExceededException|KinesisInvalidArgumentException|any, data: any) => void): Request;
-      deleteStream(params: KinesisDeleteStreamInput, callback?: (err: KinesisResourceNotFoundException|KinesisLimitExceededException|any, data: any) => void): Request;
-      describeStream(params: KinesisDescribeStreamInput, callback?: (err: KinesisResourceNotFoundException|KinesisLimitExceededException|any, data: KinesisDescribeStreamOutput|any) => void): Request;
-      getRecords(params: KinesisGetRecordsInput, callback?: (err: KinesisResourceNotFoundException|KinesisInvalidArgumentException|KinesisProvisionedThroughputExceededException|KinesisExpiredIteratorException|any, data: KinesisGetRecordsOutput|any) => void): Request;
-      getShardIterator(params: KinesisGetShardIteratorInput, callback?: (err: KinesisResourceNotFoundException|KinesisInvalidArgumentException|KinesisProvisionedThroughputExceededException|any, data: KinesisGetShardIteratorOutput|any) => void): Request;
-      increaseStreamRetentionPeriod(params: KinesisIncreaseStreamRetentionPeriodInput, callback?: (err: KinesisResourceInUseException|KinesisResourceNotFoundException|KinesisLimitExceededException|KinesisInvalidArgumentException|any, data: any) => void): Request;
-      listStreams(params: KinesisListStreamsInput, callback?: (err: KinesisLimitExceededException|any, data: KinesisListStreamsOutput|any) => void): Request;
-      listTagsForStream(params: KinesisListTagsForStreamInput, callback?: (err: KinesisResourceNotFoundException|KinesisInvalidArgumentException|KinesisLimitExceededException|any, data: KinesisListTagsForStreamOutput|any) => void): Request;
-      mergeShards(params: KinesisMergeShardsInput, callback?: (err: KinesisResourceNotFoundException|KinesisResourceInUseException|KinesisInvalidArgumentException|KinesisLimitExceededException|any, data: any) => void): Request;
-      putRecord(params: KinesisPutRecordInput, callback?: (err: KinesisResourceNotFoundException|KinesisInvalidArgumentException|KinesisProvisionedThroughputExceededException|any, data: KinesisPutRecordOutput|any) => void): Request;
-      putRecords(params: KinesisPutRecordsInput, callback?: (err: KinesisResourceNotFoundException|KinesisInvalidArgumentException|KinesisProvisionedThroughputExceededException|any, data: KinesisPutRecordsOutput|any) => void): Request;
-      removeTagsFromStream(params: KinesisRemoveTagsFromStreamInput, callback?: (err: KinesisResourceNotFoundException|KinesisResourceInUseException|KinesisInvalidArgumentException|KinesisLimitExceededException|any, data: any) => void): Request;
-      splitShard(params: KinesisSplitShardInput, callback?: (err: KinesisResourceNotFoundException|KinesisResourceInUseException|KinesisInvalidArgumentException|KinesisLimitExceededException|any, data: any) => void): Request;
+      addTagsToStream(params: Kinesis.AddTagsToStreamInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.ResourceInUseException|Kinesis.InvalidArgumentException|Kinesis.LimitExceededException|any, data: any) => void): Request;
+      createStream(params: Kinesis.CreateStreamInput, callback?: (err: Kinesis.ResourceInUseException|Kinesis.LimitExceededException|Kinesis.InvalidArgumentException|any, data: any) => void): Request;
+      decreaseStreamRetentionPeriod(params: Kinesis.DecreaseStreamRetentionPeriodInput, callback?: (err: Kinesis.ResourceInUseException|Kinesis.ResourceNotFoundException|Kinesis.LimitExceededException|Kinesis.InvalidArgumentException|any, data: any) => void): Request;
+      deleteStream(params: Kinesis.DeleteStreamInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.LimitExceededException|any, data: any) => void): Request;
+      describeStream(params: Kinesis.DescribeStreamInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.LimitExceededException|any, data: Kinesis.DescribeStreamOutput|any) => void): Request;
+      getRecords(params: Kinesis.GetRecordsInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.InvalidArgumentException|Kinesis.ProvisionedThroughputExceededException|Kinesis.ExpiredIteratorException|any, data: Kinesis.GetRecordsOutput|any) => void): Request;
+      getShardIterator(params: Kinesis.GetShardIteratorInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.InvalidArgumentException|Kinesis.ProvisionedThroughputExceededException|any, data: Kinesis.GetShardIteratorOutput|any) => void): Request;
+      increaseStreamRetentionPeriod(params: Kinesis.IncreaseStreamRetentionPeriodInput, callback?: (err: Kinesis.ResourceInUseException|Kinesis.ResourceNotFoundException|Kinesis.LimitExceededException|Kinesis.InvalidArgumentException|any, data: any) => void): Request;
+      listStreams(params: Kinesis.ListStreamsInput, callback?: (err: Kinesis.LimitExceededException|any, data: Kinesis.ListStreamsOutput|any) => void): Request;
+      listTagsForStream(params: Kinesis.ListTagsForStreamInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.InvalidArgumentException|Kinesis.LimitExceededException|any, data: Kinesis.ListTagsForStreamOutput|any) => void): Request;
+      mergeShards(params: Kinesis.MergeShardsInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.ResourceInUseException|Kinesis.InvalidArgumentException|Kinesis.LimitExceededException|any, data: any) => void): Request;
+      putRecord(params: Kinesis.PutRecordInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.InvalidArgumentException|Kinesis.ProvisionedThroughputExceededException|any, data: Kinesis.PutRecordOutput|any) => void): Request;
+      putRecords(params: Kinesis.PutRecordsInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.InvalidArgumentException|Kinesis.ProvisionedThroughputExceededException|any, data: Kinesis.PutRecordsOutput|any) => void): Request;
+      removeTagsFromStream(params: Kinesis.RemoveTagsFromStreamInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.ResourceInUseException|Kinesis.InvalidArgumentException|Kinesis.LimitExceededException|any, data: any) => void): Request;
+      splitShard(params: Kinesis.SplitShardInput, callback?: (err: Kinesis.ResourceNotFoundException|Kinesis.ResourceInUseException|Kinesis.InvalidArgumentException|Kinesis.LimitExceededException|any, data: any) => void): Request;
     }
+    
+    export module Kinesis {
+        export type ApproximateArrivalTimestamp = number;
+        export type BooleanObject = boolean;
+        export type Data = any;    // max: 1048576, type: blob
+        export type DescribeStreamInputLimit = number;    // max: 10000, min: 1
+        export type ErrorCode = string;
+        export type ErrorMessage = string;
+        export type GetRecordsInputLimit = number;    // max: 10000, min: 1
+        export type HashKey = string;    // pattern: &quot;0|([1-9]\d{0,38})&quot;
+        export type ListStreamsInputLimit = number;    // max: 10000, min: 1
+        export type ListTagsForStreamInputLimit = number;    // max: 10, min: 1
+        export type MillisBehindLatest = number;
+        export type PartitionKey = string;    // max: 256, min: 1
+        export type PositiveIntegerObject = number;    // max: 100000, min: 1
+        export type PutRecordsRequestEntryList = PutRecordsRequestEntry[];    // max: 500, min: 1
+        export type PutRecordsResultEntryList = PutRecordsResultEntry[];    // max: 500, min: 1
+        export type RecordList = Record[];
+        export type RetentionPeriodHours = number;    // max: 168, min: 24
+        export type SequenceNumber = string;    // pattern: &quot;0|([1-9]\d{0,128})&quot;
+        export type ShardId = string;    // pattern: &quot;[a-zA-Z0-9_.-]+&quot;, max: 128, min: 1
+        export type ShardIterator = string;    // max: 512, min: 1
+        export type ShardIteratorType = string;
+        export type ShardList = Shard[];
+        export type StreamARN = string;
+        export type StreamName = string;    // pattern: &quot;[a-zA-Z0-9_.-]+&quot;, max: 128, min: 1
+        export type StreamNameList = StreamName[];
+        export type StreamStatus = string;
+        export type TagKey = string;    // max: 128, min: 1
+        export type TagKeyList = TagKey[];    // max: 10, min: 1
+        export type TagList = Tag[];
+        export type TagMap = {[key:string]: TagValue};    // max: 10, min: 1
+        export type TagValue = string;    // max: 256
 
-    export interface KinesisAddTagsToStreamInput {
-        StreamName: KinesisStreamName;
-        Tags: KinesisTagMap;
+        export interface AddTagsToStreamInput {
+            StreamName: StreamName;            
+            Tags: TagMap;            
+        }
+        export interface CreateStreamInput {
+            StreamName: StreamName;            
+            ShardCount: PositiveIntegerObject;            
+        }
+        export interface DecreaseStreamRetentionPeriodInput {
+            StreamName: StreamName;            
+            RetentionPeriodHours: RetentionPeriodHours;            
+        }
+        export interface DeleteStreamInput {
+            StreamName: StreamName;            
+        }
+        export interface DescribeStreamInput {
+            StreamName: StreamName;            
+            Limit?: DescribeStreamInputLimit;            
+            ExclusiveStartShardId?: ShardId;            
+        }
+        export interface DescribeStreamOutput {
+            StreamDescription: StreamDescription;            
+        }
+        export interface ExpiredIteratorException {
+            message?: ErrorMessage;            
+        }
+        export interface GetRecordsInput {
+            ShardIterator: ShardIterator;            
+            Limit?: GetRecordsInputLimit;            
+        }
+        export interface GetRecordsOutput {
+            Records: RecordList;            
+            NextShardIterator?: ShardIterator;            
+            MillisBehindLatest?: MillisBehindLatest;            
+        }
+        export interface GetShardIteratorInput {
+            StreamName: StreamName;            
+            ShardId: ShardId;            
+            ShardIteratorType: ShardIteratorType;            
+            StartingSequenceNumber?: SequenceNumber;            
+        }
+        export interface GetShardIteratorOutput {
+            ShardIterator?: ShardIterator;            
+        }
+        export interface HashKeyRange {
+            StartingHashKey: HashKey;            
+            EndingHashKey: HashKey;            
+        }
+        export interface IncreaseStreamRetentionPeriodInput {
+            StreamName: StreamName;            
+            RetentionPeriodHours: RetentionPeriodHours;            
+        }
+        export interface InvalidArgumentException {
+            message?: ErrorMessage;            
+        }
+        export interface LimitExceededException {
+            message?: ErrorMessage;            
+        }
+        export interface ListStreamsInput {
+            Limit?: ListStreamsInputLimit;            
+            ExclusiveStartStreamName?: StreamName;            
+        }
+        export interface ListStreamsOutput {
+            StreamNames: StreamNameList;            
+            HasMoreStreams: BooleanObject;            
+        }
+        export interface ListTagsForStreamInput {
+            StreamName: StreamName;            
+            ExclusiveStartTagKey?: TagKey;            
+            Limit?: ListTagsForStreamInputLimit;            
+        }
+        export interface ListTagsForStreamOutput {
+            Tags: TagList;            
+            HasMoreTags: BooleanObject;            
+        }
+        export interface MergeShardsInput {
+            StreamName: StreamName;            
+            ShardToMerge: ShardId;            
+            AdjacentShardToMerge: ShardId;            
+        }
+        export interface ProvisionedThroughputExceededException {
+            message?: ErrorMessage;            
+        }
+        export interface PutRecordInput {
+            StreamName: StreamName;            
+            Data: Data;            
+            PartitionKey: PartitionKey;            
+            ExplicitHashKey?: HashKey;            
+            SequenceNumberForOrdering?: SequenceNumber;            
+        }
+        export interface PutRecordOutput {
+            ShardId: ShardId;            
+            SequenceNumber: SequenceNumber;            
+        }
+        export interface PutRecordsInput {
+            Records: PutRecordsRequestEntryList;            
+            StreamName: StreamName;            
+        }
+        export interface PutRecordsOutput {
+            FailedRecordCount?: PositiveIntegerObject;            
+            Records: PutRecordsResultEntryList;            
+        }
+        export interface PutRecordsRequestEntry {
+            Data: Data;            
+            ExplicitHashKey?: HashKey;            
+            PartitionKey: PartitionKey;            
+        }
+        export interface PutRecordsResultEntry {
+            SequenceNumber?: SequenceNumber;            
+            ShardId?: ShardId;            
+            ErrorCode?: ErrorCode;            
+            ErrorMessage?: ErrorMessage;            
+        }
+        export interface Record {
+            SequenceNumber: SequenceNumber;            
+            ApproximateArrivalTimestamp?: ApproximateArrivalTimestamp;            
+            Data: Data;            
+            PartitionKey: PartitionKey;            
+        }
+        export interface RemoveTagsFromStreamInput {
+            StreamName: StreamName;            
+            TagKeys: TagKeyList;            
+        }
+        export interface ResourceInUseException {
+            message?: ErrorMessage;            
+        }
+        export interface ResourceNotFoundException {
+            message?: ErrorMessage;            
+        }
+        export interface SequenceNumberRange {
+            StartingSequenceNumber: SequenceNumber;            
+            EndingSequenceNumber?: SequenceNumber;            
+        }
+        export interface Shard {
+            ShardId: ShardId;            
+            ParentShardId?: ShardId;            
+            AdjacentParentShardId?: ShardId;            
+            HashKeyRange: HashKeyRange;            
+            SequenceNumberRange: SequenceNumberRange;            
+        }
+        export interface SplitShardInput {
+            StreamName: StreamName;            
+            ShardToSplit: ShardId;            
+            NewStartingHashKey: HashKey;            
+        }
+        export interface StreamDescription {
+            StreamName: StreamName;            
+            StreamARN: StreamARN;            
+            StreamStatus: StreamStatus;            
+            Shards: ShardList;            
+            HasMoreShards: BooleanObject;            
+            RetentionPeriodHours: RetentionPeriodHours;            
+        }
+        export interface Tag {
+            Key: TagKey;            
+            Value?: TagValue;            
+        }
+
     }
-
-    export type KinesisApproximateArrivalTimestamp = number;
-    export type KinesisBooleanObject = boolean;
-    export interface KinesisCreateStreamInput {
-        StreamName: KinesisStreamName;
-        ShardCount: KinesisPositiveIntegerObject;
-    }
-
-    export type KinesisData = any; // not really - it was 'blob' instead - must fix this one
-    export interface KinesisDecreaseStreamRetentionPeriodInput {
-        StreamName: KinesisStreamName;
-        RetentionPeriodHours: KinesisRetentionPeriodHours;
-    }
-
-    export interface KinesisDeleteStreamInput {
-        StreamName: KinesisStreamName;
-    }
-
-    export interface KinesisDescribeStreamInput {
-        StreamName: KinesisStreamName;
-        Limit?: KinesisDescribeStreamInputLimit;
-        ExclusiveStartShardId?: KinesisShardId;
-    }
-
-    export type KinesisDescribeStreamInputLimit = number;
-    export interface KinesisDescribeStreamOutput {
-        StreamDescription: KinesisStreamDescription;
-    }
-
-    export type KinesisErrorCode = string;
-    export type KinesisErrorMessage = string;
-    export interface KinesisExpiredIteratorException {
-        message?: KinesisErrorMessage;
-    }
-
-    export interface KinesisGetRecordsInput {
-        ShardIterator: KinesisShardIterator;
-        Limit?: KinesisGetRecordsInputLimit;
-    }
-
-    export type KinesisGetRecordsInputLimit = number;
-    export interface KinesisGetRecordsOutput {
-        Records: KinesisRecordList;
-        NextShardIterator?: KinesisShardIterator;
-        MillisBehindLatest?: KinesisMillisBehindLatest;
-    }
-
-    export interface KinesisGetShardIteratorInput {
-        StreamName: KinesisStreamName;
-        ShardId: KinesisShardId;
-        ShardIteratorType: KinesisShardIteratorType;
-        StartingSequenceNumber?: KinesisSequenceNumber;
-    }
-
-    export interface KinesisGetShardIteratorOutput {
-        ShardIterator?: KinesisShardIterator;
-    }
-
-    export type KinesisHashKey = string; // pattern: "0|([1-9]\d{0,38})"
-    export interface KinesisHashKeyRange {
-        StartingHashKey: KinesisHashKey;
-        EndingHashKey: KinesisHashKey;
-    }
-
-    export interface KinesisIncreaseStreamRetentionPeriodInput {
-        StreamName: KinesisStreamName;
-        RetentionPeriodHours: KinesisRetentionPeriodHours;
-    }
-
-    export interface KinesisInvalidArgumentException {
-        message?: KinesisErrorMessage;
-    }
-
-    export interface KinesisLimitExceededException {
-        message?: KinesisErrorMessage;
-    }
-
-    export interface KinesisListStreamsInput {
-        Limit?: KinesisListStreamsInputLimit;
-        ExclusiveStartStreamName?: KinesisStreamName;
-    }
-
-    export type KinesisListStreamsInputLimit = number;
-    export interface KinesisListStreamsOutput {
-        StreamNames: KinesisStreamNameList;
-        HasMoreStreams: KinesisBooleanObject;
-    }
-
-    export interface KinesisListTagsForStreamInput {
-        StreamName: KinesisStreamName;
-        ExclusiveStartTagKey?: KinesisTagKey;
-        Limit?: KinesisListTagsForStreamInputLimit;
-    }
-
-    export type KinesisListTagsForStreamInputLimit = number;
-    export interface KinesisListTagsForStreamOutput {
-        Tags: KinesisTagList;
-        HasMoreTags: KinesisBooleanObject;
-    }
-
-    export interface KinesisMergeShardsInput {
-        StreamName: KinesisStreamName;
-        ShardToMerge: KinesisShardId;
-        AdjacentShardToMerge: KinesisShardId;
-    }
-
-    export type KinesisMillisBehindLatest = number;
-    export type KinesisPartitionKey = string;
-    export type KinesisPositiveIntegerObject = number;
-    export interface KinesisProvisionedThroughputExceededException {
-        message?: KinesisErrorMessage;
-    }
-
-    export interface KinesisPutRecordInput {
-        StreamName: KinesisStreamName;
-        Data: KinesisData;
-        PartitionKey: KinesisPartitionKey;
-        ExplicitHashKey?: KinesisHashKey;
-        SequenceNumberForOrdering?: KinesisSequenceNumber;
-    }
-
-    export interface KinesisPutRecordOutput {
-        ShardId: KinesisShardId;
-        SequenceNumber: KinesisSequenceNumber;
-    }
-
-    export interface KinesisPutRecordsInput {
-        Records: KinesisPutRecordsRequestEntryList;
-        StreamName: KinesisStreamName;
-    }
-
-    export interface KinesisPutRecordsOutput {
-        FailedRecordCount?: KinesisPositiveIntegerObject;
-        Records: KinesisPutRecordsResultEntryList;
-    }
-
-    export interface KinesisPutRecordsRequestEntry {
-        Data: KinesisData;
-        ExplicitHashKey?: KinesisHashKey;
-        PartitionKey: KinesisPartitionKey;
-    }
-
-    export type KinesisPutRecordsRequestEntryList = Array<KinesisPutRecordsRequestEntry>; // max: 500
-    export interface KinesisPutRecordsResultEntry {
-        SequenceNumber?: KinesisSequenceNumber;
-        ShardId?: KinesisShardId;
-        ErrorCode?: KinesisErrorCode;
-        ErrorMessage?: KinesisErrorMessage;
-    }
-
-    export type KinesisPutRecordsResultEntryList = Array<KinesisPutRecordsResultEntry>; // max: 500
-    export interface KinesisRecord {
-        SequenceNumber: KinesisSequenceNumber;
-        ApproximateArrivalTimestamp?: KinesisApproximateArrivalTimestamp;
-        Data: KinesisData;
-        PartitionKey: KinesisPartitionKey;
-    }
-
-    export type KinesisRecordList = Array<KinesisRecord>;
-    export interface KinesisRemoveTagsFromStreamInput {
-        StreamName: KinesisStreamName;
-        TagKeys: KinesisTagKeyList;
-    }
-
-    export interface KinesisResourceInUseException {
-        message?: KinesisErrorMessage;
-    }
-
-    export interface KinesisResourceNotFoundException {
-        message?: KinesisErrorMessage;
-    }
-
-    export type KinesisRetentionPeriodHours = number;
-    export type KinesisSequenceNumber = string; // pattern: "0|([1-9]\d{0,128})"
-    export interface KinesisSequenceNumberRange {
-        StartingSequenceNumber: KinesisSequenceNumber;
-        EndingSequenceNumber?: KinesisSequenceNumber;
-    }
-
-    export interface KinesisShard {
-        ShardId: KinesisShardId;
-        ParentShardId?: KinesisShardId;
-        AdjacentParentShardId?: KinesisShardId;
-        HashKeyRange: KinesisHashKeyRange;
-        SequenceNumberRange: KinesisSequenceNumberRange;
-    }
-
-    export type KinesisShardId = string; // pattern: "[a-zA-Z0-9_.-]+"
-    export type KinesisShardIterator = string;
-    export type KinesisShardIteratorType = string;
-    export type KinesisShardList = Array<KinesisShard>;
-    export interface KinesisSplitShardInput {
-        StreamName: KinesisStreamName;
-        ShardToSplit: KinesisShardId;
-        NewStartingHashKey: KinesisHashKey;
-    }
-
-    export type KinesisStreamARN = string;
-    export interface KinesisStreamDescription {
-        StreamName: KinesisStreamName;
-        StreamARN: KinesisStreamARN;
-        StreamStatus: KinesisStreamStatus;
-        Shards: KinesisShardList;
-        HasMoreShards: KinesisBooleanObject;
-        RetentionPeriodHours: KinesisRetentionPeriodHours;
-    }
-
-    export type KinesisStreamName = string; // pattern: "[a-zA-Z0-9_.-]+"
-    export type KinesisStreamNameList = Array<KinesisStreamName>;
-    export type KinesisStreamStatus = string;
-    export interface KinesisTag {
-        Key: KinesisTagKey;
-        Value?: KinesisTagValue;
-    }
-
-    export type KinesisTagKey = string;
-    export type KinesisTagKeyList = Array<KinesisTagKey>; // max: 10
-    export type KinesisTagList = Array<KinesisTag>;
-    export type KinesisTagMap = any; // not really - it was 'map' instead - must fix this one
-    export type KinesisTagValue = string;
 }

--- a/output/aws-kms.d.ts
+++ b/output/aws-kms.d.ts
@@ -6,421 +6,357 @@ declare module "aws-sdk" {
 
     export class KMS extends Service {
       constructor(options?: any);
-      cancelKeyDeletion(params: KMSCancelKeyDeletionRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSCancelKeyDeletionResponse|any) => void): Request;
-      createAlias(params: KMSCreateAliasRequest, callback?: (err: KMSDependencyTimeoutException|KMSAlreadyExistsException|KMSNotFoundException|KMSInvalidAliasNameException|KMSKMSInternalException|KMSLimitExceededException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      createGrant(params: KMSCreateGrantRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSDependencyTimeoutException|KMSInvalidArnException|KMSKMSInternalException|KMSInvalidGrantTokenException|KMSLimitExceededException|KMSKMSInvalidStateException|any, data: KMSCreateGrantResponse|any) => void): Request;
-      createKey(params: KMSCreateKeyRequest, callback?: (err: KMSMalformedPolicyDocumentException|KMSDependencyTimeoutException|KMSInvalidArnException|KMSUnsupportedOperationException|KMSKMSInternalException|KMSLimitExceededException|any, data: KMSCreateKeyResponse|any) => void): Request;
-      decrypt(params: KMSDecryptRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSInvalidCiphertextException|KMSKeyUnavailableException|KMSDependencyTimeoutException|KMSInvalidGrantTokenException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSDecryptResponse|any) => void): Request;
-      deleteAlias(params: KMSDeleteAliasRequest, callback?: (err: KMSDependencyTimeoutException|KMSNotFoundException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      describeKey(params: KMSDescribeKeyRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|any, data: KMSDescribeKeyResponse|any) => void): Request;
-      disableKey(params: KMSDisableKeyRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      disableKeyRotation(params: KMSDisableKeyRotationRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      enableKey(params: KMSEnableKeyRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSLimitExceededException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      enableKeyRotation(params: KMSEnableKeyRotationRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      encrypt(params: KMSEncryptRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSKeyUnavailableException|KMSDependencyTimeoutException|KMSInvalidKeyUsageException|KMSInvalidGrantTokenException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSEncryptResponse|any) => void): Request;
-      generateDataKey(params: KMSGenerateDataKeyRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSKeyUnavailableException|KMSDependencyTimeoutException|KMSInvalidKeyUsageException|KMSInvalidGrantTokenException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSGenerateDataKeyResponse|any) => void): Request;
-      generateDataKeyWithoutPlaintext(params: KMSGenerateDataKeyWithoutPlaintextRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSKeyUnavailableException|KMSDependencyTimeoutException|KMSInvalidKeyUsageException|KMSInvalidGrantTokenException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSGenerateDataKeyWithoutPlaintextResponse|any) => void): Request;
-      generateRandom(params: KMSGenerateRandomRequest, callback?: (err: KMSDependencyTimeoutException|KMSKMSInternalException|any, data: KMSGenerateRandomResponse|any) => void): Request;
-      getKeyPolicy(params: KMSGetKeyPolicyRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSGetKeyPolicyResponse|any) => void): Request;
-      getKeyRotationStatus(params: KMSGetKeyRotationStatusRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSGetKeyRotationStatusResponse|any) => void): Request;
-      listAliases(params: KMSListAliasesRequest, callback?: (err: KMSDependencyTimeoutException|KMSInvalidMarkerException|KMSKMSInternalException|any, data: KMSListAliasesResponse|any) => void): Request;
-      listGrants(params: KMSListGrantsRequest, callback?: (err: KMSNotFoundException|KMSDependencyTimeoutException|KMSInvalidMarkerException|KMSInvalidArnException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSListGrantsResponse|any) => void): Request;
-      listKeyPolicies(params: KMSListKeyPoliciesRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSListKeyPoliciesResponse|any) => void): Request;
-      listKeys(params: KMSListKeysRequest, callback?: (err: KMSDependencyTimeoutException|KMSKMSInternalException|any, data: KMSListKeysResponse|any) => void): Request;
-      listRetirableGrants(params: KMSListRetirableGrantsRequest, callback?: (err: KMSDependencyTimeoutException|KMSInvalidMarkerException|KMSInvalidArnException|KMSNotFoundException|KMSKMSInternalException|any, data: KMSListGrantsResponse|any) => void): Request;
-      putKeyPolicy(params: KMSPutKeyPolicyRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSMalformedPolicyDocumentException|KMSDependencyTimeoutException|KMSInvalidArnException|KMSUnsupportedOperationException|KMSKMSInternalException|KMSLimitExceededException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      reEncrypt(params: KMSReEncryptRequest, callback?: (err: KMSNotFoundException|KMSDisabledException|KMSInvalidCiphertextException|KMSKeyUnavailableException|KMSDependencyTimeoutException|KMSInvalidKeyUsageException|KMSInvalidGrantTokenException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSReEncryptResponse|any) => void): Request;
-      retireGrant(params: KMSRetireGrantRequest, callback?: (err: KMSInvalidGrantTokenException|KMSInvalidGrantIdException|KMSNotFoundException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      revokeGrant(params: KMSRevokeGrantRequest, callback?: (err: KMSNotFoundException|KMSDependencyTimeoutException|KMSInvalidArnException|KMSInvalidGrantIdException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      scheduleKeyDeletion(params: KMSScheduleKeyDeletionRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: KMSScheduleKeyDeletionResponse|any) => void): Request;
-      updateAlias(params: KMSUpdateAliasRequest, callback?: (err: KMSDependencyTimeoutException|KMSNotFoundException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-      updateKeyDescription(params: KMSUpdateKeyDescriptionRequest, callback?: (err: KMSNotFoundException|KMSInvalidArnException|KMSDependencyTimeoutException|KMSKMSInternalException|KMSKMSInvalidStateException|any, data: any) => void): Request;
-    }
-
-    export type KMSAWSAccountIdType = string;
-    export type KMSAliasList = Array<KMSAliasListEntry>;
-    export interface KMSAliasListEntry {
-        AliasName?: KMSAliasNameType;
-        AliasArn?: KMSArnType;
-        TargetKeyId?: KMSKeyIdType;
-    }
-
-    export type KMSAliasNameType = string; // pattern: "^[a-zA-Z0-9:/_-]+$"
-    export interface KMSAlreadyExistsException {
-        message?: KMSErrorMessageType;
-    }
-
-    export type KMSArnType = string;
-    export type KMSBooleanType = boolean;
-    export interface KMSCancelKeyDeletionRequest {
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSCancelKeyDeletionResponse {
-        KeyId?: KMSKeyIdType;
-    }
-
-    export type KMSCiphertextType = any; // not really - it was 'blob' instead - must fix this one
-    export interface KMSCreateAliasRequest {
-        AliasName: KMSAliasNameType;
-        TargetKeyId: KMSKeyIdType;
-    }
-
-    export interface KMSCreateGrantRequest {
-        KeyId: KMSKeyIdType;
-        GranteePrincipal: KMSPrincipalIdType;
-        RetiringPrincipal?: KMSPrincipalIdType;
-        Operations?: KMSGrantOperationList;
-        Constraints?: KMSGrantConstraints;
-        GrantTokens?: KMSGrantTokenList;
-        Name?: KMSGrantNameType;
-    }
-
-    export interface KMSCreateGrantResponse {
-        GrantToken?: KMSGrantTokenType;
-        GrantId?: KMSGrantIdType;
-    }
-
-    export interface KMSCreateKeyRequest {
-        Policy?: KMSPolicyType;
-        Description?: KMSDescriptionType;
-        KeyUsage?: KMSKeyUsageType;
-    }
-
-    export interface KMSCreateKeyResponse {
-        KeyMetadata?: KMSKeyMetadata;
-    }
-
-    export type KMSDataKeySpec = string;
-    export type KMSDateType = number;
-    export interface KMSDecryptRequest {
-        CiphertextBlob: KMSCiphertextType;
-        EncryptionContext?: KMSEncryptionContextType;
-        GrantTokens?: KMSGrantTokenList;
-    }
-
-    export interface KMSDecryptResponse {
-        KeyId?: KMSKeyIdType;
-        Plaintext?: KMSPlaintextType;
-    }
-
-    export interface KMSDeleteAliasRequest {
-        AliasName: KMSAliasNameType;
-    }
-
-    export interface KMSDependencyTimeoutException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSDescribeKeyRequest {
-        KeyId: KMSKeyIdType;
-        GrantTokens?: KMSGrantTokenList;
-    }
-
-    export interface KMSDescribeKeyResponse {
-        KeyMetadata?: KMSKeyMetadata;
-    }
-
-    export type KMSDescriptionType = string;
-    export interface KMSDisableKeyRequest {
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSDisableKeyRotationRequest {
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSDisabledException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSEnableKeyRequest {
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSEnableKeyRotationRequest {
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSEncryptRequest {
-        KeyId: KMSKeyIdType;
-        Plaintext: KMSPlaintextType;
-        EncryptionContext?: KMSEncryptionContextType;
-        GrantTokens?: KMSGrantTokenList;
-    }
-
-    export interface KMSEncryptResponse {
-        CiphertextBlob?: KMSCiphertextType;
-        KeyId?: KMSKeyIdType;
-    }
-
-    export type KMSEncryptionContextKey = string;
-    export type KMSEncryptionContextType = any; // not really - it was 'map' instead - must fix this one
-    export type KMSEncryptionContextValue = string;
-    export type KMSErrorMessageType = string;
-    export interface KMSGenerateDataKeyRequest {
-        KeyId: KMSKeyIdType;
-        EncryptionContext?: KMSEncryptionContextType;
-        NumberOfBytes?: KMSNumberOfBytesType;
-        KeySpec?: KMSDataKeySpec;
-        GrantTokens?: KMSGrantTokenList;
-    }
-
-    export interface KMSGenerateDataKeyResponse {
-        CiphertextBlob?: KMSCiphertextType;
-        Plaintext?: KMSPlaintextType;
-        KeyId?: KMSKeyIdType;
-    }
-
-    export interface KMSGenerateDataKeyWithoutPlaintextRequest {
-        KeyId: KMSKeyIdType;
-        EncryptionContext?: KMSEncryptionContextType;
-        KeySpec?: KMSDataKeySpec;
-        NumberOfBytes?: KMSNumberOfBytesType;
-        GrantTokens?: KMSGrantTokenList;
-    }
-
-    export interface KMSGenerateDataKeyWithoutPlaintextResponse {
-        CiphertextBlob?: KMSCiphertextType;
-        KeyId?: KMSKeyIdType;
-    }
-
-    export interface KMSGenerateRandomRequest {
-        NumberOfBytes?: KMSNumberOfBytesType;
-    }
-
-    export interface KMSGenerateRandomResponse {
-        Plaintext?: KMSPlaintextType;
-    }
-
-    export interface KMSGetKeyPolicyRequest {
-        KeyId: KMSKeyIdType;
-        PolicyName: KMSPolicyNameType;
-    }
-
-    export interface KMSGetKeyPolicyResponse {
-        Policy?: KMSPolicyType;
-    }
-
-    export interface KMSGetKeyRotationStatusRequest {
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSGetKeyRotationStatusResponse {
-        KeyRotationEnabled?: KMSBooleanType;
-    }
-
-    export interface KMSGrantConstraints {
-        EncryptionContextSubset?: KMSEncryptionContextType;
-        EncryptionContextEquals?: KMSEncryptionContextType;
-    }
-
-    export type KMSGrantIdType = string;
-    export type KMSGrantList = Array<KMSGrantListEntry>;
-    export interface KMSGrantListEntry {
-        KeyId?: KMSKeyIdType;
-        GrantId?: KMSGrantIdType;
-        Name?: KMSGrantNameType;
-        CreationDate?: KMSDateType;
-        GranteePrincipal?: KMSPrincipalIdType;
-        RetiringPrincipal?: KMSPrincipalIdType;
-        IssuingAccount?: KMSPrincipalIdType;
-        Operations?: KMSGrantOperationList;
-        Constraints?: KMSGrantConstraints;
-    }
-
-    export type KMSGrantNameType = string; // pattern: "^[a-zA-Z0-9:/_-]+$"
-    export type KMSGrantOperation = string;
-    export type KMSGrantOperationList = Array<KMSGrantOperation>;
-    export type KMSGrantTokenList = Array<KMSGrantTokenType>; // max: 10
-    export type KMSGrantTokenType = string;
-    export interface KMSInvalidAliasNameException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSInvalidArnException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSInvalidCiphertextException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSInvalidGrantIdException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSInvalidGrantTokenException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSInvalidKeyUsageException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSInvalidMarkerException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSKMSInternalException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSKMSInvalidStateException {
-        message?: KMSErrorMessageType;
-    }
-
-    export type KMSKeyIdType = string;
-    export type KMSKeyList = Array<KMSKeyListEntry>;
-    export interface KMSKeyListEntry {
-        KeyId?: KMSKeyIdType;
-        KeyArn?: KMSArnType;
-    }
-
-    export interface KMSKeyMetadata {
-        AWSAccountId?: KMSAWSAccountIdType;
-        KeyId: KMSKeyIdType;
-        Arn?: KMSArnType;
-        CreationDate?: KMSDateType;
-        Enabled?: KMSBooleanType;
-        Description?: KMSDescriptionType;
-        KeyUsage?: KMSKeyUsageType;
-        KeyState?: KMSKeyState;
-        DeletionDate?: KMSDateType;
-    }
-
-    export type KMSKeyState = string;
-    export interface KMSKeyUnavailableException {
-        message?: KMSErrorMessageType;
-    }
-
-    export type KMSKeyUsageType = string;
-    export interface KMSLimitExceededException {
-        message?: KMSErrorMessageType;
-    }
-
-    export type KMSLimitType = number;
-    export interface KMSListAliasesRequest {
-        Limit?: KMSLimitType;
-        Marker?: KMSMarkerType;
-    }
-
-    export interface KMSListAliasesResponse {
-        Aliases?: KMSAliasList;
-        NextMarker?: KMSMarkerType;
-        Truncated?: KMSBooleanType;
-    }
-
-    export interface KMSListGrantsRequest {
-        Limit?: KMSLimitType;
-        Marker?: KMSMarkerType;
-        KeyId: KMSKeyIdType;
-    }
-
-    export interface KMSListGrantsResponse {
-        Grants?: KMSGrantList;
-        NextMarker?: KMSMarkerType;
-        Truncated?: KMSBooleanType;
-    }
-
-    export interface KMSListKeyPoliciesRequest {
-        KeyId: KMSKeyIdType;
-        Limit?: KMSLimitType;
-        Marker?: KMSMarkerType;
-    }
-
-    export interface KMSListKeyPoliciesResponse {
-        PolicyNames?: KMSPolicyNameList;
-        NextMarker?: KMSMarkerType;
-        Truncated?: KMSBooleanType;
-    }
-
-    export interface KMSListKeysRequest {
-        Limit?: KMSLimitType;
-        Marker?: KMSMarkerType;
-    }
-
-    export interface KMSListKeysResponse {
-        Keys?: KMSKeyList;
-        NextMarker?: KMSMarkerType;
-        Truncated?: KMSBooleanType;
-    }
-
-    export interface KMSListRetirableGrantsRequest {
-        Limit?: KMSLimitType;
-        Marker?: KMSMarkerType;
-        RetiringPrincipal: KMSPrincipalIdType;
-    }
-
-    export interface KMSMalformedPolicyDocumentException {
-        message?: KMSErrorMessageType;
-    }
-
-    export type KMSMarkerType = string; // pattern: "[\u0020-\u00FF]*"
-    export interface KMSNotFoundException {
-        message?: KMSErrorMessageType;
-    }
-
-    export type KMSNumberOfBytesType = number;
-    export type KMSPendingWindowInDaysType = number;
-    export type KMSPlaintextType = any; // not really - it was 'blob' instead - must fix this one
-    export type KMSPolicyNameList = Array<KMSPolicyNameType>;
-    export type KMSPolicyNameType = string; // pattern: "[\w]+"
-    export type KMSPolicyType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type KMSPrincipalIdType = string;
-    export interface KMSPutKeyPolicyRequest {
-        KeyId: KMSKeyIdType;
-        PolicyName: KMSPolicyNameType;
-        Policy: KMSPolicyType;
-    }
+      cancelKeyDeletion(params: KMS.CancelKeyDeletionRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.CancelKeyDeletionResponse|any) => void): Request;
+      createAlias(params: KMS.CreateAliasRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.AlreadyExistsException|KMS.NotFoundException|KMS.InvalidAliasNameException|KMS.KMSInternalException|KMS.LimitExceededException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      createGrant(params: KMS.CreateGrantRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.DependencyTimeoutException|KMS.InvalidArnException|KMS.KMSInternalException|KMS.InvalidGrantTokenException|KMS.LimitExceededException|KMS.KMSInvalidStateException|any, data: KMS.CreateGrantResponse|any) => void): Request;
+      createKey(params: KMS.CreateKeyRequest, callback?: (err: KMS.MalformedPolicyDocumentException|KMS.DependencyTimeoutException|KMS.InvalidArnException|KMS.UnsupportedOperationException|KMS.KMSInternalException|KMS.LimitExceededException|any, data: KMS.CreateKeyResponse|any) => void): Request;
+      decrypt(params: KMS.DecryptRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.InvalidCiphertextException|KMS.KeyUnavailableException|KMS.DependencyTimeoutException|KMS.InvalidGrantTokenException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.DecryptResponse|any) => void): Request;
+      deleteAlias(params: KMS.DeleteAliasRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.NotFoundException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      describeKey(params: KMS.DescribeKeyRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|any, data: KMS.DescribeKeyResponse|any) => void): Request;
+      disableKey(params: KMS.DisableKeyRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      disableKeyRotation(params: KMS.DisableKeyRotationRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      enableKey(params: KMS.EnableKeyRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.LimitExceededException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      enableKeyRotation(params: KMS.EnableKeyRotationRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      encrypt(params: KMS.EncryptRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.KeyUnavailableException|KMS.DependencyTimeoutException|KMS.InvalidKeyUsageException|KMS.InvalidGrantTokenException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.EncryptResponse|any) => void): Request;
+      generateDataKey(params: KMS.GenerateDataKeyRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.KeyUnavailableException|KMS.DependencyTimeoutException|KMS.InvalidKeyUsageException|KMS.InvalidGrantTokenException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.GenerateDataKeyResponse|any) => void): Request;
+      generateDataKeyWithoutPlaintext(params: KMS.GenerateDataKeyWithoutPlaintextRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.KeyUnavailableException|KMS.DependencyTimeoutException|KMS.InvalidKeyUsageException|KMS.InvalidGrantTokenException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.GenerateDataKeyWithoutPlaintextResponse|any) => void): Request;
+      generateRandom(params: KMS.GenerateRandomRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.KMSInternalException|any, data: KMS.GenerateRandomResponse|any) => void): Request;
+      getKeyPolicy(params: KMS.GetKeyPolicyRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.GetKeyPolicyResponse|any) => void): Request;
+      getKeyRotationStatus(params: KMS.GetKeyRotationStatusRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.GetKeyRotationStatusResponse|any) => void): Request;
+      listAliases(params: KMS.ListAliasesRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.InvalidMarkerException|KMS.KMSInternalException|any, data: KMS.ListAliasesResponse|any) => void): Request;
+      listGrants(params: KMS.ListGrantsRequest, callback?: (err: KMS.NotFoundException|KMS.DependencyTimeoutException|KMS.InvalidMarkerException|KMS.InvalidArnException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.ListGrantsResponse|any) => void): Request;
+      listKeyPolicies(params: KMS.ListKeyPoliciesRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.ListKeyPoliciesResponse|any) => void): Request;
+      listKeys(params: KMS.ListKeysRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.KMSInternalException|any, data: KMS.ListKeysResponse|any) => void): Request;
+      listRetirableGrants(params: KMS.ListRetirableGrantsRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.InvalidMarkerException|KMS.InvalidArnException|KMS.NotFoundException|KMS.KMSInternalException|any, data: KMS.ListGrantsResponse|any) => void): Request;
+      putKeyPolicy(params: KMS.PutKeyPolicyRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.MalformedPolicyDocumentException|KMS.DependencyTimeoutException|KMS.InvalidArnException|KMS.UnsupportedOperationException|KMS.KMSInternalException|KMS.LimitExceededException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      reEncrypt(params: KMS.ReEncryptRequest, callback?: (err: KMS.NotFoundException|KMS.DisabledException|KMS.InvalidCiphertextException|KMS.KeyUnavailableException|KMS.DependencyTimeoutException|KMS.InvalidKeyUsageException|KMS.InvalidGrantTokenException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.ReEncryptResponse|any) => void): Request;
+      retireGrant(params: KMS.RetireGrantRequest, callback?: (err: KMS.InvalidGrantTokenException|KMS.InvalidGrantIdException|KMS.NotFoundException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      revokeGrant(params: KMS.RevokeGrantRequest, callback?: (err: KMS.NotFoundException|KMS.DependencyTimeoutException|KMS.InvalidArnException|KMS.InvalidGrantIdException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      scheduleKeyDeletion(params: KMS.ScheduleKeyDeletionRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: KMS.ScheduleKeyDeletionResponse|any) => void): Request;
+      updateAlias(params: KMS.UpdateAliasRequest, callback?: (err: KMS.DependencyTimeoutException|KMS.NotFoundException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+      updateKeyDescription(params: KMS.UpdateKeyDescriptionRequest, callback?: (err: KMS.NotFoundException|KMS.InvalidArnException|KMS.DependencyTimeoutException|KMS.KMSInternalException|KMS.KMSInvalidStateException|any, data: any) => void): Request;
+    }
+    
+    export module KMS {
+        export type AWSAccountIdType = string;
+        export type AliasList = AliasListEntry[];
+        export type AliasNameType = string;    // pattern: &quot;^[a-zA-Z0-9:/_-]+$&quot;, max: 256, min: 1
+        export type ArnType = string;    // max: 2048, min: 20
+        export type BooleanType = boolean;
+        export type CiphertextType = any;    // max: 6144, min: 1, type: blob
+        export type DataKeySpec = string;
+        export type DateType = number;
+        export type DescriptionType = string;    // max: 8192
+        export type EncryptionContextKey = string;
+        export type EncryptionContextType = {[key:string]: EncryptionContextValue};
+        export type EncryptionContextValue = string;
+        export type ErrorMessageType = string;
+        export type GrantIdType = string;    // max: 128, min: 1
+        export type GrantList = GrantListEntry[];
+        export type GrantNameType = string;    // pattern: &quot;^[a-zA-Z0-9:/_-]+$&quot;, max: 256, min: 1
+        export type GrantOperation = string;
+        export type GrantOperationList = GrantOperation[];
+        export type GrantTokenList = GrantTokenType[];    // max: 10
+        export type GrantTokenType = string;    // max: 8192, min: 1
+        export type KeyIdType = string;    // max: 256, min: 1
+        export type KeyList = KeyListEntry[];
+        export type KeyState = string;
+        export type KeyUsageType = string;
+        export type LimitType = number;    // max: 1000, min: 1
+        export type MarkerType = string;    // pattern: &quot;[\u0020-\u00FF]*&quot;, max: 320, min: 1
+        export type NumberOfBytesType = number;    // max: 1024, min: 1
+        export type PendingWindowInDaysType = number;    // max: 365, min: 1
+        export type PlaintextType = any;    // max: 4096, min: 1, type: blob
+        export type PolicyNameList = PolicyNameType[];
+        export type PolicyNameType = string;    // pattern: &quot;[\w]+&quot;, max: 128, min: 1
+        export type PolicyType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 131072, min: 1
+        export type PrincipalIdType = string;    // max: 256, min: 1
+
+        export interface AliasListEntry {
+            AliasName?: AliasNameType;            
+            AliasArn?: ArnType;            
+            TargetKeyId?: KeyIdType;            
+        }
+        export interface AlreadyExistsException {
+            message?: ErrorMessageType;            
+        }
+        export interface CancelKeyDeletionRequest {
+            KeyId: KeyIdType;            
+        }
+        export interface CancelKeyDeletionResponse {
+            KeyId?: KeyIdType;            
+        }
+        export interface CreateAliasRequest {
+            AliasName: AliasNameType;            
+            TargetKeyId: KeyIdType;            
+        }
+        export interface CreateGrantRequest {
+            KeyId: KeyIdType;            
+            GranteePrincipal: PrincipalIdType;            
+            RetiringPrincipal?: PrincipalIdType;            
+            Operations?: GrantOperationList;            
+            Constraints?: GrantConstraints;            
+            GrantTokens?: GrantTokenList;            
+            Name?: GrantNameType;            
+        }
+        export interface CreateGrantResponse {
+            GrantToken?: GrantTokenType;            
+            GrantId?: GrantIdType;            
+        }
+        export interface CreateKeyRequest {
+            Policy?: PolicyType;            
+            Description?: DescriptionType;            
+            KeyUsage?: KeyUsageType;            
+        }
+        export interface CreateKeyResponse {
+            KeyMetadata?: KeyMetadata;            
+        }
+        export interface DecryptRequest {
+            CiphertextBlob: CiphertextType;            
+            EncryptionContext?: EncryptionContextType;            
+            GrantTokens?: GrantTokenList;            
+        }
+        export interface DecryptResponse {
+            KeyId?: KeyIdType;            
+            Plaintext?: PlaintextType;            
+        }
+        export interface DeleteAliasRequest {
+            AliasName: AliasNameType;            
+        }
+        export interface DependencyTimeoutException {
+            message?: ErrorMessageType;            
+        }
+        export interface DescribeKeyRequest {
+            KeyId: KeyIdType;            
+            GrantTokens?: GrantTokenList;            
+        }
+        export interface DescribeKeyResponse {
+            KeyMetadata?: KeyMetadata;            
+        }
+        export interface DisableKeyRequest {
+            KeyId: KeyIdType;            
+        }
+        export interface DisableKeyRotationRequest {
+            KeyId: KeyIdType;            
+        }
+        export interface DisabledException {
+            message?: ErrorMessageType;            
+        }
+        export interface EnableKeyRequest {
+            KeyId: KeyIdType;            
+        }
+        export interface EnableKeyRotationRequest {
+            KeyId: KeyIdType;            
+        }
+        export interface EncryptRequest {
+            KeyId: KeyIdType;            
+            Plaintext: PlaintextType;            
+            EncryptionContext?: EncryptionContextType;            
+            GrantTokens?: GrantTokenList;            
+        }
+        export interface EncryptResponse {
+            CiphertextBlob?: CiphertextType;            
+            KeyId?: KeyIdType;            
+        }
+        export interface GenerateDataKeyRequest {
+            KeyId: KeyIdType;            
+            EncryptionContext?: EncryptionContextType;            
+            NumberOfBytes?: NumberOfBytesType;            
+            KeySpec?: DataKeySpec;            
+            GrantTokens?: GrantTokenList;            
+        }
+        export interface GenerateDataKeyResponse {
+            CiphertextBlob?: CiphertextType;            
+            Plaintext?: PlaintextType;            
+            KeyId?: KeyIdType;            
+        }
+        export interface GenerateDataKeyWithoutPlaintextRequest {
+            KeyId: KeyIdType;            
+            EncryptionContext?: EncryptionContextType;            
+            KeySpec?: DataKeySpec;            
+            NumberOfBytes?: NumberOfBytesType;            
+            GrantTokens?: GrantTokenList;            
+        }
+        export interface GenerateDataKeyWithoutPlaintextResponse {
+            CiphertextBlob?: CiphertextType;            
+            KeyId?: KeyIdType;            
+        }
+        export interface GenerateRandomRequest {
+            NumberOfBytes?: NumberOfBytesType;            
+        }
+        export interface GenerateRandomResponse {
+            Plaintext?: PlaintextType;            
+        }
+        export interface GetKeyPolicyRequest {
+            KeyId: KeyIdType;            
+            PolicyName: PolicyNameType;            
+        }
+        export interface GetKeyPolicyResponse {
+            Policy?: PolicyType;            
+        }
+        export interface GetKeyRotationStatusRequest {
+            KeyId: KeyIdType;            
+        }
+        export interface GetKeyRotationStatusResponse {
+            KeyRotationEnabled?: BooleanType;            
+        }
+        export interface GrantConstraints {
+            EncryptionContextSubset?: EncryptionContextType;            
+            EncryptionContextEquals?: EncryptionContextType;            
+        }
+        export interface GrantListEntry {
+            KeyId?: KeyIdType;            
+            GrantId?: GrantIdType;            
+            Name?: GrantNameType;            
+            CreationDate?: DateType;            
+            GranteePrincipal?: PrincipalIdType;            
+            RetiringPrincipal?: PrincipalIdType;            
+            IssuingAccount?: PrincipalIdType;            
+            Operations?: GrantOperationList;            
+            Constraints?: GrantConstraints;            
+        }
+        export interface InvalidAliasNameException {
+            message?: ErrorMessageType;            
+        }
+        export interface InvalidArnException {
+            message?: ErrorMessageType;            
+        }
+        export interface InvalidCiphertextException {
+            message?: ErrorMessageType;            
+        }
+        export interface InvalidGrantIdException {
+            message?: ErrorMessageType;            
+        }
+        export interface InvalidGrantTokenException {
+            message?: ErrorMessageType;            
+        }
+        export interface InvalidKeyUsageException {
+            message?: ErrorMessageType;            
+        }
+        export interface InvalidMarkerException {
+            message?: ErrorMessageType;            
+        }
+        export interface KMSInternalException {
+            message?: ErrorMessageType;            
+        }
+        export interface KMSInvalidStateException {
+            message?: ErrorMessageType;            
+        }
+        export interface KeyListEntry {
+            KeyId?: KeyIdType;            
+            KeyArn?: ArnType;            
+        }
+        export interface KeyMetadata {
+            AWSAccountId?: AWSAccountIdType;            
+            KeyId: KeyIdType;            
+            Arn?: ArnType;            
+            CreationDate?: DateType;            
+            Enabled?: BooleanType;            
+            Description?: DescriptionType;            
+            KeyUsage?: KeyUsageType;            
+            KeyState?: KeyState;            
+            DeletionDate?: DateType;            
+        }
+        export interface KeyUnavailableException {
+            message?: ErrorMessageType;            
+        }
+        export interface LimitExceededException {
+            message?: ErrorMessageType;            
+        }
+        export interface ListAliasesRequest {
+            Limit?: LimitType;            
+            Marker?: MarkerType;            
+        }
+        export interface ListAliasesResponse {
+            Aliases?: AliasList;            
+            NextMarker?: MarkerType;            
+            Truncated?: BooleanType;            
+        }
+        export interface ListGrantsRequest {
+            Limit?: LimitType;            
+            Marker?: MarkerType;            
+            KeyId: KeyIdType;            
+        }
+        export interface ListGrantsResponse {
+            Grants?: GrantList;            
+            NextMarker?: MarkerType;            
+            Truncated?: BooleanType;            
+        }
+        export interface ListKeyPoliciesRequest {
+            KeyId: KeyIdType;            
+            Limit?: LimitType;            
+            Marker?: MarkerType;            
+        }
+        export interface ListKeyPoliciesResponse {
+            PolicyNames?: PolicyNameList;            
+            NextMarker?: MarkerType;            
+            Truncated?: BooleanType;            
+        }
+        export interface ListKeysRequest {
+            Limit?: LimitType;            
+            Marker?: MarkerType;            
+        }
+        export interface ListKeysResponse {
+            Keys?: KeyList;            
+            NextMarker?: MarkerType;            
+            Truncated?: BooleanType;            
+        }
+        export interface ListRetirableGrantsRequest {
+            Limit?: LimitType;            
+            Marker?: MarkerType;            
+            RetiringPrincipal: PrincipalIdType;            
+        }
+        export interface MalformedPolicyDocumentException {
+            message?: ErrorMessageType;            
+        }
+        export interface NotFoundException {
+            message?: ErrorMessageType;            
+        }
+        export interface PutKeyPolicyRequest {
+            KeyId: KeyIdType;            
+            PolicyName: PolicyNameType;            
+            Policy: PolicyType;            
+        }
+        export interface ReEncryptRequest {
+            CiphertextBlob: CiphertextType;            
+            SourceEncryptionContext?: EncryptionContextType;            
+            DestinationKeyId: KeyIdType;            
+            DestinationEncryptionContext?: EncryptionContextType;            
+            GrantTokens?: GrantTokenList;            
+        }
+        export interface ReEncryptResponse {
+            CiphertextBlob?: CiphertextType;            
+            SourceKeyId?: KeyIdType;            
+            KeyId?: KeyIdType;            
+        }
+        export interface RetireGrantRequest {
+            GrantToken?: GrantTokenType;            
+            KeyId?: KeyIdType;            
+            GrantId?: GrantIdType;            
+        }
+        export interface RevokeGrantRequest {
+            KeyId: KeyIdType;            
+            GrantId: GrantIdType;            
+        }
+        export interface ScheduleKeyDeletionRequest {
+            KeyId: KeyIdType;            
+            PendingWindowInDays?: PendingWindowInDaysType;            
+        }
+        export interface ScheduleKeyDeletionResponse {
+            KeyId?: KeyIdType;            
+            DeletionDate?: DateType;            
+        }
+        export interface UnsupportedOperationException {
+            message?: ErrorMessageType;            
+        }
+        export interface UpdateAliasRequest {
+            AliasName: AliasNameType;            
+            TargetKeyId: KeyIdType;            
+        }
+        export interface UpdateKeyDescriptionRequest {
+            KeyId: KeyIdType;            
+            Description: DescriptionType;            
+        }
 
-    export interface KMSReEncryptRequest {
-        CiphertextBlob: KMSCiphertextType;
-        SourceEncryptionContext?: KMSEncryptionContextType;
-        DestinationKeyId: KMSKeyIdType;
-        DestinationEncryptionContext?: KMSEncryptionContextType;
-        GrantTokens?: KMSGrantTokenList;
     }
-
-    export interface KMSReEncryptResponse {
-        CiphertextBlob?: KMSCiphertextType;
-        SourceKeyId?: KMSKeyIdType;
-        KeyId?: KMSKeyIdType;
-    }
-
-    export interface KMSRetireGrantRequest {
-        GrantToken?: KMSGrantTokenType;
-        KeyId?: KMSKeyIdType;
-        GrantId?: KMSGrantIdType;
-    }
-
-    export interface KMSRevokeGrantRequest {
-        KeyId: KMSKeyIdType;
-        GrantId: KMSGrantIdType;
-    }
-
-    export interface KMSScheduleKeyDeletionRequest {
-        KeyId: KMSKeyIdType;
-        PendingWindowInDays?: KMSPendingWindowInDaysType;
-    }
-
-    export interface KMSScheduleKeyDeletionResponse {
-        KeyId?: KMSKeyIdType;
-        DeletionDate?: KMSDateType;
-    }
-
-    export interface KMSUnsupportedOperationException {
-        message?: KMSErrorMessageType;
-    }
-
-    export interface KMSUpdateAliasRequest {
-        AliasName: KMSAliasNameType;
-        TargetKeyId: KMSKeyIdType;
-    }
-
-    export interface KMSUpdateKeyDescriptionRequest {
-        KeyId: KMSKeyIdType;
-        Description: KMSDescriptionType;
-    }
-
 }

--- a/output/aws-lambda.d.ts
+++ b/output/aws-lambda.d.ts
@@ -6,174 +6,156 @@ declare module "aws-sdk" {
 
     export class Lambda extends Service {
       constructor(options?: any);
-      addEventSource(params: LambdaAddEventSourceRequest, callback?: (err: LambdaServiceException|LambdaInvalidParameterValueException|any, data: LambdaEventSourceConfiguration|any) => void): Request;
-      deleteFunction(params: LambdaDeleteFunctionRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|any, data: any) => void): Request;
-      getEventSource(params: LambdaGetEventSourceRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|LambdaInvalidParameterValueException|any, data: LambdaEventSourceConfiguration|any) => void): Request;
-      getFunction(params: LambdaGetFunctionRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|any, data: LambdaGetFunctionResponse|any) => void): Request;
-      getFunctionConfiguration(params: LambdaGetFunctionConfigurationRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|any, data: LambdaFunctionConfiguration|any) => void): Request;
-      invokeAsync(params: LambdaInvokeAsyncRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|LambdaInvalidRequestContentException|any, data: LambdaInvokeAsyncResponse|any) => void): Request;
-      listEventSources(params: LambdaListEventSourcesRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|LambdaInvalidParameterValueException|any, data: LambdaListEventSourcesResponse|any) => void): Request;
-      listFunctions(params: LambdaListFunctionsRequest, callback?: (err: LambdaServiceException|any, data: LambdaListFunctionsResponse|any) => void): Request;
-      removeEventSource(params: LambdaRemoveEventSourceRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|LambdaInvalidParameterValueException|any, data: any) => void): Request;
-      updateFunctionConfiguration(params: LambdaUpdateFunctionConfigurationRequest, callback?: (err: LambdaServiceException|LambdaResourceNotFoundException|LambdaInvalidParameterValueException|any, data: LambdaFunctionConfiguration|any) => void): Request;
-      uploadFunction(params: LambdaUploadFunctionRequest, callback?: (err: LambdaServiceException|LambdaInvalidParameterValueException|LambdaResourceNotFoundException|any, data: LambdaFunctionConfiguration|any) => void): Request;
+      addEventSource(params: Lambda.AddEventSourceRequest, callback?: (err: Lambda.ServiceException|Lambda.InvalidParameterValueException|any, data: Lambda.EventSourceConfiguration|any) => void): Request;
+      deleteFunction(params: Lambda.DeleteFunctionRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|any, data: any) => void): Request;
+      getEventSource(params: Lambda.GetEventSourceRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|Lambda.InvalidParameterValueException|any, data: Lambda.EventSourceConfiguration|any) => void): Request;
+      getFunction(params: Lambda.GetFunctionRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|any, data: Lambda.GetFunctionResponse|any) => void): Request;
+      getFunctionConfiguration(params: Lambda.GetFunctionConfigurationRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|any, data: Lambda.FunctionConfiguration|any) => void): Request;
+      invokeAsync(params: Lambda.InvokeAsyncRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|Lambda.InvalidRequestContentException|any, data: Lambda.InvokeAsyncResponse|any) => void): Request;
+      listEventSources(params: Lambda.ListEventSourcesRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|Lambda.InvalidParameterValueException|any, data: Lambda.ListEventSourcesResponse|any) => void): Request;
+      listFunctions(params: Lambda.ListFunctionsRequest, callback?: (err: Lambda.ServiceException|any, data: Lambda.ListFunctionsResponse|any) => void): Request;
+      removeEventSource(params: Lambda.RemoveEventSourceRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|Lambda.InvalidParameterValueException|any, data: any) => void): Request;
+      updateFunctionConfiguration(params: Lambda.UpdateFunctionConfigurationRequest, callback?: (err: Lambda.ServiceException|Lambda.ResourceNotFoundException|Lambda.InvalidParameterValueException|any, data: Lambda.FunctionConfiguration|any) => void): Request;
+      uploadFunction(params: Lambda.UploadFunctionRequest, callback?: (err: Lambda.ServiceException|Lambda.InvalidParameterValueException|Lambda.ResourceNotFoundException|any, data: Lambda.FunctionConfiguration|any) => void): Request;
     }
+    
+    export module Lambda {
+        export type Blob = any;    // type: blob
+        export type Description = string;    // max: 256
+        export type EventSourceList = EventSourceConfiguration[];
+        export type FunctionArn = string;    // pattern: &quot;arn:aws:lambda:[a-z]{2}-[a-z]+-\d{1}:\d{12}:function:[a-zA-Z0-9-_]+(\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?&quot;
+        export type FunctionList = FunctionConfiguration[];
+        export type FunctionName = string;    // pattern: &quot;[a-zA-Z0-9-_]+&quot;, max: 64, min: 1
+        export type Handler = string;    // pattern: &quot;[a-zA-Z0-9./\-_]+&quot;
+        export type HttpStatus = number;
+        export type Integer = number;
+        export type Long = number;
+        export type Map = {[key:string]: String};
+        export type MaxListItems = number;    // max: 10000, min: 1
+        export type MemorySize = number;    // max: 1024, min: 128
+        export type Mode = string;
+        export type RoleArn = string;    // pattern: &quot;arn:aws:iam::\d{12}:role/?[a-zA-Z_0-9+=,.@\-_/]+&quot;
+        export type Runtime = string;
+        export type String = string;
+        export type Timeout = number;    // max: 60, min: 1
+        export type Timestamp = number;
+        export type Boolean = boolean;
 
-    export interface LambdaAddEventSourceRequest {
-        EventSource: LambdaString;
-        FunctionName: LambdaFunctionName;
-        Role: LambdaRoleArn;
-        BatchSize?: LambdaInteger;
-        Parameters?: LambdaMap;
+        export interface AddEventSourceRequest {
+            EventSource: String;            
+            FunctionName: FunctionName;            
+            Role: RoleArn;            
+            BatchSize?: Integer;            
+            Parameters?: Map;            
+        }
+        export interface DeleteFunctionRequest {
+            FunctionName: FunctionName;            
+        }
+        export interface EventSourceConfiguration {
+            UUID?: String;            
+            BatchSize?: Integer;            
+            EventSource?: String;            
+            FunctionName?: FunctionName;            
+            Parameters?: Map;            
+            Role?: RoleArn;            
+            LastModified?: Timestamp;            
+            IsActive?: Boolean;            
+            Status?: String;            
+        }
+        export interface FunctionCodeLocation {
+            RepositoryType?: String;            
+            Location?: String;            
+        }
+        export interface FunctionConfiguration {
+            FunctionName?: FunctionName;            
+            FunctionARN?: FunctionArn;            
+            ConfigurationId?: String;            
+            Runtime?: Runtime;            
+            Role?: RoleArn;            
+            Handler?: Handler;            
+            Mode?: Mode;            
+            CodeSize?: Long;            
+            Description?: Description;            
+            Timeout?: Timeout;            
+            MemorySize?: MemorySize;            
+            LastModified?: Timestamp;            
+        }
+        export interface GetEventSourceRequest {
+            UUID: String;            
+        }
+        export interface GetFunctionConfigurationRequest {
+            FunctionName: FunctionName;            
+        }
+        export interface GetFunctionRequest {
+            FunctionName: FunctionName;            
+        }
+        export interface GetFunctionResponse {
+            Configuration?: FunctionConfiguration;            
+            Code?: FunctionCodeLocation;            
+        }
+        export interface InvalidParameterValueException {
+            Type?: String;            
+            message?: String;            
+        }
+        export interface InvalidRequestContentException {
+            Type?: String;            
+            message?: String;            
+        }
+        export interface InvokeAsyncRequest {
+            FunctionName: FunctionName;            
+            InvokeArgs: Blob;            
+        }
+        export interface InvokeAsyncResponse {
+            Status?: HttpStatus;            
+        }
+        export interface ListEventSourcesRequest {
+            EventSourceArn?: String;            
+            FunctionName?: FunctionName;            
+            Marker?: String;            
+            MaxItems?: MaxListItems;            
+        }
+        export interface ListEventSourcesResponse {
+            NextMarker?: String;            
+            EventSources?: EventSourceList;            
+        }
+        export interface ListFunctionsRequest {
+            Marker?: String;            
+            MaxItems?: MaxListItems;            
+        }
+        export interface ListFunctionsResponse {
+            NextMarker?: String;            
+            Functions?: FunctionList;            
+        }
+        export interface RemoveEventSourceRequest {
+            UUID: String;            
+        }
+        export interface ResourceNotFoundException {
+            Type?: String;            
+            Message?: String;            
+        }
+        export interface ServiceException {
+            Type?: String;            
+            Message?: String;            
+        }
+        export interface UpdateFunctionConfigurationRequest {
+            FunctionName: FunctionName;            
+            Role?: RoleArn;            
+            Handler?: Handler;            
+            Description?: Description;            
+            Timeout?: Timeout;            
+            MemorySize?: MemorySize;            
+        }
+        export interface UploadFunctionRequest {
+            FunctionName: FunctionName;            
+            FunctionZip: Blob;            
+            Runtime: Runtime;            
+            Role: RoleArn;            
+            Handler: Handler;            
+            Mode: Mode;            
+            Description?: Description;            
+            Timeout?: Timeout;            
+            MemorySize?: MemorySize;            
+        }
+
     }
-
-    export type LambdaBlob = any; // not really - it was 'blob' instead - must fix this one
-    export interface LambdaDeleteFunctionRequest {
-        FunctionName: LambdaFunctionName;
-    }
-
-    export type LambdaDescription = string;
-    export interface LambdaEventSourceConfiguration {
-        UUID?: LambdaString;
-        BatchSize?: LambdaInteger;
-        EventSource?: LambdaString;
-        FunctionName?: LambdaFunctionName;
-        Parameters?: LambdaMap;
-        Role?: LambdaRoleArn;
-        LastModified?: LambdaTimestamp;
-        IsActive?: LambdaBoolean;
-        Status?: LambdaString;
-    }
-
-    export type LambdaEventSourceList = Array<LambdaEventSourceConfiguration>;
-    export type LambdaFunctionArn = string; // pattern: "arn:aws:lambda:[a-z]{2}-[a-z]+-\d{1}:\d{12}:function:[a-zA-Z0-9-_]+(\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?"
-    export interface LambdaFunctionCodeLocation {
-        RepositoryType?: LambdaString;
-        Location?: LambdaString;
-    }
-
-    export interface LambdaFunctionConfiguration {
-        FunctionName?: LambdaFunctionName;
-        FunctionARN?: LambdaFunctionArn;
-        ConfigurationId?: LambdaString;
-        Runtime?: LambdaRuntime;
-        Role?: LambdaRoleArn;
-        Handler?: LambdaHandler;
-        Mode?: LambdaMode;
-        CodeSize?: LambdaLong;
-        Description?: LambdaDescription;
-        Timeout?: LambdaTimeout;
-        MemorySize?: LambdaMemorySize;
-        LastModified?: LambdaTimestamp;
-    }
-
-    export type LambdaFunctionList = Array<LambdaFunctionConfiguration>;
-    export type LambdaFunctionName = string; // pattern: "[a-zA-Z0-9-_]+"
-    export interface LambdaGetEventSourceRequest {
-        UUID: LambdaString;
-    }
-
-    export interface LambdaGetFunctionConfigurationRequest {
-        FunctionName: LambdaFunctionName;
-    }
-
-    export interface LambdaGetFunctionRequest {
-        FunctionName: LambdaFunctionName;
-    }
-
-    export interface LambdaGetFunctionResponse {
-        Configuration?: LambdaFunctionConfiguration;
-        Code?: LambdaFunctionCodeLocation;
-    }
-
-    export type LambdaHandler = string; // pattern: "[a-zA-Z0-9./\-_]+"
-    export type LambdaHttpStatus = number;
-    export type LambdaInteger = number;
-    export interface LambdaInvalidParameterValueException {
-        Type?: LambdaString;
-        message?: LambdaString;
-    }
-
-    export interface LambdaInvalidRequestContentException {
-        Type?: LambdaString;
-        message?: LambdaString;
-    }
-
-    export interface LambdaInvokeAsyncRequest {
-        FunctionName: LambdaFunctionName;
-        InvokeArgs: LambdaBlob;
-    }
-
-    export interface LambdaInvokeAsyncResponse {
-        Status?: LambdaHttpStatus;
-    }
-
-    export interface LambdaListEventSourcesRequest {
-        EventSourceArn?: LambdaString;
-        FunctionName?: LambdaFunctionName;
-        Marker?: LambdaString;
-        MaxItems?: LambdaMaxListItems;
-    }
-
-    export interface LambdaListEventSourcesResponse {
-        NextMarker?: LambdaString;
-        EventSources?: LambdaEventSourceList;
-    }
-
-    export interface LambdaListFunctionsRequest {
-        Marker?: LambdaString;
-        MaxItems?: LambdaMaxListItems;
-    }
-
-    export interface LambdaListFunctionsResponse {
-        NextMarker?: LambdaString;
-        Functions?: LambdaFunctionList;
-    }
-
-    export type LambdaLong = number;
-    export type LambdaMap = any; // not really - it was 'map' instead - must fix this one
-    export type LambdaMaxListItems = number;
-    export type LambdaMemorySize = number;
-    export type LambdaMode = string;
-    export interface LambdaRemoveEventSourceRequest {
-        UUID: LambdaString;
-    }
-
-    export interface LambdaResourceNotFoundException {
-        Type?: LambdaString;
-        Message?: LambdaString;
-    }
-
-    export type LambdaRoleArn = string; // pattern: "arn:aws:iam::\d{12}:role/?[a-zA-Z_0-9+=,.@\-_/]+"
-    export type LambdaRuntime = string;
-    export interface LambdaServiceException {
-        Type?: LambdaString;
-        Message?: LambdaString;
-    }
-
-    export type LambdaString = string;
-    export type LambdaTimeout = number;
-    export type LambdaTimestamp = number;
-    export interface LambdaUpdateFunctionConfigurationRequest {
-        FunctionName: LambdaFunctionName;
-        Role?: LambdaRoleArn;
-        Handler?: LambdaHandler;
-        Description?: LambdaDescription;
-        Timeout?: LambdaTimeout;
-        MemorySize?: LambdaMemorySize;
-    }
-
-    export interface LambdaUploadFunctionRequest {
-        FunctionName: LambdaFunctionName;
-        FunctionZip: LambdaBlob;
-        Runtime: LambdaRuntime;
-        Role: LambdaRoleArn;
-        Handler: LambdaHandler;
-        Mode: LambdaMode;
-        Description?: LambdaDescription;
-        Timeout?: LambdaTimeout;
-        MemorySize?: LambdaMemorySize;
-    }
-
-    export type LambdaBoolean = boolean;
 }

--- a/output/aws-machinelearning.d.ts
+++ b/output/aws-machinelearning.d.ts
@@ -6,609 +6,541 @@ declare module "aws-sdk" {
 
     export class MachineLearning extends Service {
       constructor(options?: any);
-      createBatchPrediction(params: MachineLearningCreateBatchPredictionInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|MachineLearningIdempotentParameterMismatchException|any, data: MachineLearningCreateBatchPredictionOutput|any) => void): Request;
-      createDataSourceFromRDS(params: MachineLearningCreateDataSourceFromRDSInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|MachineLearningIdempotentParameterMismatchException|any, data: MachineLearningCreateDataSourceFromRDSOutput|any) => void): Request;
-      createDataSourceFromRedshift(params: MachineLearningCreateDataSourceFromRedshiftInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|MachineLearningIdempotentParameterMismatchException|any, data: MachineLearningCreateDataSourceFromRedshiftOutput|any) => void): Request;
-      createDataSourceFromS3(params: MachineLearningCreateDataSourceFromS3Input, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|MachineLearningIdempotentParameterMismatchException|any, data: MachineLearningCreateDataSourceFromS3Output|any) => void): Request;
-      createEvaluation(params: MachineLearningCreateEvaluationInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|MachineLearningIdempotentParameterMismatchException|any, data: MachineLearningCreateEvaluationOutput|any) => void): Request;
-      createMLModel(params: MachineLearningCreateMLModelInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|MachineLearningIdempotentParameterMismatchException|any, data: MachineLearningCreateMLModelOutput|any) => void): Request;
-      createRealtimeEndpoint(params: MachineLearningCreateRealtimeEndpointInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningCreateRealtimeEndpointOutput|any) => void): Request;
-      deleteBatchPrediction(params: MachineLearningDeleteBatchPredictionInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningDeleteBatchPredictionOutput|any) => void): Request;
-      deleteDataSource(params: MachineLearningDeleteDataSourceInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningDeleteDataSourceOutput|any) => void): Request;
-      deleteEvaluation(params: MachineLearningDeleteEvaluationInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningDeleteEvaluationOutput|any) => void): Request;
-      deleteMLModel(params: MachineLearningDeleteMLModelInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningDeleteMLModelOutput|any) => void): Request;
-      deleteRealtimeEndpoint(params: MachineLearningDeleteRealtimeEndpointInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningDeleteRealtimeEndpointOutput|any) => void): Request;
-      describeBatchPredictions(params: MachineLearningDescribeBatchPredictionsInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|any, data: MachineLearningDescribeBatchPredictionsOutput|any) => void): Request;
-      describeDataSources(params: MachineLearningDescribeDataSourcesInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|any, data: MachineLearningDescribeDataSourcesOutput|any) => void): Request;
-      describeEvaluations(params: MachineLearningDescribeEvaluationsInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|any, data: MachineLearningDescribeEvaluationsOutput|any) => void): Request;
-      describeMLModels(params: MachineLearningDescribeMLModelsInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningInternalServerException|any, data: MachineLearningDescribeMLModelsOutput|any) => void): Request;
-      getBatchPrediction(params: MachineLearningGetBatchPredictionInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningGetBatchPredictionOutput|any) => void): Request;
-      getDataSource(params: MachineLearningGetDataSourceInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningGetDataSourceOutput|any) => void): Request;
-      getEvaluation(params: MachineLearningGetEvaluationInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningGetEvaluationOutput|any) => void): Request;
-      getMLModel(params: MachineLearningGetMLModelInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningGetMLModelOutput|any) => void): Request;
-      predict(params: MachineLearningPredictInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningLimitExceededException|MachineLearningInternalServerException|MachineLearningPredictorNotMountedException|any, data: MachineLearningPredictOutput|any) => void): Request;
-      updateBatchPrediction(params: MachineLearningUpdateBatchPredictionInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningUpdateBatchPredictionOutput|any) => void): Request;
-      updateDataSource(params: MachineLearningUpdateDataSourceInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningUpdateDataSourceOutput|any) => void): Request;
-      updateEvaluation(params: MachineLearningUpdateEvaluationInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningUpdateEvaluationOutput|any) => void): Request;
-      updateMLModel(params: MachineLearningUpdateMLModelInput, callback?: (err: MachineLearningInvalidInputException|MachineLearningResourceNotFoundException|MachineLearningInternalServerException|any, data: MachineLearningUpdateMLModelOutput|any) => void): Request;
-    }
-
-    export type MachineLearningAlgorithm = string;
-    export type MachineLearningAwsUserArn = string; // pattern: "arn:aws:iam::[0-9]+:((user/.+)|(root))"
-    export interface MachineLearningBatchPrediction {
-        BatchPredictionId?: MachineLearningEntityId;
-        MLModelId?: MachineLearningEntityId;
-        BatchPredictionDataSourceId?: MachineLearningEntityId;
-        InputDataLocationS3?: MachineLearningS3Url;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        Name?: MachineLearningEntityName;
-        Status?: MachineLearningEntityStatus;
-        OutputUri?: MachineLearningS3Url;
-        Message?: MachineLearningMessage;
-    }
-
-    export type MachineLearningBatchPredictionFilterVariable = string;
-    export type MachineLearningBatchPredictions = Array<MachineLearningBatchPrediction>;
-    export type MachineLearningComparatorValue = string; // pattern: ".*\S.*|^$"
-    export type MachineLearningComputeStatistics = boolean;
-    export interface MachineLearningCreateBatchPredictionInput {
-        BatchPredictionId: MachineLearningEntityId;
-        BatchPredictionName?: MachineLearningEntityName;
-        MLModelId: MachineLearningEntityId;
-        BatchPredictionDataSourceId: MachineLearningEntityId;
-        OutputUri: MachineLearningS3Url;
-    }
-
-    export interface MachineLearningCreateBatchPredictionOutput {
-        BatchPredictionId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateDataSourceFromRDSInput {
-        DataSourceId: MachineLearningEntityId;
-        DataSourceName?: MachineLearningEntityName;
-        RDSData: MachineLearningRDSDataSpec;
-        RoleARN: MachineLearningRoleARN;
-        ComputeStatistics?: MachineLearningComputeStatistics;
-    }
-
-    export interface MachineLearningCreateDataSourceFromRDSOutput {
-        DataSourceId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateDataSourceFromRedshiftInput {
-        DataSourceId: MachineLearningEntityId;
-        DataSourceName?: MachineLearningEntityName;
-        DataSpec: MachineLearningRedshiftDataSpec;
-        RoleARN: MachineLearningRoleARN;
-        ComputeStatistics?: MachineLearningComputeStatistics;
-    }
-
-    export interface MachineLearningCreateDataSourceFromRedshiftOutput {
-        DataSourceId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateDataSourceFromS3Input {
-        DataSourceId: MachineLearningEntityId;
-        DataSourceName?: MachineLearningEntityName;
-        DataSpec: MachineLearningS3DataSpec;
-        ComputeStatistics?: MachineLearningComputeStatistics;
-    }
-
-    export interface MachineLearningCreateDataSourceFromS3Output {
-        DataSourceId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateEvaluationInput {
-        EvaluationId: MachineLearningEntityId;
-        EvaluationName?: MachineLearningEntityName;
-        MLModelId: MachineLearningEntityId;
-        EvaluationDataSourceId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateEvaluationOutput {
-        EvaluationId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateMLModelInput {
-        MLModelId: MachineLearningEntityId;
-        MLModelName?: MachineLearningEntityName;
-        MLModelType: MachineLearningMLModelType;
-        Parameters?: MachineLearningTrainingParameters;
-        TrainingDataSourceId: MachineLearningEntityId;
-        Recipe?: MachineLearningRecipe;
-        RecipeUri?: MachineLearningS3Url;
-    }
-
-    export interface MachineLearningCreateMLModelOutput {
-        MLModelId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateRealtimeEndpointInput {
-        MLModelId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningCreateRealtimeEndpointOutput {
-        MLModelId?: MachineLearningEntityId;
-        RealtimeEndpointInfo?: MachineLearningRealtimeEndpointInfo;
-    }
-
-    export type MachineLearningDataRearrangement = string;
-    export type MachineLearningDataSchema = string;
-    export interface MachineLearningDataSource {
-        DataSourceId?: MachineLearningEntityId;
-        DataLocationS3?: MachineLearningS3Url;
-        DataRearrangement?: MachineLearningDataRearrangement;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        DataSizeInBytes?: MachineLearningLongType;
-        NumberOfFiles?: MachineLearningLongType;
-        Name?: MachineLearningEntityName;
-        Status?: MachineLearningEntityStatus;
-        Message?: MachineLearningMessage;
-        RedshiftMetadata?: MachineLearningRedshiftMetadata;
-        RDSMetadata?: MachineLearningRDSMetadata;
-        RoleARN?: MachineLearningRoleARN;
-        ComputeStatistics?: MachineLearningComputeStatistics;
-    }
-
-    export type MachineLearningDataSourceFilterVariable = string;
-    export type MachineLearningDataSources = Array<MachineLearningDataSource>;
-    export interface MachineLearningDeleteBatchPredictionInput {
-        BatchPredictionId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteBatchPredictionOutput {
-        BatchPredictionId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteDataSourceInput {
-        DataSourceId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteDataSourceOutput {
-        DataSourceId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteEvaluationInput {
-        EvaluationId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteEvaluationOutput {
-        EvaluationId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteMLModelInput {
-        MLModelId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteMLModelOutput {
-        MLModelId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteRealtimeEndpointInput {
-        MLModelId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningDeleteRealtimeEndpointOutput {
-        MLModelId?: MachineLearningEntityId;
-        RealtimeEndpointInfo?: MachineLearningRealtimeEndpointInfo;
-    }
-
-    export interface MachineLearningDescribeBatchPredictionsInput {
-        FilterVariable?: MachineLearningBatchPredictionFilterVariable;
-        EQ?: MachineLearningComparatorValue;
-        GT?: MachineLearningComparatorValue;
-        LT?: MachineLearningComparatorValue;
-        GE?: MachineLearningComparatorValue;
-        LE?: MachineLearningComparatorValue;
-        NE?: MachineLearningComparatorValue;
-        Prefix?: MachineLearningComparatorValue;
-        SortOrder?: MachineLearningSortOrder;
-        NextToken?: MachineLearningStringType;
-        Limit?: MachineLearningPageLimit;
-    }
-
-    export interface MachineLearningDescribeBatchPredictionsOutput {
-        Results?: MachineLearningBatchPredictions;
-        NextToken?: MachineLearningStringType;
-    }
-
-    export interface MachineLearningDescribeDataSourcesInput {
-        FilterVariable?: MachineLearningDataSourceFilterVariable;
-        EQ?: MachineLearningComparatorValue;
-        GT?: MachineLearningComparatorValue;
-        LT?: MachineLearningComparatorValue;
-        GE?: MachineLearningComparatorValue;
-        LE?: MachineLearningComparatorValue;
-        NE?: MachineLearningComparatorValue;
-        Prefix?: MachineLearningComparatorValue;
-        SortOrder?: MachineLearningSortOrder;
-        NextToken?: MachineLearningStringType;
-        Limit?: MachineLearningPageLimit;
-    }
-
-    export interface MachineLearningDescribeDataSourcesOutput {
-        Results?: MachineLearningDataSources;
-        NextToken?: MachineLearningStringType;
-    }
-
-    export interface MachineLearningDescribeEvaluationsInput {
-        FilterVariable?: MachineLearningEvaluationFilterVariable;
-        EQ?: MachineLearningComparatorValue;
-        GT?: MachineLearningComparatorValue;
-        LT?: MachineLearningComparatorValue;
-        GE?: MachineLearningComparatorValue;
-        LE?: MachineLearningComparatorValue;
-        NE?: MachineLearningComparatorValue;
-        Prefix?: MachineLearningComparatorValue;
-        SortOrder?: MachineLearningSortOrder;
-        NextToken?: MachineLearningStringType;
-        Limit?: MachineLearningPageLimit;
-    }
-
-    export interface MachineLearningDescribeEvaluationsOutput {
-        Results?: MachineLearningEvaluations;
-        NextToken?: MachineLearningStringType;
-    }
-
-    export interface MachineLearningDescribeMLModelsInput {
-        FilterVariable?: MachineLearningMLModelFilterVariable;
-        EQ?: MachineLearningComparatorValue;
-        GT?: MachineLearningComparatorValue;
-        LT?: MachineLearningComparatorValue;
-        GE?: MachineLearningComparatorValue;
-        LE?: MachineLearningComparatorValue;
-        NE?: MachineLearningComparatorValue;
-        Prefix?: MachineLearningComparatorValue;
-        SortOrder?: MachineLearningSortOrder;
-        NextToken?: MachineLearningStringType;
-        Limit?: MachineLearningPageLimit;
-    }
-
-    export interface MachineLearningDescribeMLModelsOutput {
-        Results?: MachineLearningMLModels;
-        NextToken?: MachineLearningStringType;
-    }
-
-    export type MachineLearningDetailsAttributes = string;
-    export type MachineLearningDetailsMap = any; // not really - it was 'map' instead - must fix this one
-    export type MachineLearningDetailsValue = string;
-    export type MachineLearningEDPPipelineId = string;
-    export type MachineLearningEDPResourceRole = string;
-    export type MachineLearningEDPSecurityGroupId = string;
-    export type MachineLearningEDPSecurityGroupIds = Array<MachineLearningEDPSecurityGroupId>;
-    export type MachineLearningEDPServiceRole = string;
-    export type MachineLearningEDPSubnetId = string;
-    export type MachineLearningEntityId = string; // pattern: "[a-zA-Z0-9_.-]+"
-    export type MachineLearningEntityName = string; // pattern: ".*\S.*|^$"
-    export type MachineLearningEntityStatus = string;
-    export type MachineLearningEpochTime = number;
-    export type MachineLearningErrorCode = number;
-    export type MachineLearningErrorMessage = string;
-    export interface MachineLearningEvaluation {
-        EvaluationId?: MachineLearningEntityId;
-        MLModelId?: MachineLearningEntityId;
-        EvaluationDataSourceId?: MachineLearningEntityId;
-        InputDataLocationS3?: MachineLearningS3Url;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        Name?: MachineLearningEntityName;
-        Status?: MachineLearningEntityStatus;
-        PerformanceMetrics?: MachineLearningPerformanceMetrics;
-        Message?: MachineLearningMessage;
-    }
-
-    export type MachineLearningEvaluationFilterVariable = string;
-    export type MachineLearningEvaluations = Array<MachineLearningEvaluation>;
-    export interface MachineLearningGetBatchPredictionInput {
-        BatchPredictionId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningGetBatchPredictionOutput {
-        BatchPredictionId?: MachineLearningEntityId;
-        MLModelId?: MachineLearningEntityId;
-        BatchPredictionDataSourceId?: MachineLearningEntityId;
-        InputDataLocationS3?: MachineLearningS3Url;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        Name?: MachineLearningEntityName;
-        Status?: MachineLearningEntityStatus;
-        OutputUri?: MachineLearningS3Url;
-        LogUri?: MachineLearningPresignedS3Url;
-        Message?: MachineLearningMessage;
-    }
-
-    export interface MachineLearningGetDataSourceInput {
-        DataSourceId: MachineLearningEntityId;
-        Verbose?: MachineLearningVerbose;
-    }
-
-    export interface MachineLearningGetDataSourceOutput {
-        DataSourceId?: MachineLearningEntityId;
-        DataLocationS3?: MachineLearningS3Url;
-        DataRearrangement?: MachineLearningDataRearrangement;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        DataSizeInBytes?: MachineLearningLongType;
-        NumberOfFiles?: MachineLearningLongType;
-        Name?: MachineLearningEntityName;
-        Status?: MachineLearningEntityStatus;
-        LogUri?: MachineLearningPresignedS3Url;
-        Message?: MachineLearningMessage;
-        RedshiftMetadata?: MachineLearningRedshiftMetadata;
-        RDSMetadata?: MachineLearningRDSMetadata;
-        RoleARN?: MachineLearningRoleARN;
-        ComputeStatistics?: MachineLearningComputeStatistics;
-        DataSourceSchema?: MachineLearningDataSchema;
-    }
-
-    export interface MachineLearningGetEvaluationInput {
-        EvaluationId: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningGetEvaluationOutput {
-        EvaluationId?: MachineLearningEntityId;
-        MLModelId?: MachineLearningEntityId;
-        EvaluationDataSourceId?: MachineLearningEntityId;
-        InputDataLocationS3?: MachineLearningS3Url;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        Name?: MachineLearningEntityName;
-        Status?: MachineLearningEntityStatus;
-        PerformanceMetrics?: MachineLearningPerformanceMetrics;
-        LogUri?: MachineLearningPresignedS3Url;
-        Message?: MachineLearningMessage;
-    }
-
-    export interface MachineLearningGetMLModelInput {
-        MLModelId: MachineLearningEntityId;
-        Verbose?: MachineLearningVerbose;
-    }
-
-    export interface MachineLearningGetMLModelOutput {
-        MLModelId?: MachineLearningEntityId;
-        TrainingDataSourceId?: MachineLearningEntityId;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        Name?: MachineLearningMLModelName;
-        Status?: MachineLearningEntityStatus;
-        SizeInBytes?: MachineLearningLongType;
-        EndpointInfo?: MachineLearningRealtimeEndpointInfo;
-        TrainingParameters?: MachineLearningTrainingParameters;
-        InputDataLocationS3?: MachineLearningS3Url;
-        MLModelType?: MachineLearningMLModelType;
-        ScoreThreshold?: MachineLearningScoreThreshold;
-        ScoreThresholdLastUpdatedAt?: MachineLearningEpochTime;
-        LogUri?: MachineLearningPresignedS3Url;
-        Message?: MachineLearningMessage;
-        Recipe?: MachineLearningRecipe;
-        Schema?: MachineLearningDataSchema;
-    }
-
-    export interface MachineLearningIdempotentParameterMismatchException {
-        message?: MachineLearningErrorMessage;
-        code?: MachineLearningErrorCode;
-    }
-
-    export type MachineLearningIntegerType = number;
-    export interface MachineLearningInternalServerException {
-        message?: MachineLearningErrorMessage;
-        code?: MachineLearningErrorCode;
-    }
-
-    export interface MachineLearningInvalidInputException {
-        message?: MachineLearningErrorMessage;
-        code?: MachineLearningErrorCode;
-    }
-
-    export type MachineLearningLabel = string;
-    export interface MachineLearningLimitExceededException {
-        message?: MachineLearningErrorMessage;
-        code?: MachineLearningErrorCode;
-    }
-
-    export type MachineLearningLongType = number;
-    export interface MachineLearningMLModel {
-        MLModelId?: MachineLearningEntityId;
-        TrainingDataSourceId?: MachineLearningEntityId;
-        CreatedByIamUser?: MachineLearningAwsUserArn;
-        CreatedAt?: MachineLearningEpochTime;
-        LastUpdatedAt?: MachineLearningEpochTime;
-        Name?: MachineLearningMLModelName;
-        Status?: MachineLearningEntityStatus;
-        SizeInBytes?: MachineLearningLongType;
-        EndpointInfo?: MachineLearningRealtimeEndpointInfo;
-        TrainingParameters?: MachineLearningTrainingParameters;
-        InputDataLocationS3?: MachineLearningS3Url;
-        Algorithm?: MachineLearningAlgorithm;
-        MLModelType?: MachineLearningMLModelType;
-        ScoreThreshold?: MachineLearningScoreThreshold;
-        ScoreThresholdLastUpdatedAt?: MachineLearningEpochTime;
-        Message?: MachineLearningMessage;
-    }
-
-    export type MachineLearningMLModelFilterVariable = string;
-    export type MachineLearningMLModelName = string;
-    export type MachineLearningMLModelType = string;
-    export type MachineLearningMLModels = Array<MachineLearningMLModel>;
-    export type MachineLearningMessage = string;
-    export type MachineLearningPageLimit = number;
-    export interface MachineLearningPerformanceMetrics {
-        Properties?: MachineLearningPerformanceMetricsProperties;
-    }
-
-    export type MachineLearningPerformanceMetricsProperties = any; // not really - it was 'map' instead - must fix this one
-    export type MachineLearningPerformanceMetricsPropertyKey = string;
-    export type MachineLearningPerformanceMetricsPropertyValue = string;
-    export interface MachineLearningPredictInput {
-        MLModelId: MachineLearningEntityId;
-        Record: MachineLearningRecord;
-        PredictEndpoint: MachineLearningVipURL;
-    }
-
-    export interface MachineLearningPredictOutput {
-        Prediction?: MachineLearningPrediction;
-    }
-
-    export interface MachineLearningPrediction {
-        predictedLabel?: MachineLearningLabel;
-        predictedValue?: MachineLearningfloatLabel;
-        predictedScores?: MachineLearningScoreValuePerLabelMap;
-        details?: MachineLearningDetailsMap;
-    }
-
-    export interface MachineLearningPredictorNotMountedException {
-        message?: MachineLearningErrorMessage;
-    }
-
-    export type MachineLearningPresignedS3Url = string;
-    export interface MachineLearningRDSDataSpec {
-        DatabaseInformation: MachineLearningRDSDatabase;
-        SelectSqlQuery: MachineLearningRDSSelectSqlQuery;
-        DatabaseCredentials: MachineLearningRDSDatabaseCredentials;
-        S3StagingLocation: MachineLearningS3Url;
-        DataRearrangement?: MachineLearningDataRearrangement;
-        DataSchema?: MachineLearningDataSchema;
-        DataSchemaUri?: MachineLearningS3Url;
-        ResourceRole: MachineLearningEDPResourceRole;
-        ServiceRole: MachineLearningEDPServiceRole;
-        SubnetId: MachineLearningEDPSubnetId;
-        SecurityGroupIds: MachineLearningEDPSecurityGroupIds;
-    }
-
-    export interface MachineLearningRDSDatabase {
-        InstanceIdentifier: MachineLearningRDSInstanceIdentifier;
-        DatabaseName: MachineLearningRDSDatabaseName;
-    }
-
-    export interface MachineLearningRDSDatabaseCredentials {
-        Username: MachineLearningRDSDatabaseUsername;
-        Password: MachineLearningRDSDatabasePassword;
-    }
-
-    export type MachineLearningRDSDatabaseName = string;
-    export type MachineLearningRDSDatabasePassword = string;
-    export type MachineLearningRDSDatabaseUsername = string;
-    export type MachineLearningRDSInstanceIdentifier = string; // pattern: "[a-z0-9-]+"
-    export interface MachineLearningRDSMetadata {
-        Database?: MachineLearningRDSDatabase;
-        DatabaseUserName?: MachineLearningRDSDatabaseUsername;
-        SelectSqlQuery?: MachineLearningRDSSelectSqlQuery;
-        ResourceRole?: MachineLearningEDPResourceRole;
-        ServiceRole?: MachineLearningEDPServiceRole;
-        DataPipelineId?: MachineLearningEDPPipelineId;
-    }
-
-    export type MachineLearningRDSSelectSqlQuery = string;
-    export interface MachineLearningRealtimeEndpointInfo {
-        PeakRequestsPerSecond?: MachineLearningIntegerType;
-        CreatedAt?: MachineLearningEpochTime;
-        EndpointUrl?: MachineLearningVipURL;
-        EndpointStatus?: MachineLearningRealtimeEndpointStatus;
-    }
-
-    export type MachineLearningRealtimeEndpointStatus = string;
-    export type MachineLearningRecipe = string;
-    export type MachineLearningRecord = any; // not really - it was 'map' instead - must fix this one
-    export type MachineLearningRedshiftClusterIdentifier = string; // pattern: "[a-z0-9-]+"
-    export interface MachineLearningRedshiftDataSpec {
-        DatabaseInformation: MachineLearningRedshiftDatabase;
-        SelectSqlQuery: MachineLearningRedshiftSelectSqlQuery;
-        DatabaseCredentials: MachineLearningRedshiftDatabaseCredentials;
-        S3StagingLocation: MachineLearningS3Url;
-        DataRearrangement?: MachineLearningDataRearrangement;
-        DataSchema?: MachineLearningDataSchema;
-        DataSchemaUri?: MachineLearningS3Url;
-    }
-
-    export interface MachineLearningRedshiftDatabase {
-        DatabaseName: MachineLearningRedshiftDatabaseName;
-        ClusterIdentifier: MachineLearningRedshiftClusterIdentifier;
-    }
-
-    export interface MachineLearningRedshiftDatabaseCredentials {
-        Username: MachineLearningRedshiftDatabaseUsername;
-        Password: MachineLearningRedshiftDatabasePassword;
-    }
-
-    export type MachineLearningRedshiftDatabaseName = string; // pattern: "[a-z0-9]+"
-    export type MachineLearningRedshiftDatabasePassword = string;
-    export type MachineLearningRedshiftDatabaseUsername = string;
-    export interface MachineLearningRedshiftMetadata {
-        RedshiftDatabase?: MachineLearningRedshiftDatabase;
-        DatabaseUserName?: MachineLearningRedshiftDatabaseUsername;
-        SelectSqlQuery?: MachineLearningRedshiftSelectSqlQuery;
-    }
-
-    export type MachineLearningRedshiftSelectSqlQuery = string;
-    export interface MachineLearningResourceNotFoundException {
-        message?: MachineLearningErrorMessage;
-        code?: MachineLearningErrorCode;
-    }
-
-    export type MachineLearningRoleARN = string;
-    export interface MachineLearningS3DataSpec {
-        DataLocationS3: MachineLearningS3Url;
-        DataRearrangement?: MachineLearningDataRearrangement;
-        DataSchema?: MachineLearningDataSchema;
-        DataSchemaLocationS3?: MachineLearningS3Url;
-    }
-
-    export type MachineLearningS3Url = string; // pattern: "s3://([^/]+)(/.*)?"
-    export type MachineLearningScoreThreshold = number;
-    export type MachineLearningScoreValue = number;
-    export type MachineLearningScoreValuePerLabelMap = any; // not really - it was 'map' instead - must fix this one
-    export type MachineLearningSortOrder = string;
-    export type MachineLearningStringType = string;
-    export type MachineLearningTrainingParameters = any; // not really - it was 'map' instead - must fix this one
-    export interface MachineLearningUpdateBatchPredictionInput {
-        BatchPredictionId: MachineLearningEntityId;
-        BatchPredictionName: MachineLearningEntityName;
-    }
-
-    export interface MachineLearningUpdateBatchPredictionOutput {
-        BatchPredictionId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningUpdateDataSourceInput {
-        DataSourceId: MachineLearningEntityId;
-        DataSourceName: MachineLearningEntityName;
-    }
+      createBatchPrediction(params: MachineLearning.CreateBatchPredictionInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|MachineLearning.IdempotentParameterMismatchException|any, data: MachineLearning.CreateBatchPredictionOutput|any) => void): Request;
+      createDataSourceFromRDS(params: MachineLearning.CreateDataSourceFromRDSInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|MachineLearning.IdempotentParameterMismatchException|any, data: MachineLearning.CreateDataSourceFromRDSOutput|any) => void): Request;
+      createDataSourceFromRedshift(params: MachineLearning.CreateDataSourceFromRedshiftInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|MachineLearning.IdempotentParameterMismatchException|any, data: MachineLearning.CreateDataSourceFromRedshiftOutput|any) => void): Request;
+      createDataSourceFromS3(params: MachineLearning.CreateDataSourceFromS3Input, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|MachineLearning.IdempotentParameterMismatchException|any, data: MachineLearning.CreateDataSourceFromS3Output|any) => void): Request;
+      createEvaluation(params: MachineLearning.CreateEvaluationInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|MachineLearning.IdempotentParameterMismatchException|any, data: MachineLearning.CreateEvaluationOutput|any) => void): Request;
+      createMLModel(params: MachineLearning.CreateMLModelInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|MachineLearning.IdempotentParameterMismatchException|any, data: MachineLearning.CreateMLModelOutput|any) => void): Request;
+      createRealtimeEndpoint(params: MachineLearning.CreateRealtimeEndpointInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.CreateRealtimeEndpointOutput|any) => void): Request;
+      deleteBatchPrediction(params: MachineLearning.DeleteBatchPredictionInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.DeleteBatchPredictionOutput|any) => void): Request;
+      deleteDataSource(params: MachineLearning.DeleteDataSourceInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.DeleteDataSourceOutput|any) => void): Request;
+      deleteEvaluation(params: MachineLearning.DeleteEvaluationInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.DeleteEvaluationOutput|any) => void): Request;
+      deleteMLModel(params: MachineLearning.DeleteMLModelInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.DeleteMLModelOutput|any) => void): Request;
+      deleteRealtimeEndpoint(params: MachineLearning.DeleteRealtimeEndpointInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.DeleteRealtimeEndpointOutput|any) => void): Request;
+      describeBatchPredictions(params: MachineLearning.DescribeBatchPredictionsInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|any, data: MachineLearning.DescribeBatchPredictionsOutput|any) => void): Request;
+      describeDataSources(params: MachineLearning.DescribeDataSourcesInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|any, data: MachineLearning.DescribeDataSourcesOutput|any) => void): Request;
+      describeEvaluations(params: MachineLearning.DescribeEvaluationsInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|any, data: MachineLearning.DescribeEvaluationsOutput|any) => void): Request;
+      describeMLModels(params: MachineLearning.DescribeMLModelsInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.InternalServerException|any, data: MachineLearning.DescribeMLModelsOutput|any) => void): Request;
+      getBatchPrediction(params: MachineLearning.GetBatchPredictionInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.GetBatchPredictionOutput|any) => void): Request;
+      getDataSource(params: MachineLearning.GetDataSourceInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.GetDataSourceOutput|any) => void): Request;
+      getEvaluation(params: MachineLearning.GetEvaluationInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.GetEvaluationOutput|any) => void): Request;
+      getMLModel(params: MachineLearning.GetMLModelInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.GetMLModelOutput|any) => void): Request;
+      predict(params: MachineLearning.PredictInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.LimitExceededException|MachineLearning.InternalServerException|MachineLearning.PredictorNotMountedException|any, data: MachineLearning.PredictOutput|any) => void): Request;
+      updateBatchPrediction(params: MachineLearning.UpdateBatchPredictionInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.UpdateBatchPredictionOutput|any) => void): Request;
+      updateDataSource(params: MachineLearning.UpdateDataSourceInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.UpdateDataSourceOutput|any) => void): Request;
+      updateEvaluation(params: MachineLearning.UpdateEvaluationInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.UpdateEvaluationOutput|any) => void): Request;
+      updateMLModel(params: MachineLearning.UpdateMLModelInput, callback?: (err: MachineLearning.InvalidInputException|MachineLearning.ResourceNotFoundException|MachineLearning.InternalServerException|any, data: MachineLearning.UpdateMLModelOutput|any) => void): Request;
+    }
+    
+    export module MachineLearning {
+        export type Algorithm = string;
+        export type AwsUserArn = string;    // pattern: &quot;arn:aws:iam::[0-9]+:((user/.+)|(root))&quot;
+        export type BatchPredictionFilterVariable = string;
+        export type BatchPredictions = BatchPrediction[];
+        export type ComparatorValue = string;    // pattern: &quot;.*\S.*|^$&quot;, max: 1024
+        export type ComputeStatistics = boolean;
+        export type DataRearrangement = string;
+        export type DataSchema = string;    // max: 131071
+        export type DataSourceFilterVariable = string;
+        export type DataSources = DataSource[];
+        export type DetailsAttributes = string;
+        export type DetailsMap = {[key:string]: DetailsValue};
+        export type DetailsValue = string;    // min: 1
+        export type EDPPipelineId = string;    // max: 1024, min: 1
+        export type EDPResourceRole = string;    // max: 64, min: 1
+        export type EDPSecurityGroupId = string;    // max: 255, min: 1
+        export type EDPSecurityGroupIds = EDPSecurityGroupId[];
+        export type EDPServiceRole = string;    // max: 64, min: 1
+        export type EDPSubnetId = string;    // max: 255, min: 1
+        export type EntityId = string;    // pattern: &quot;[a-zA-Z0-9_.-]+&quot;, max: 64, min: 1
+        export type EntityName = string;    // pattern: &quot;.*\S.*|^$&quot;, max: 1024
+        export type EntityStatus = string;
+        export type EpochTime = number;
+        export type ErrorCode = number;
+        export type ErrorMessage = string;    // max: 2048
+        export type EvaluationFilterVariable = string;
+        export type Evaluations = Evaluation[];
+        export type IntegerType = number;
+        export type Label = string;    // min: 1
+        export type LongType = number;
+        export type MLModelFilterVariable = string;
+        export type MLModelName = string;    // max: 1024
+        export type MLModelType = string;
+        export type MLModels = MLModel[];
+        export type Message = string;    // max: 10240
+        export type PageLimit = number;    // max: 100, min: 1
+        export type PerformanceMetricsProperties = {[key:string]: PerformanceMetricsPropertyValue};
+        export type PerformanceMetricsPropertyKey = string;
+        export type PerformanceMetricsPropertyValue = string;
+        export type PresignedS3Url = string;
+        export type RDSDatabaseName = string;    // max: 64, min: 1
+        export type RDSDatabasePassword = string;    // max: 128, min: 8
+        export type RDSDatabaseUsername = string;    // max: 128, min: 1
+        export type RDSInstanceIdentifier = string;    // pattern: &quot;[a-z0-9-]+&quot;, max: 63, min: 1
+        export type RDSSelectSqlQuery = string;    // max: 16777216, min: 1
+        export type RealtimeEndpointStatus = string;
+        export type Recipe = string;    // max: 131071
+        export type Record = {[key:string]: VariableValue};
+        export type RedshiftClusterIdentifier = string;    // pattern: &quot;[a-z0-9-]+&quot;, max: 63, min: 1
+        export type RedshiftDatabaseName = string;    // pattern: &quot;[a-z0-9]+&quot;, max: 64, min: 1
+        export type RedshiftDatabasePassword = string;    // max: 64, min: 8
+        export type RedshiftDatabaseUsername = string;    // max: 128, min: 1
+        export type RedshiftSelectSqlQuery = string;    // max: 16777216, min: 1
+        export type RoleARN = string;    // max: 100, min: 1
+        export type S3Url = string;    // pattern: &quot;s3://([^/]+)(/.*)?&quot;, max: 2048
+        export type ScoreThreshold = number;
+        export type ScoreValue = number;
+        export type ScoreValuePerLabelMap = {[key:string]: ScoreValue};
+        export type SortOrder = string;
+        export type StringType = string;
+        export type TrainingParameters = {[key:string]: StringType};
+        export type VariableName = string;
+        export type VariableValue = string;
+        export type Verbose = boolean;
+        export type VipURL = string;    // pattern: &quot;https://[a-zA-Z0-9-.]*\.amazon(aws)?\.com[/]?&quot;, max: 2048
+        export type floatLabel = number;
+
+        export interface BatchPrediction {
+            BatchPredictionId?: EntityId;            
+            MLModelId?: EntityId;            
+            BatchPredictionDataSourceId?: EntityId;            
+            InputDataLocationS3?: S3Url;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            Name?: EntityName;            
+            Status?: EntityStatus;            
+            OutputUri?: S3Url;            
+            Message?: Message;            
+        }
+        export interface CreateBatchPredictionInput {
+            BatchPredictionId: EntityId;            
+            BatchPredictionName?: EntityName;            
+            MLModelId: EntityId;            
+            BatchPredictionDataSourceId: EntityId;            
+            OutputUri: S3Url;            
+        }
+        export interface CreateBatchPredictionOutput {
+            BatchPredictionId?: EntityId;            
+        }
+        export interface CreateDataSourceFromRDSInput {
+            DataSourceId: EntityId;            
+            DataSourceName?: EntityName;            
+            RDSData: RDSDataSpec;            
+            RoleARN: RoleARN;            
+            ComputeStatistics?: ComputeStatistics;            
+        }
+        export interface CreateDataSourceFromRDSOutput {
+            DataSourceId?: EntityId;            
+        }
+        export interface CreateDataSourceFromRedshiftInput {
+            DataSourceId: EntityId;            
+            DataSourceName?: EntityName;            
+            DataSpec: RedshiftDataSpec;            
+            RoleARN: RoleARN;            
+            ComputeStatistics?: ComputeStatistics;            
+        }
+        export interface CreateDataSourceFromRedshiftOutput {
+            DataSourceId?: EntityId;            
+        }
+        export interface CreateDataSourceFromS3Input {
+            DataSourceId: EntityId;            
+            DataSourceName?: EntityName;            
+            DataSpec: S3DataSpec;            
+            ComputeStatistics?: ComputeStatistics;            
+        }
+        export interface CreateDataSourceFromS3Output {
+            DataSourceId?: EntityId;            
+        }
+        export interface CreateEvaluationInput {
+            EvaluationId: EntityId;            
+            EvaluationName?: EntityName;            
+            MLModelId: EntityId;            
+            EvaluationDataSourceId: EntityId;            
+        }
+        export interface CreateEvaluationOutput {
+            EvaluationId?: EntityId;            
+        }
+        export interface CreateMLModelInput {
+            MLModelId: EntityId;            
+            MLModelName?: EntityName;            
+            MLModelType: MLModelType;            
+            Parameters?: TrainingParameters;            
+            TrainingDataSourceId: EntityId;            
+            Recipe?: Recipe;            
+            RecipeUri?: S3Url;            
+        }
+        export interface CreateMLModelOutput {
+            MLModelId?: EntityId;            
+        }
+        export interface CreateRealtimeEndpointInput {
+            MLModelId: EntityId;            
+        }
+        export interface CreateRealtimeEndpointOutput {
+            MLModelId?: EntityId;            
+            RealtimeEndpointInfo?: RealtimeEndpointInfo;            
+        }
+        export interface DataSource {
+            DataSourceId?: EntityId;            
+            DataLocationS3?: S3Url;            
+            DataRearrangement?: DataRearrangement;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            DataSizeInBytes?: LongType;            
+            NumberOfFiles?: LongType;            
+            Name?: EntityName;            
+            Status?: EntityStatus;            
+            Message?: Message;            
+            RedshiftMetadata?: RedshiftMetadata;            
+            RDSMetadata?: RDSMetadata;            
+            RoleARN?: RoleARN;            
+            ComputeStatistics?: ComputeStatistics;            
+        }
+        export interface DeleteBatchPredictionInput {
+            BatchPredictionId: EntityId;            
+        }
+        export interface DeleteBatchPredictionOutput {
+            BatchPredictionId?: EntityId;            
+        }
+        export interface DeleteDataSourceInput {
+            DataSourceId: EntityId;            
+        }
+        export interface DeleteDataSourceOutput {
+            DataSourceId?: EntityId;            
+        }
+        export interface DeleteEvaluationInput {
+            EvaluationId: EntityId;            
+        }
+        export interface DeleteEvaluationOutput {
+            EvaluationId?: EntityId;            
+        }
+        export interface DeleteMLModelInput {
+            MLModelId: EntityId;            
+        }
+        export interface DeleteMLModelOutput {
+            MLModelId?: EntityId;            
+        }
+        export interface DeleteRealtimeEndpointInput {
+            MLModelId: EntityId;            
+        }
+        export interface DeleteRealtimeEndpointOutput {
+            MLModelId?: EntityId;            
+            RealtimeEndpointInfo?: RealtimeEndpointInfo;            
+        }
+        export interface DescribeBatchPredictionsInput {
+            FilterVariable?: BatchPredictionFilterVariable;            
+            EQ?: ComparatorValue;            
+            GT?: ComparatorValue;            
+            LT?: ComparatorValue;            
+            GE?: ComparatorValue;            
+            LE?: ComparatorValue;            
+            NE?: ComparatorValue;            
+            Prefix?: ComparatorValue;            
+            SortOrder?: SortOrder;            
+            NextToken?: StringType;            
+            Limit?: PageLimit;            
+        }
+        export interface DescribeBatchPredictionsOutput {
+            Results?: BatchPredictions;            
+            NextToken?: StringType;            
+        }
+        export interface DescribeDataSourcesInput {
+            FilterVariable?: DataSourceFilterVariable;            
+            EQ?: ComparatorValue;            
+            GT?: ComparatorValue;            
+            LT?: ComparatorValue;            
+            GE?: ComparatorValue;            
+            LE?: ComparatorValue;            
+            NE?: ComparatorValue;            
+            Prefix?: ComparatorValue;            
+            SortOrder?: SortOrder;            
+            NextToken?: StringType;            
+            Limit?: PageLimit;            
+        }
+        export interface DescribeDataSourcesOutput {
+            Results?: DataSources;            
+            NextToken?: StringType;            
+        }
+        export interface DescribeEvaluationsInput {
+            FilterVariable?: EvaluationFilterVariable;            
+            EQ?: ComparatorValue;            
+            GT?: ComparatorValue;            
+            LT?: ComparatorValue;            
+            GE?: ComparatorValue;            
+            LE?: ComparatorValue;            
+            NE?: ComparatorValue;            
+            Prefix?: ComparatorValue;            
+            SortOrder?: SortOrder;            
+            NextToken?: StringType;            
+            Limit?: PageLimit;            
+        }
+        export interface DescribeEvaluationsOutput {
+            Results?: Evaluations;            
+            NextToken?: StringType;            
+        }
+        export interface DescribeMLModelsInput {
+            FilterVariable?: MLModelFilterVariable;            
+            EQ?: ComparatorValue;            
+            GT?: ComparatorValue;            
+            LT?: ComparatorValue;            
+            GE?: ComparatorValue;            
+            LE?: ComparatorValue;            
+            NE?: ComparatorValue;            
+            Prefix?: ComparatorValue;            
+            SortOrder?: SortOrder;            
+            NextToken?: StringType;            
+            Limit?: PageLimit;            
+        }
+        export interface DescribeMLModelsOutput {
+            Results?: MLModels;            
+            NextToken?: StringType;            
+        }
+        export interface Evaluation {
+            EvaluationId?: EntityId;            
+            MLModelId?: EntityId;            
+            EvaluationDataSourceId?: EntityId;            
+            InputDataLocationS3?: S3Url;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            Name?: EntityName;            
+            Status?: EntityStatus;            
+            PerformanceMetrics?: PerformanceMetrics;            
+            Message?: Message;            
+        }
+        export interface GetBatchPredictionInput {
+            BatchPredictionId: EntityId;            
+        }
+        export interface GetBatchPredictionOutput {
+            BatchPredictionId?: EntityId;            
+            MLModelId?: EntityId;            
+            BatchPredictionDataSourceId?: EntityId;            
+            InputDataLocationS3?: S3Url;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            Name?: EntityName;            
+            Status?: EntityStatus;            
+            OutputUri?: S3Url;            
+            LogUri?: PresignedS3Url;            
+            Message?: Message;            
+        }
+        export interface GetDataSourceInput {
+            DataSourceId: EntityId;            
+            Verbose?: Verbose;            
+        }
+        export interface GetDataSourceOutput {
+            DataSourceId?: EntityId;            
+            DataLocationS3?: S3Url;            
+            DataRearrangement?: DataRearrangement;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            DataSizeInBytes?: LongType;            
+            NumberOfFiles?: LongType;            
+            Name?: EntityName;            
+            Status?: EntityStatus;            
+            LogUri?: PresignedS3Url;            
+            Message?: Message;            
+            RedshiftMetadata?: RedshiftMetadata;            
+            RDSMetadata?: RDSMetadata;            
+            RoleARN?: RoleARN;            
+            ComputeStatistics?: ComputeStatistics;            
+            DataSourceSchema?: DataSchema;            
+        }
+        export interface GetEvaluationInput {
+            EvaluationId: EntityId;            
+        }
+        export interface GetEvaluationOutput {
+            EvaluationId?: EntityId;            
+            MLModelId?: EntityId;            
+            EvaluationDataSourceId?: EntityId;            
+            InputDataLocationS3?: S3Url;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            Name?: EntityName;            
+            Status?: EntityStatus;            
+            PerformanceMetrics?: PerformanceMetrics;            
+            LogUri?: PresignedS3Url;            
+            Message?: Message;            
+        }
+        export interface GetMLModelInput {
+            MLModelId: EntityId;            
+            Verbose?: Verbose;            
+        }
+        export interface GetMLModelOutput {
+            MLModelId?: EntityId;            
+            TrainingDataSourceId?: EntityId;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            Name?: MLModelName;            
+            Status?: EntityStatus;            
+            SizeInBytes?: LongType;            
+            EndpointInfo?: RealtimeEndpointInfo;            
+            TrainingParameters?: TrainingParameters;            
+            InputDataLocationS3?: S3Url;            
+            MLModelType?: MLModelType;            
+            ScoreThreshold?: ScoreThreshold;            
+            ScoreThresholdLastUpdatedAt?: EpochTime;            
+            LogUri?: PresignedS3Url;            
+            Message?: Message;            
+            Recipe?: Recipe;            
+            Schema?: DataSchema;            
+        }
+        export interface IdempotentParameterMismatchException {
+            message?: ErrorMessage;            
+            code?: ErrorCode;            
+        }
+        export interface InternalServerException {
+            message?: ErrorMessage;            
+            code?: ErrorCode;            
+        }
+        export interface InvalidInputException {
+            message?: ErrorMessage;            
+            code?: ErrorCode;            
+        }
+        export interface LimitExceededException {
+            message?: ErrorMessage;            
+            code?: ErrorCode;            
+        }
+        export interface MLModel {
+            MLModelId?: EntityId;            
+            TrainingDataSourceId?: EntityId;            
+            CreatedByIamUser?: AwsUserArn;            
+            CreatedAt?: EpochTime;            
+            LastUpdatedAt?: EpochTime;            
+            Name?: MLModelName;            
+            Status?: EntityStatus;            
+            SizeInBytes?: LongType;            
+            EndpointInfo?: RealtimeEndpointInfo;            
+            TrainingParameters?: TrainingParameters;            
+            InputDataLocationS3?: S3Url;            
+            Algorithm?: Algorithm;            
+            MLModelType?: MLModelType;            
+            ScoreThreshold?: ScoreThreshold;            
+            ScoreThresholdLastUpdatedAt?: EpochTime;            
+            Message?: Message;            
+        }
+        export interface PerformanceMetrics {
+            Properties?: PerformanceMetricsProperties;            
+        }
+        export interface PredictInput {
+            MLModelId: EntityId;            
+            Record: Record;            
+            PredictEndpoint: VipURL;            
+        }
+        export interface PredictOutput {
+            Prediction?: Prediction;            
+        }
+        export interface Prediction {
+            predictedLabel?: Label;            
+            predictedValue?: floatLabel;            
+            predictedScores?: ScoreValuePerLabelMap;            
+            details?: DetailsMap;            
+        }
+        export interface PredictorNotMountedException {
+            message?: ErrorMessage;            
+        }
+        export interface RDSDataSpec {
+            DatabaseInformation: RDSDatabase;            
+            SelectSqlQuery: RDSSelectSqlQuery;            
+            DatabaseCredentials: RDSDatabaseCredentials;            
+            S3StagingLocation: S3Url;            
+            DataRearrangement?: DataRearrangement;            
+            DataSchema?: DataSchema;            
+            DataSchemaUri?: S3Url;            
+            ResourceRole: EDPResourceRole;            
+            ServiceRole: EDPServiceRole;            
+            SubnetId: EDPSubnetId;            
+            SecurityGroupIds: EDPSecurityGroupIds;            
+        }
+        export interface RDSDatabase {
+            InstanceIdentifier: RDSInstanceIdentifier;            
+            DatabaseName: RDSDatabaseName;            
+        }
+        export interface RDSDatabaseCredentials {
+            Username: RDSDatabaseUsername;            
+            Password: RDSDatabasePassword;            
+        }
+        export interface RDSMetadata {
+            Database?: RDSDatabase;            
+            DatabaseUserName?: RDSDatabaseUsername;            
+            SelectSqlQuery?: RDSSelectSqlQuery;            
+            ResourceRole?: EDPResourceRole;            
+            ServiceRole?: EDPServiceRole;            
+            DataPipelineId?: EDPPipelineId;            
+        }
+        export interface RealtimeEndpointInfo {
+            PeakRequestsPerSecond?: IntegerType;            
+            CreatedAt?: EpochTime;            
+            EndpointUrl?: VipURL;            
+            EndpointStatus?: RealtimeEndpointStatus;            
+        }
+        export interface RedshiftDataSpec {
+            DatabaseInformation: RedshiftDatabase;            
+            SelectSqlQuery: RedshiftSelectSqlQuery;            
+            DatabaseCredentials: RedshiftDatabaseCredentials;            
+            S3StagingLocation: S3Url;            
+            DataRearrangement?: DataRearrangement;            
+            DataSchema?: DataSchema;            
+            DataSchemaUri?: S3Url;            
+        }
+        export interface RedshiftDatabase {
+            DatabaseName: RedshiftDatabaseName;            
+            ClusterIdentifier: RedshiftClusterIdentifier;            
+        }
+        export interface RedshiftDatabaseCredentials {
+            Username: RedshiftDatabaseUsername;            
+            Password: RedshiftDatabasePassword;            
+        }
+        export interface RedshiftMetadata {
+            RedshiftDatabase?: RedshiftDatabase;            
+            DatabaseUserName?: RedshiftDatabaseUsername;            
+            SelectSqlQuery?: RedshiftSelectSqlQuery;            
+        }
+        export interface ResourceNotFoundException {
+            message?: ErrorMessage;            
+            code?: ErrorCode;            
+        }
+        export interface S3DataSpec {
+            DataLocationS3: S3Url;            
+            DataRearrangement?: DataRearrangement;            
+            DataSchema?: DataSchema;            
+            DataSchemaLocationS3?: S3Url;            
+        }
+        export interface UpdateBatchPredictionInput {
+            BatchPredictionId: EntityId;            
+            BatchPredictionName: EntityName;            
+        }
+        export interface UpdateBatchPredictionOutput {
+            BatchPredictionId?: EntityId;            
+        }
+        export interface UpdateDataSourceInput {
+            DataSourceId: EntityId;            
+            DataSourceName: EntityName;            
+        }
+        export interface UpdateDataSourceOutput {
+            DataSourceId?: EntityId;            
+        }
+        export interface UpdateEvaluationInput {
+            EvaluationId: EntityId;            
+            EvaluationName: EntityName;            
+        }
+        export interface UpdateEvaluationOutput {
+            EvaluationId?: EntityId;            
+        }
+        export interface UpdateMLModelInput {
+            MLModelId: EntityId;            
+            MLModelName?: EntityName;            
+            ScoreThreshold?: ScoreThreshold;            
+        }
+        export interface UpdateMLModelOutput {
+            MLModelId?: EntityId;            
+        }
 
-    export interface MachineLearningUpdateDataSourceOutput {
-        DataSourceId?: MachineLearningEntityId;
     }
-
-    export interface MachineLearningUpdateEvaluationInput {
-        EvaluationId: MachineLearningEntityId;
-        EvaluationName: MachineLearningEntityName;
-    }
-
-    export interface MachineLearningUpdateEvaluationOutput {
-        EvaluationId?: MachineLearningEntityId;
-    }
-
-    export interface MachineLearningUpdateMLModelInput {
-        MLModelId: MachineLearningEntityId;
-        MLModelName?: MachineLearningEntityName;
-        ScoreThreshold?: MachineLearningScoreThreshold;
-    }
-
-    export interface MachineLearningUpdateMLModelOutput {
-        MLModelId?: MachineLearningEntityId;
-    }
-
-    export type MachineLearningVariableName = string;
-    export type MachineLearningVariableValue = string;
-    export type MachineLearningVerbose = boolean;
-    export type MachineLearningVipURL = string; // pattern: "https://[a-zA-Z0-9-.]*\.amazon(aws)?\.com[/]?"
-    export type MachineLearningfloatLabel = number;
 }

--- a/output/aws-marketplacecommerceanalytics.d.ts
+++ b/output/aws-marketplacecommerceanalytics.d.ts
@@ -6,32 +6,33 @@ declare module "aws-sdk" {
 
     export class MarketplaceCommerceAnalytics extends Service {
       constructor(options?: any);
-      generateDataSet(params: MarketplaceCommerceAnalyticsGenerateDataSetRequest, callback?: (err: MarketplaceCommerceAnalyticsMarketplaceCommerceAnalyticsException|any, data: MarketplaceCommerceAnalyticsGenerateDataSetResult|any) => void): Request;
+      generateDataSet(params: MarketplaceCommerceAnalytics.GenerateDataSetRequest, callback?: (err: MarketplaceCommerceAnalytics.MarketplaceCommerceAnalyticsException|any, data: MarketplaceCommerceAnalytics.GenerateDataSetResult|any) => void): Request;
     }
+    
+    export module MarketplaceCommerceAnalytics {
+        export type DataSetPublicationDate = number;
+        export type DataSetRequestId = string;
+        export type DataSetType = string;    // max: 255, min: 1
+        export type DestinationS3BucketName = string;    // min: 1
+        export type DestinationS3Prefix = string;
+        export type ExceptionMessage = string;
+        export type RoleNameArn = string;    // min: 1
+        export type SnsTopicArn = string;    // min: 1
 
-    export type MarketplaceCommerceAnalyticsDataSetPublicationDate = number;
-    export type MarketplaceCommerceAnalyticsDataSetRequestId = string;
-    export type MarketplaceCommerceAnalyticsDataSetType = string;
-    export type MarketplaceCommerceAnalyticsDestinationS3BucketName = string;
-    export type MarketplaceCommerceAnalyticsDestinationS3Prefix = string;
-    export type MarketplaceCommerceAnalyticsExceptionMessage = string;
-    export interface MarketplaceCommerceAnalyticsGenerateDataSetRequest {
-        dataSetType: MarketplaceCommerceAnalyticsDataSetType;
-        dataSetPublicationDate: MarketplaceCommerceAnalyticsDataSetPublicationDate;
-        roleNameArn: MarketplaceCommerceAnalyticsRoleNameArn;
-        destinationS3BucketName: MarketplaceCommerceAnalyticsDestinationS3BucketName;
-        destinationS3Prefix?: MarketplaceCommerceAnalyticsDestinationS3Prefix;
-        snsTopicArn: MarketplaceCommerceAnalyticsSnsTopicArn;
+        export interface GenerateDataSetRequest {
+            dataSetType: DataSetType;            
+            dataSetPublicationDate: DataSetPublicationDate;            
+            roleNameArn: RoleNameArn;            
+            destinationS3BucketName: DestinationS3BucketName;            
+            destinationS3Prefix?: DestinationS3Prefix;            
+            snsTopicArn: SnsTopicArn;            
+        }
+        export interface GenerateDataSetResult {
+            dataSetRequestId?: DataSetRequestId;            
+        }
+        export interface MarketplaceCommerceAnalyticsException {
+            message?: ExceptionMessage;            
+        }
+
     }
-
-    export interface MarketplaceCommerceAnalyticsGenerateDataSetResult {
-        dataSetRequestId?: MarketplaceCommerceAnalyticsDataSetRequestId;
-    }
-
-    export interface MarketplaceCommerceAnalyticsMarketplaceCommerceAnalyticsException {
-        message?: MarketplaceCommerceAnalyticsExceptionMessage;
-    }
-
-    export type MarketplaceCommerceAnalyticsRoleNameArn = string;
-    export type MarketplaceCommerceAnalyticsSnsTopicArn = string;
 }

--- a/output/aws-mobileanalytics.d.ts
+++ b/output/aws-mobileanalytics.d.ts
@@ -6,43 +6,43 @@ declare module "aws-sdk" {
 
     export class MobileAnalytics extends Service {
       constructor(options?: any);
-      putEvents(params: MobileAnalyticsPutEventsInput, callback?: (err: MobileAnalyticsBadRequestException|any, data: any) => void): Request;
+      putEvents(params: MobileAnalytics.PutEventsInput, callback?: (err: MobileAnalytics.BadRequestException|any, data: any) => void): Request;
     }
+    
+    export module MobileAnalytics {
+        export type Double = number;
+        export type EventListDefinition = Event[];
+        export type ISO8601Timestamp = string;
+        export type Long = number;
+        export type MapOfStringToNumber = {[key:string]: Double};    // max: 50
+        export type MapOfStringToString = {[key:string]: String0to1000Chars};    // max: 50
+        export type String = string;
+        export type String0to1000Chars = string;    // max: 1000
+        export type String10Chars = string;    // max: 10, min: 1
+        export type String50Chars = string;    // max: 50, min: 1
 
-    export interface MobileAnalyticsBadRequestException {
-        message?: MobileAnalyticsString;
+        export interface BadRequestException {
+            message?: String;            
+        }
+        export interface Event {
+            eventType: String50Chars;            
+            timestamp: ISO8601Timestamp;            
+            session?: Session;            
+            version?: String10Chars;            
+            attributes?: MapOfStringToString;            
+            metrics?: MapOfStringToNumber;            
+        }
+        export interface PutEventsInput {
+            events: EventListDefinition;            
+            clientContext: String;            
+            clientContextEncoding?: String;            
+        }
+        export interface Session {
+            id?: String50Chars;            
+            duration?: Long;            
+            startTimestamp?: ISO8601Timestamp;            
+            stopTimestamp?: ISO8601Timestamp;            
+        }
+
     }
-
-    export type MobileAnalyticsDouble = number;
-    export interface MobileAnalyticsEvent {
-        eventType: MobileAnalyticsString50Chars;
-        timestamp: MobileAnalyticsISO8601Timestamp;
-        session?: MobileAnalyticsSession;
-        version?: MobileAnalyticsString10Chars;
-        attributes?: MobileAnalyticsMapOfStringToString;
-        metrics?: MobileAnalyticsMapOfStringToNumber;
-    }
-
-    export type MobileAnalyticsEventListDefinition = Array<MobileAnalyticsEvent>;
-    export type MobileAnalyticsISO8601Timestamp = string;
-    export type MobileAnalyticsLong = number;
-    export type MobileAnalyticsMapOfStringToNumber = any; // not really - it was 'map' instead - must fix this one
-    export type MobileAnalyticsMapOfStringToString = any; // not really - it was 'map' instead - must fix this one
-    export interface MobileAnalyticsPutEventsInput {
-        events: MobileAnalyticsEventListDefinition;
-        clientContext: MobileAnalyticsString;
-        clientContextEncoding?: MobileAnalyticsString;
-    }
-
-    export interface MobileAnalyticsSession {
-        id?: MobileAnalyticsString50Chars;
-        duration?: MobileAnalyticsLong;
-        startTimestamp?: MobileAnalyticsISO8601Timestamp;
-        stopTimestamp?: MobileAnalyticsISO8601Timestamp;
-    }
-
-    export type MobileAnalyticsString = string;
-    export type MobileAnalyticsString0to1000Chars = string;
-    export type MobileAnalyticsString10Chars = string;
-    export type MobileAnalyticsString50Chars = string;
 }

--- a/output/aws-opsworks.d.ts
+++ b/output/aws-opsworks.d.ts
@@ -6,1160 +6,1020 @@ declare module "aws-sdk" {
 
     export class OpsWorks extends Service {
       constructor(options?: any);
-      assignInstance(params: OpsWorksAssignInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      assignVolume(params: OpsWorksAssignVolumeRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      associateElasticIp(params: OpsWorksAssociateElasticIpRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      attachElasticLoadBalancer(params: OpsWorksAttachElasticLoadBalancerRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      cloneStack(params: OpsWorksCloneStackRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksCloneStackResult|any) => void): Request;
-      createApp(params: OpsWorksCreateAppRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksCreateAppResult|any) => void): Request;
-      createDeployment(params: OpsWorksCreateDeploymentRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksCreateDeploymentResult|any) => void): Request;
-      createInstance(params: OpsWorksCreateInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksCreateInstanceResult|any) => void): Request;
-      createLayer(params: OpsWorksCreateLayerRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksCreateLayerResult|any) => void): Request;
-      createStack(params: OpsWorksCreateStackRequest, callback?: (err: OpsWorksValidationException|any, data: OpsWorksCreateStackResult|any) => void): Request;
-      createUserProfile(params: OpsWorksCreateUserProfileRequest, callback?: (err: OpsWorksValidationException|any, data: OpsWorksCreateUserProfileResult|any) => void): Request;
-      deleteApp(params: OpsWorksDeleteAppRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deleteInstance(params: OpsWorksDeleteInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deleteLayer(params: OpsWorksDeleteLayerRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deleteStack(params: OpsWorksDeleteStackRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deleteUserProfile(params: OpsWorksDeleteUserProfileRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deregisterEcsCluster(params: OpsWorksDeregisterEcsClusterRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deregisterElasticIp(params: OpsWorksDeregisterElasticIpRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deregisterInstance(params: OpsWorksDeregisterInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deregisterRdsDbInstance(params: OpsWorksDeregisterRdsDbInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      deregisterVolume(params: OpsWorksDeregisterVolumeRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      describeAgentVersions(params: OpsWorksDescribeAgentVersionsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeAgentVersionsResult|any) => void): Request;
-      describeApps(params: OpsWorksDescribeAppsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeAppsResult|any) => void): Request;
-      describeCommands(params: OpsWorksDescribeCommandsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeCommandsResult|any) => void): Request;
-      describeDeployments(params: OpsWorksDescribeDeploymentsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeDeploymentsResult|any) => void): Request;
-      describeEcsClusters(params: OpsWorksDescribeEcsClustersRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeEcsClustersResult|any) => void): Request;
-      describeElasticIps(params: OpsWorksDescribeElasticIpsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeElasticIpsResult|any) => void): Request;
-      describeElasticLoadBalancers(params: OpsWorksDescribeElasticLoadBalancersRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeElasticLoadBalancersResult|any) => void): Request;
-      describeInstances(params: OpsWorksDescribeInstancesRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeInstancesResult|any) => void): Request;
-      describeLayers(params: OpsWorksDescribeLayersRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeLayersResult|any) => void): Request;
-      describeLoadBasedAutoScaling(params: OpsWorksDescribeLoadBasedAutoScalingRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeLoadBasedAutoScalingResult|any) => void): Request;
-      describeMyUserProfile(callback?: (err: any, data: OpsWorksDescribeMyUserProfileResult|any) => void): Request;
-      describePermissions(params: OpsWorksDescribePermissionsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribePermissionsResult|any) => void): Request;
-      describeRaidArrays(params: OpsWorksDescribeRaidArraysRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeRaidArraysResult|any) => void): Request;
-      describeRdsDbInstances(params: OpsWorksDescribeRdsDbInstancesRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeRdsDbInstancesResult|any) => void): Request;
-      describeServiceErrors(params: OpsWorksDescribeServiceErrorsRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeServiceErrorsResult|any) => void): Request;
-      describeStackProvisioningParameters(params: OpsWorksDescribeStackProvisioningParametersRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeStackProvisioningParametersResult|any) => void): Request;
-      describeStackSummary(params: OpsWorksDescribeStackSummaryRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeStackSummaryResult|any) => void): Request;
-      describeStacks(params: OpsWorksDescribeStacksRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeStacksResult|any) => void): Request;
-      describeTimeBasedAutoScaling(params: OpsWorksDescribeTimeBasedAutoScalingRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeTimeBasedAutoScalingResult|any) => void): Request;
-      describeUserProfiles(params: OpsWorksDescribeUserProfilesRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeUserProfilesResult|any) => void): Request;
-      describeVolumes(params: OpsWorksDescribeVolumesRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksDescribeVolumesResult|any) => void): Request;
-      detachElasticLoadBalancer(params: OpsWorksDetachElasticLoadBalancerRequest, callback?: (err: OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      disassociateElasticIp(params: OpsWorksDisassociateElasticIpRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      getHostnameSuggestion(params: OpsWorksGetHostnameSuggestionRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksGetHostnameSuggestionResult|any) => void): Request;
-      grantAccess(params: OpsWorksGrantAccessRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksGrantAccessResult|any) => void): Request;
-      rebootInstance(params: OpsWorksRebootInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      registerEcsCluster(params: OpsWorksRegisterEcsClusterRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksRegisterEcsClusterResult|any) => void): Request;
-      registerElasticIp(params: OpsWorksRegisterElasticIpRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksRegisterElasticIpResult|any) => void): Request;
-      registerInstance(params: OpsWorksRegisterInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksRegisterInstanceResult|any) => void): Request;
-      registerRdsDbInstance(params: OpsWorksRegisterRdsDbInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      registerVolume(params: OpsWorksRegisterVolumeRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: OpsWorksRegisterVolumeResult|any) => void): Request;
-      setLoadBasedAutoScaling(params: OpsWorksSetLoadBasedAutoScalingRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      setPermission(params: OpsWorksSetPermissionRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      setTimeBasedAutoScaling(params: OpsWorksSetTimeBasedAutoScalingRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      startInstance(params: OpsWorksStartInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      startStack(params: OpsWorksStartStackRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      stopInstance(params: OpsWorksStopInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      stopStack(params: OpsWorksStopStackRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      unassignInstance(params: OpsWorksUnassignInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      unassignVolume(params: OpsWorksUnassignVolumeRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateApp(params: OpsWorksUpdateAppRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateElasticIp(params: OpsWorksUpdateElasticIpRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateInstance(params: OpsWorksUpdateInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateLayer(params: OpsWorksUpdateLayerRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateMyUserProfile(params: OpsWorksUpdateMyUserProfileRequest, callback?: (err: OpsWorksValidationException|any, data: any) => void): Request;
-      updateRdsDbInstance(params: OpsWorksUpdateRdsDbInstanceRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateStack(params: OpsWorksUpdateStackRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateUserProfile(params: OpsWorksUpdateUserProfileRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-      updateVolume(params: OpsWorksUpdateVolumeRequest, callback?: (err: OpsWorksValidationException|OpsWorksResourceNotFoundException|any, data: any) => void): Request;
-    }
-
-    export interface OpsWorksAgentVersion {
-        Version?: OpsWorksString;
-        ConfigurationManager?: OpsWorksStackConfigurationManager;
-    }
-
-    export type OpsWorksAgentVersions = Array<OpsWorksAgentVersion>;
-    export interface OpsWorksApp {
-        AppId?: OpsWorksString;
-        StackId?: OpsWorksString;
-        Shortname?: OpsWorksString;
-        Name?: OpsWorksString;
-        Description?: OpsWorksString;
-        DataSources?: OpsWorksDataSources;
-        Type?: OpsWorksAppType;
-        AppSource?: OpsWorksSource;
-        Domains?: OpsWorksStrings;
-        EnableSsl?: OpsWorksBoolean;
-        SslConfiguration?: OpsWorksSslConfiguration;
-        Attributes?: OpsWorksAppAttributes;
-        CreatedAt?: OpsWorksString;
-        Environment?: OpsWorksEnvironmentVariables;
-    }
-
-    export type OpsWorksAppAttributes = any; // not really - it was 'map' instead - must fix this one
-    export type OpsWorksAppAttributesKeys = string;
-    export type OpsWorksAppType = string;
-    export type OpsWorksApps = Array<OpsWorksApp>;
-    export type OpsWorksArchitecture = string;
-    export interface OpsWorksAssignInstanceRequest {
-        InstanceId: OpsWorksString;
-        LayerIds: OpsWorksStrings;
-    }
-
-    export interface OpsWorksAssignVolumeRequest {
-        VolumeId: OpsWorksString;
-        InstanceId?: OpsWorksString;
-    }
-
-    export interface OpsWorksAssociateElasticIpRequest {
-        ElasticIp: OpsWorksString;
-        InstanceId?: OpsWorksString;
-    }
-
-    export interface OpsWorksAttachElasticLoadBalancerRequest {
-        ElasticLoadBalancerName: OpsWorksString;
-        LayerId: OpsWorksString;
-    }
-
-    export interface OpsWorksAutoScalingThresholds {
-        InstanceCount?: OpsWorksInteger;
-        ThresholdsWaitTime?: OpsWorksMinute;
-        IgnoreMetricsTime?: OpsWorksMinute;
-        CpuThreshold?: OpsWorksDouble;
-        MemoryThreshold?: OpsWorksDouble;
-        LoadThreshold?: OpsWorksDouble;
-        Alarms?: OpsWorksStrings;
-    }
-
-    export type OpsWorksAutoScalingType = string;
-    export interface OpsWorksBlockDeviceMapping {
-        DeviceName?: OpsWorksString;
-        NoDevice?: OpsWorksString;
-        VirtualName?: OpsWorksString;
-        Ebs?: OpsWorksEbsBlockDevice;
-    }
-
-    export type OpsWorksBlockDeviceMappings = Array<OpsWorksBlockDeviceMapping>;
-    export type OpsWorksBoolean = boolean;
-    export interface OpsWorksChefConfiguration {
-        ManageBerkshelf?: OpsWorksBoolean;
-        BerkshelfVersion?: OpsWorksString;
-    }
-
-    export interface OpsWorksCloneStackRequest {
-        SourceStackId: OpsWorksString;
-        Name?: OpsWorksString;
-        Region?: OpsWorksString;
-        VpcId?: OpsWorksString;
-        Attributes?: OpsWorksStackAttributes;
-        ServiceRoleArn: OpsWorksString;
-        DefaultInstanceProfileArn?: OpsWorksString;
-        DefaultOs?: OpsWorksString;
-        HostnameTheme?: OpsWorksString;
-        DefaultAvailabilityZone?: OpsWorksString;
-        DefaultSubnetId?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        ConfigurationManager?: OpsWorksStackConfigurationManager;
-        ChefConfiguration?: OpsWorksChefConfiguration;
-        UseCustomCookbooks?: OpsWorksBoolean;
-        UseOpsworksSecurityGroups?: OpsWorksBoolean;
-        CustomCookbooksSource?: OpsWorksSource;
-        DefaultSshKeyName?: OpsWorksString;
-        ClonePermissions?: OpsWorksBoolean;
-        CloneAppIds?: OpsWorksStrings;
-        DefaultRootDeviceType?: OpsWorksRootDeviceType;
-        AgentVersion?: OpsWorksString;
-    }
-
-    export interface OpsWorksCloneStackResult {
-        StackId?: OpsWorksString;
-    }
-
-    export interface OpsWorksCommand {
-        CommandId?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-        DeploymentId?: OpsWorksString;
-        CreatedAt?: OpsWorksDateTime;
-        AcknowledgedAt?: OpsWorksDateTime;
-        CompletedAt?: OpsWorksDateTime;
-        Status?: OpsWorksString;
-        ExitCode?: OpsWorksInteger;
-        LogUrl?: OpsWorksString;
-        Type?: OpsWorksString;
-    }
-
-    export type OpsWorksCommands = Array<OpsWorksCommand>;
-    export interface OpsWorksCreateAppRequest {
-        StackId: OpsWorksString;
-        Shortname?: OpsWorksString;
-        Name: OpsWorksString;
-        Description?: OpsWorksString;
-        DataSources?: OpsWorksDataSources;
-        Type: OpsWorksAppType;
-        AppSource?: OpsWorksSource;
-        Domains?: OpsWorksStrings;
-        EnableSsl?: OpsWorksBoolean;
-        SslConfiguration?: OpsWorksSslConfiguration;
-        Attributes?: OpsWorksAppAttributes;
-        Environment?: OpsWorksEnvironmentVariables;
-    }
-
-    export interface OpsWorksCreateAppResult {
-        AppId?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateDeploymentRequest {
-        StackId: OpsWorksString;
-        AppId?: OpsWorksString;
-        InstanceIds?: OpsWorksStrings;
-        Command: OpsWorksDeploymentCommand;
-        Comment?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateDeploymentResult {
-        DeploymentId?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateInstanceRequest {
-        StackId: OpsWorksString;
-        LayerIds: OpsWorksStrings;
-        InstanceType: OpsWorksString;
-        AutoScalingType?: OpsWorksAutoScalingType;
-        Hostname?: OpsWorksString;
-        Os?: OpsWorksString;
-        AmiId?: OpsWorksString;
-        SshKeyName?: OpsWorksString;
-        AvailabilityZone?: OpsWorksString;
-        VirtualizationType?: OpsWorksString;
-        SubnetId?: OpsWorksString;
-        Architecture?: OpsWorksArchitecture;
-        RootDeviceType?: OpsWorksRootDeviceType;
-        BlockDeviceMappings?: OpsWorksBlockDeviceMappings;
-        InstallUpdatesOnBoot?: OpsWorksBoolean;
-        EbsOptimized?: OpsWorksBoolean;
-        AgentVersion?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateInstanceResult {
-        InstanceId?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateLayerRequest {
-        StackId: OpsWorksString;
-        Type: OpsWorksLayerType;
-        Name: OpsWorksString;
-        Shortname: OpsWorksString;
-        Attributes?: OpsWorksLayerAttributes;
-        CustomInstanceProfileArn?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        CustomSecurityGroupIds?: OpsWorksStrings;
-        Packages?: OpsWorksStrings;
-        VolumeConfigurations?: OpsWorksVolumeConfigurations;
-        EnableAutoHealing?: OpsWorksBoolean;
-        AutoAssignElasticIps?: OpsWorksBoolean;
-        AutoAssignPublicIps?: OpsWorksBoolean;
-        CustomRecipes?: OpsWorksRecipes;
-        InstallUpdatesOnBoot?: OpsWorksBoolean;
-        UseEbsOptimizedInstances?: OpsWorksBoolean;
-        LifecycleEventConfiguration?: OpsWorksLifecycleEventConfiguration;
-    }
-
-    export interface OpsWorksCreateLayerResult {
-        LayerId?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateStackRequest {
-        Name: OpsWorksString;
-        Region: OpsWorksString;
-        VpcId?: OpsWorksString;
-        Attributes?: OpsWorksStackAttributes;
-        ServiceRoleArn: OpsWorksString;
-        DefaultInstanceProfileArn: OpsWorksString;
-        DefaultOs?: OpsWorksString;
-        HostnameTheme?: OpsWorksString;
-        DefaultAvailabilityZone?: OpsWorksString;
-        DefaultSubnetId?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        ConfigurationManager?: OpsWorksStackConfigurationManager;
-        ChefConfiguration?: OpsWorksChefConfiguration;
-        UseCustomCookbooks?: OpsWorksBoolean;
-        UseOpsworksSecurityGroups?: OpsWorksBoolean;
-        CustomCookbooksSource?: OpsWorksSource;
-        DefaultSshKeyName?: OpsWorksString;
-        DefaultRootDeviceType?: OpsWorksRootDeviceType;
-        AgentVersion?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateStackResult {
-        StackId?: OpsWorksString;
-    }
-
-    export interface OpsWorksCreateUserProfileRequest {
-        IamUserArn: OpsWorksString;
-        SshUsername?: OpsWorksString;
-        SshPublicKey?: OpsWorksString;
-        AllowSelfManagement?: OpsWorksBoolean;
-    }
-
-    export interface OpsWorksCreateUserProfileResult {
-        IamUserArn?: OpsWorksString;
-    }
-
-    export type OpsWorksDailyAutoScalingSchedule = any; // not really - it was 'map' instead - must fix this one
-    export interface OpsWorksDataSource {
-        Type?: OpsWorksString;
-        Arn?: OpsWorksString;
-        DatabaseName?: OpsWorksString;
-    }
-
-    export type OpsWorksDataSources = Array<OpsWorksDataSource>;
-    export type OpsWorksDateTime = string;
-    export interface OpsWorksDeleteAppRequest {
-        AppId: OpsWorksString;
-    }
-
-    export interface OpsWorksDeleteInstanceRequest {
-        InstanceId: OpsWorksString;
-        DeleteElasticIp?: OpsWorksBoolean;
-        DeleteVolumes?: OpsWorksBoolean;
-    }
-
-    export interface OpsWorksDeleteLayerRequest {
-        LayerId: OpsWorksString;
-    }
-
-    export interface OpsWorksDeleteStackRequest {
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksDeleteUserProfileRequest {
-        IamUserArn: OpsWorksString;
-    }
-
-    export interface OpsWorksDeployment {
-        DeploymentId?: OpsWorksString;
-        StackId?: OpsWorksString;
-        AppId?: OpsWorksString;
-        CreatedAt?: OpsWorksDateTime;
-        CompletedAt?: OpsWorksDateTime;
-        Duration?: OpsWorksInteger;
-        IamUserArn?: OpsWorksString;
-        Comment?: OpsWorksString;
-        Command?: OpsWorksDeploymentCommand;
-        Status?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        InstanceIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDeploymentCommand {
-        Name: OpsWorksDeploymentCommandName;
-        Args?: OpsWorksDeploymentCommandArgs;
-    }
-
-    export type OpsWorksDeploymentCommandArgs = any; // not really - it was 'map' instead - must fix this one
-    export type OpsWorksDeploymentCommandName = string;
-    export type OpsWorksDeployments = Array<OpsWorksDeployment>;
-    export interface OpsWorksDeregisterEcsClusterRequest {
-        EcsClusterArn: OpsWorksString;
-    }
-
-    export interface OpsWorksDeregisterElasticIpRequest {
-        ElasticIp: OpsWorksString;
-    }
-
-    export interface OpsWorksDeregisterInstanceRequest {
-        InstanceId: OpsWorksString;
-    }
-
-    export interface OpsWorksDeregisterRdsDbInstanceRequest {
-        RdsDbInstanceArn: OpsWorksString;
-    }
-
-    export interface OpsWorksDeregisterVolumeRequest {
-        VolumeId: OpsWorksString;
-    }
-
-    export interface OpsWorksDescribeAgentVersionsRequest {
-        StackId?: OpsWorksString;
-        ConfigurationManager?: OpsWorksStackConfigurationManager;
-    }
-
-    export interface OpsWorksDescribeAgentVersionsResult {
-        AgentVersions?: OpsWorksAgentVersions;
-    }
-
-    export interface OpsWorksDescribeAppsRequest {
-        StackId?: OpsWorksString;
-        AppIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeAppsResult {
-        Apps?: OpsWorksApps;
-    }
-
-    export interface OpsWorksDescribeCommandsRequest {
-        DeploymentId?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-        CommandIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeCommandsResult {
-        Commands?: OpsWorksCommands;
-    }
-
-    export interface OpsWorksDescribeDeploymentsRequest {
-        StackId?: OpsWorksString;
-        AppId?: OpsWorksString;
-        DeploymentIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeDeploymentsResult {
-        Deployments?: OpsWorksDeployments;
-    }
-
-    export interface OpsWorksDescribeEcsClustersRequest {
-        EcsClusterArns?: OpsWorksStrings;
-        StackId?: OpsWorksString;
-        NextToken?: OpsWorksString;
-        MaxResults?: OpsWorksInteger;
-    }
-
-    export interface OpsWorksDescribeEcsClustersResult {
-        EcsClusters?: OpsWorksEcsClusters;
-        NextToken?: OpsWorksString;
-    }
-
-    export interface OpsWorksDescribeElasticIpsRequest {
-        InstanceId?: OpsWorksString;
-        StackId?: OpsWorksString;
-        Ips?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeElasticIpsResult {
-        ElasticIps?: OpsWorksElasticIps;
-    }
-
-    export interface OpsWorksDescribeElasticLoadBalancersRequest {
-        StackId?: OpsWorksString;
-        LayerIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeElasticLoadBalancersResult {
-        ElasticLoadBalancers?: OpsWorksElasticLoadBalancers;
-    }
-
-    export interface OpsWorksDescribeInstancesRequest {
-        StackId?: OpsWorksString;
-        LayerId?: OpsWorksString;
-        InstanceIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeInstancesResult {
-        Instances?: OpsWorksInstances;
-    }
-
-    export interface OpsWorksDescribeLayersRequest {
-        StackId?: OpsWorksString;
-        LayerIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeLayersResult {
-        Layers?: OpsWorksLayers;
-    }
-
-    export interface OpsWorksDescribeLoadBasedAutoScalingRequest {
-        LayerIds: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeLoadBasedAutoScalingResult {
-        LoadBasedAutoScalingConfigurations?: OpsWorksLoadBasedAutoScalingConfigurations;
-    }
-
-    export interface OpsWorksDescribeMyUserProfileResult {
-        UserProfile?: OpsWorksSelfUserProfile;
-    }
-
-    export interface OpsWorksDescribePermissionsRequest {
-        IamUserArn?: OpsWorksString;
-        StackId?: OpsWorksString;
-    }
-
-    export interface OpsWorksDescribePermissionsResult {
-        Permissions?: OpsWorksPermissions;
-    }
-
-    export interface OpsWorksDescribeRaidArraysRequest {
-        InstanceId?: OpsWorksString;
-        StackId?: OpsWorksString;
-        RaidArrayIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeRaidArraysResult {
-        RaidArrays?: OpsWorksRaidArrays;
-    }
-
-    export interface OpsWorksDescribeRdsDbInstancesRequest {
-        StackId: OpsWorksString;
-        RdsDbInstanceArns?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeRdsDbInstancesResult {
-        RdsDbInstances?: OpsWorksRdsDbInstances;
-    }
-
-    export interface OpsWorksDescribeServiceErrorsRequest {
-        StackId?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-        ServiceErrorIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeServiceErrorsResult {
-        ServiceErrors?: OpsWorksServiceErrors;
-    }
-
-    export interface OpsWorksDescribeStackProvisioningParametersRequest {
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksDescribeStackProvisioningParametersResult {
-        AgentInstallerUrl?: OpsWorksString;
-        Parameters?: OpsWorksParameters;
-    }
-
-    export interface OpsWorksDescribeStackSummaryRequest {
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksDescribeStackSummaryResult {
-        StackSummary?: OpsWorksStackSummary;
-    }
-
-    export interface OpsWorksDescribeStacksRequest {
-        StackIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeStacksResult {
-        Stacks?: OpsWorksStacks;
-    }
-
-    export interface OpsWorksDescribeTimeBasedAutoScalingRequest {
-        InstanceIds: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeTimeBasedAutoScalingResult {
-        TimeBasedAutoScalingConfigurations?: OpsWorksTimeBasedAutoScalingConfigurations;
-    }
-
-    export interface OpsWorksDescribeUserProfilesRequest {
-        IamUserArns?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeUserProfilesResult {
-        UserProfiles?: OpsWorksUserProfiles;
-    }
-
-    export interface OpsWorksDescribeVolumesRequest {
-        InstanceId?: OpsWorksString;
-        StackId?: OpsWorksString;
-        RaidArrayId?: OpsWorksString;
-        VolumeIds?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksDescribeVolumesResult {
-        Volumes?: OpsWorksVolumes;
-    }
-
-    export interface OpsWorksDetachElasticLoadBalancerRequest {
-        ElasticLoadBalancerName: OpsWorksString;
-        LayerId: OpsWorksString;
-    }
-
-    export interface OpsWorksDisassociateElasticIpRequest {
-        ElasticIp: OpsWorksString;
-    }
-
-    export type OpsWorksDouble = number;
-    export interface OpsWorksEbsBlockDevice {
-        SnapshotId?: OpsWorksString;
-        Iops?: OpsWorksInteger;
-        VolumeSize?: OpsWorksInteger;
-        VolumeType?: OpsWorksVolumeType;
-        DeleteOnTermination?: OpsWorksBoolean;
-    }
-
-    export interface OpsWorksEcsCluster {
-        EcsClusterArn?: OpsWorksString;
-        EcsClusterName?: OpsWorksString;
-        StackId?: OpsWorksString;
-        RegisteredAt?: OpsWorksDateTime;
-    }
-
-    export type OpsWorksEcsClusters = Array<OpsWorksEcsCluster>;
-    export interface OpsWorksElasticIp {
-        Ip?: OpsWorksString;
-        Name?: OpsWorksString;
-        Domain?: OpsWorksString;
-        Region?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-    }
-
-    export type OpsWorksElasticIps = Array<OpsWorksElasticIp>;
-    export interface OpsWorksElasticLoadBalancer {
-        ElasticLoadBalancerName?: OpsWorksString;
-        Region?: OpsWorksString;
-        DnsName?: OpsWorksString;
-        StackId?: OpsWorksString;
-        LayerId?: OpsWorksString;
-        VpcId?: OpsWorksString;
-        AvailabilityZones?: OpsWorksStrings;
-        SubnetIds?: OpsWorksStrings;
-        Ec2InstanceIds?: OpsWorksStrings;
-    }
-
-    export type OpsWorksElasticLoadBalancers = Array<OpsWorksElasticLoadBalancer>;
-    export interface OpsWorksEnvironmentVariable {
-        Key: OpsWorksString;
-        Value: OpsWorksString;
-        Secure?: OpsWorksBoolean;
-    }
-
-    export type OpsWorksEnvironmentVariables = Array<OpsWorksEnvironmentVariable>;
-    export interface OpsWorksGetHostnameSuggestionRequest {
-        LayerId: OpsWorksString;
-    }
-
-    export interface OpsWorksGetHostnameSuggestionResult {
-        LayerId?: OpsWorksString;
-        Hostname?: OpsWorksString;
-    }
-
-    export interface OpsWorksGrantAccessRequest {
-        InstanceId: OpsWorksString;
-        ValidForInMinutes?: OpsWorksValidForInMinutes;
-    }
-
-    export interface OpsWorksGrantAccessResult {
-        TemporaryCredential?: OpsWorksTemporaryCredential;
-    }
-
-    export type OpsWorksHour = string;
-    export interface OpsWorksInstance {
-        AgentVersion?: OpsWorksString;
-        AmiId?: OpsWorksString;
-        Architecture?: OpsWorksArchitecture;
-        AutoScalingType?: OpsWorksAutoScalingType;
-        AvailabilityZone?: OpsWorksString;
-        BlockDeviceMappings?: OpsWorksBlockDeviceMappings;
-        CreatedAt?: OpsWorksDateTime;
-        EbsOptimized?: OpsWorksBoolean;
-        Ec2InstanceId?: OpsWorksString;
-        EcsClusterArn?: OpsWorksString;
-        EcsContainerInstanceArn?: OpsWorksString;
-        ElasticIp?: OpsWorksString;
-        Hostname?: OpsWorksString;
-        InfrastructureClass?: OpsWorksString;
-        InstallUpdatesOnBoot?: OpsWorksBoolean;
-        InstanceId?: OpsWorksString;
-        InstanceProfileArn?: OpsWorksString;
-        InstanceType?: OpsWorksString;
-        LastServiceErrorId?: OpsWorksString;
-        LayerIds?: OpsWorksStrings;
-        Os?: OpsWorksString;
-        Platform?: OpsWorksString;
-        PrivateDns?: OpsWorksString;
-        PrivateIp?: OpsWorksString;
-        PublicDns?: OpsWorksString;
-        PublicIp?: OpsWorksString;
-        RegisteredBy?: OpsWorksString;
-        ReportedAgentVersion?: OpsWorksString;
-        ReportedOs?: OpsWorksReportedOs;
-        RootDeviceType?: OpsWorksRootDeviceType;
-        RootDeviceVolumeId?: OpsWorksString;
-        SecurityGroupIds?: OpsWorksStrings;
-        SshHostDsaKeyFingerprint?: OpsWorksString;
-        SshHostRsaKeyFingerprint?: OpsWorksString;
-        SshKeyName?: OpsWorksString;
-        StackId?: OpsWorksString;
-        Status?: OpsWorksString;
-        SubnetId?: OpsWorksString;
-        VirtualizationType?: OpsWorksVirtualizationType;
-    }
-
-    export interface OpsWorksInstanceIdentity {
-        Document?: OpsWorksString;
-        Signature?: OpsWorksString;
-    }
-
-    export type OpsWorksInstances = Array<OpsWorksInstance>;
-    export interface OpsWorksInstancesCount {
-        Assigning?: OpsWorksInteger;
-        Booting?: OpsWorksInteger;
-        ConnectionLost?: OpsWorksInteger;
-        Deregistering?: OpsWorksInteger;
-        Online?: OpsWorksInteger;
-        Pending?: OpsWorksInteger;
-        Rebooting?: OpsWorksInteger;
-        Registered?: OpsWorksInteger;
-        Registering?: OpsWorksInteger;
-        Requested?: OpsWorksInteger;
-        RunningSetup?: OpsWorksInteger;
-        SetupFailed?: OpsWorksInteger;
-        ShuttingDown?: OpsWorksInteger;
-        StartFailed?: OpsWorksInteger;
-        Stopped?: OpsWorksInteger;
-        Stopping?: OpsWorksInteger;
-        Terminated?: OpsWorksInteger;
-        Terminating?: OpsWorksInteger;
-        Unassigning?: OpsWorksInteger;
-    }
-
-    export type OpsWorksInteger = number;
-    export interface OpsWorksLayer {
-        StackId?: OpsWorksString;
-        LayerId?: OpsWorksString;
-        Type?: OpsWorksLayerType;
-        Name?: OpsWorksString;
-        Shortname?: OpsWorksString;
-        Attributes?: OpsWorksLayerAttributes;
-        CustomInstanceProfileArn?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        CustomSecurityGroupIds?: OpsWorksStrings;
-        DefaultSecurityGroupNames?: OpsWorksStrings;
-        Packages?: OpsWorksStrings;
-        VolumeConfigurations?: OpsWorksVolumeConfigurations;
-        EnableAutoHealing?: OpsWorksBoolean;
-        AutoAssignElasticIps?: OpsWorksBoolean;
-        AutoAssignPublicIps?: OpsWorksBoolean;
-        DefaultRecipes?: OpsWorksRecipes;
-        CustomRecipes?: OpsWorksRecipes;
-        CreatedAt?: OpsWorksDateTime;
-        InstallUpdatesOnBoot?: OpsWorksBoolean;
-        UseEbsOptimizedInstances?: OpsWorksBoolean;
-        LifecycleEventConfiguration?: OpsWorksLifecycleEventConfiguration;
-    }
-
-    export type OpsWorksLayerAttributes = any; // not really - it was 'map' instead - must fix this one
-    export type OpsWorksLayerAttributesKeys = string;
-    export type OpsWorksLayerType = string;
-    export type OpsWorksLayers = Array<OpsWorksLayer>;
-    export interface OpsWorksLifecycleEventConfiguration {
-        Shutdown?: OpsWorksShutdownEventConfiguration;
-    }
-
-    export interface OpsWorksLoadBasedAutoScalingConfiguration {
-        LayerId?: OpsWorksString;
-        Enable?: OpsWorksBoolean;
-        UpScaling?: OpsWorksAutoScalingThresholds;
-        DownScaling?: OpsWorksAutoScalingThresholds;
-    }
-
-    export type OpsWorksLoadBasedAutoScalingConfigurations = Array<OpsWorksLoadBasedAutoScalingConfiguration>;
-    export type OpsWorksMinute = number;
-    export type OpsWorksParameters = any; // not really - it was 'map' instead - must fix this one
-    export interface OpsWorksPermission {
-        StackId?: OpsWorksString;
-        IamUserArn?: OpsWorksString;
-        AllowSsh?: OpsWorksBoolean;
-        AllowSudo?: OpsWorksBoolean;
-        Level?: OpsWorksString;
-    }
-
-    export type OpsWorksPermissions = Array<OpsWorksPermission>;
-    export interface OpsWorksRaidArray {
-        RaidArrayId?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-        Name?: OpsWorksString;
-        RaidLevel?: OpsWorksInteger;
-        NumberOfDisks?: OpsWorksInteger;
-        Size?: OpsWorksInteger;
-        Device?: OpsWorksString;
-        MountPoint?: OpsWorksString;
-        AvailabilityZone?: OpsWorksString;
-        CreatedAt?: OpsWorksDateTime;
-        StackId?: OpsWorksString;
-        VolumeType?: OpsWorksString;
-        Iops?: OpsWorksInteger;
-    }
-
-    export type OpsWorksRaidArrays = Array<OpsWorksRaidArray>;
-    export interface OpsWorksRdsDbInstance {
-        RdsDbInstanceArn?: OpsWorksString;
-        DbInstanceIdentifier?: OpsWorksString;
-        DbUser?: OpsWorksString;
-        DbPassword?: OpsWorksString;
-        Region?: OpsWorksString;
-        Address?: OpsWorksString;
-        Engine?: OpsWorksString;
-        StackId?: OpsWorksString;
-        MissingOnRds?: OpsWorksBoolean;
-    }
-
-    export type OpsWorksRdsDbInstances = Array<OpsWorksRdsDbInstance>;
-    export interface OpsWorksRebootInstanceRequest {
-        InstanceId: OpsWorksString;
-    }
-
-    export interface OpsWorksRecipes {
-        Setup?: OpsWorksStrings;
-        Configure?: OpsWorksStrings;
-        Deploy?: OpsWorksStrings;
-        Undeploy?: OpsWorksStrings;
-        Shutdown?: OpsWorksStrings;
-    }
-
-    export interface OpsWorksRegisterEcsClusterRequest {
-        EcsClusterArn: OpsWorksString;
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterEcsClusterResult {
-        EcsClusterArn?: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterElasticIpRequest {
-        ElasticIp: OpsWorksString;
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterElasticIpResult {
-        ElasticIp?: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterInstanceRequest {
-        StackId: OpsWorksString;
-        Hostname?: OpsWorksString;
-        PublicIp?: OpsWorksString;
-        PrivateIp?: OpsWorksString;
-        RsaPublicKey?: OpsWorksString;
-        RsaPublicKeyFingerprint?: OpsWorksString;
-        InstanceIdentity?: OpsWorksInstanceIdentity;
-    }
-
-    export interface OpsWorksRegisterInstanceResult {
-        InstanceId?: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterRdsDbInstanceRequest {
-        StackId: OpsWorksString;
-        RdsDbInstanceArn: OpsWorksString;
-        DbUser: OpsWorksString;
-        DbPassword: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterVolumeRequest {
-        Ec2VolumeId?: OpsWorksString;
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksRegisterVolumeResult {
-        VolumeId?: OpsWorksString;
-    }
-
-    export interface OpsWorksReportedOs {
-        Family?: OpsWorksString;
-        Name?: OpsWorksString;
-        Version?: OpsWorksString;
-    }
-
-    export interface OpsWorksResourceNotFoundException {
-        message?: OpsWorksString;
-    }
-
-    export type OpsWorksRootDeviceType = string;
-    export interface OpsWorksSelfUserProfile {
-        IamUserArn?: OpsWorksString;
-        Name?: OpsWorksString;
-        SshUsername?: OpsWorksString;
-        SshPublicKey?: OpsWorksString;
-    }
-
-    export interface OpsWorksServiceError {
-        ServiceErrorId?: OpsWorksString;
-        StackId?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-        Type?: OpsWorksString;
-        Message?: OpsWorksString;
-        CreatedAt?: OpsWorksDateTime;
-    }
-
-    export type OpsWorksServiceErrors = Array<OpsWorksServiceError>;
-    export interface OpsWorksSetLoadBasedAutoScalingRequest {
-        LayerId: OpsWorksString;
-        Enable?: OpsWorksBoolean;
-        UpScaling?: OpsWorksAutoScalingThresholds;
-        DownScaling?: OpsWorksAutoScalingThresholds;
-    }
-
-    export interface OpsWorksSetPermissionRequest {
-        StackId: OpsWorksString;
-        IamUserArn: OpsWorksString;
-        AllowSsh?: OpsWorksBoolean;
-        AllowSudo?: OpsWorksBoolean;
-        Level?: OpsWorksString;
-    }
-
-    export interface OpsWorksSetTimeBasedAutoScalingRequest {
-        InstanceId: OpsWorksString;
-        AutoScalingSchedule?: OpsWorksWeeklyAutoScalingSchedule;
-    }
-
-    export interface OpsWorksShutdownEventConfiguration {
-        ExecutionTimeout?: OpsWorksInteger;
-        DelayUntilElbConnectionsDrained?: OpsWorksBoolean;
-    }
-
-    export interface OpsWorksSource {
-        Type?: OpsWorksSourceType;
-        Url?: OpsWorksString;
-        Username?: OpsWorksString;
-        Password?: OpsWorksString;
-        SshKey?: OpsWorksString;
-        Revision?: OpsWorksString;
-    }
-
-    export type OpsWorksSourceType = string;
-    export interface OpsWorksSslConfiguration {
-        Certificate: OpsWorksString;
-        PrivateKey: OpsWorksString;
-        Chain?: OpsWorksString;
-    }
-
-    export interface OpsWorksStack {
-        StackId?: OpsWorksString;
-        Name?: OpsWorksString;
-        Arn?: OpsWorksString;
-        Region?: OpsWorksString;
-        VpcId?: OpsWorksString;
-        Attributes?: OpsWorksStackAttributes;
-        ServiceRoleArn?: OpsWorksString;
-        DefaultInstanceProfileArn?: OpsWorksString;
-        DefaultOs?: OpsWorksString;
-        HostnameTheme?: OpsWorksString;
-        DefaultAvailabilityZone?: OpsWorksString;
-        DefaultSubnetId?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        ConfigurationManager?: OpsWorksStackConfigurationManager;
-        ChefConfiguration?: OpsWorksChefConfiguration;
-        UseCustomCookbooks?: OpsWorksBoolean;
-        UseOpsworksSecurityGroups?: OpsWorksBoolean;
-        CustomCookbooksSource?: OpsWorksSource;
-        DefaultSshKeyName?: OpsWorksString;
-        CreatedAt?: OpsWorksDateTime;
-        DefaultRootDeviceType?: OpsWorksRootDeviceType;
-        AgentVersion?: OpsWorksString;
-    }
-
-    export type OpsWorksStackAttributes = any; // not really - it was 'map' instead - must fix this one
-    export type OpsWorksStackAttributesKeys = string;
-    export interface OpsWorksStackConfigurationManager {
-        Name?: OpsWorksString;
-        Version?: OpsWorksString;
-    }
-
-    export interface OpsWorksStackSummary {
-        StackId?: OpsWorksString;
-        Name?: OpsWorksString;
-        Arn?: OpsWorksString;
-        LayersCount?: OpsWorksInteger;
-        AppsCount?: OpsWorksInteger;
-        InstancesCount?: OpsWorksInstancesCount;
-    }
-
-    export type OpsWorksStacks = Array<OpsWorksStack>;
-    export interface OpsWorksStartInstanceRequest {
-        InstanceId: OpsWorksString;
-    }
-
-    export interface OpsWorksStartStackRequest {
-        StackId: OpsWorksString;
-    }
-
-    export interface OpsWorksStopInstanceRequest {
-        InstanceId: OpsWorksString;
-    }
-
-    export interface OpsWorksStopStackRequest {
-        StackId: OpsWorksString;
-    }
-
-    export type OpsWorksString = string;
-    export type OpsWorksStrings = Array<OpsWorksString>;
-    export type OpsWorksSwitch = string;
-    export interface OpsWorksTemporaryCredential {
-        Username?: OpsWorksString;
-        Password?: OpsWorksString;
-        ValidForInMinutes?: OpsWorksInteger;
-        InstanceId?: OpsWorksString;
-    }
-
-    export interface OpsWorksTimeBasedAutoScalingConfiguration {
-        InstanceId?: OpsWorksString;
-        AutoScalingSchedule?: OpsWorksWeeklyAutoScalingSchedule;
-    }
-
-    export type OpsWorksTimeBasedAutoScalingConfigurations = Array<OpsWorksTimeBasedAutoScalingConfiguration>;
-    export interface OpsWorksUnassignInstanceRequest {
-        InstanceId: OpsWorksString;
-    }
-
-    export interface OpsWorksUnassignVolumeRequest {
-        VolumeId: OpsWorksString;
-    }
-
-    export interface OpsWorksUpdateAppRequest {
-        AppId: OpsWorksString;
-        Name?: OpsWorksString;
-        Description?: OpsWorksString;
-        DataSources?: OpsWorksDataSources;
-        Type?: OpsWorksAppType;
-        AppSource?: OpsWorksSource;
-        Domains?: OpsWorksStrings;
-        EnableSsl?: OpsWorksBoolean;
-        SslConfiguration?: OpsWorksSslConfiguration;
-        Attributes?: OpsWorksAppAttributes;
-        Environment?: OpsWorksEnvironmentVariables;
-    }
-
-    export interface OpsWorksUpdateElasticIpRequest {
-        ElasticIp: OpsWorksString;
-        Name?: OpsWorksString;
-    }
-
-    export interface OpsWorksUpdateInstanceRequest {
-        InstanceId: OpsWorksString;
-        LayerIds?: OpsWorksStrings;
-        InstanceType?: OpsWorksString;
-        AutoScalingType?: OpsWorksAutoScalingType;
-        Hostname?: OpsWorksString;
-        Os?: OpsWorksString;
-        AmiId?: OpsWorksString;
-        SshKeyName?: OpsWorksString;
-        Architecture?: OpsWorksArchitecture;
-        InstallUpdatesOnBoot?: OpsWorksBoolean;
-        EbsOptimized?: OpsWorksBoolean;
-        AgentVersion?: OpsWorksString;
-    }
-
-    export interface OpsWorksUpdateLayerRequest {
-        LayerId: OpsWorksString;
-        Name?: OpsWorksString;
-        Shortname?: OpsWorksString;
-        Attributes?: OpsWorksLayerAttributes;
-        CustomInstanceProfileArn?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        CustomSecurityGroupIds?: OpsWorksStrings;
-        Packages?: OpsWorksStrings;
-        VolumeConfigurations?: OpsWorksVolumeConfigurations;
-        EnableAutoHealing?: OpsWorksBoolean;
-        AutoAssignElasticIps?: OpsWorksBoolean;
-        AutoAssignPublicIps?: OpsWorksBoolean;
-        CustomRecipes?: OpsWorksRecipes;
-        InstallUpdatesOnBoot?: OpsWorksBoolean;
-        UseEbsOptimizedInstances?: OpsWorksBoolean;
-        LifecycleEventConfiguration?: OpsWorksLifecycleEventConfiguration;
-    }
-
-    export interface OpsWorksUpdateMyUserProfileRequest {
-        SshPublicKey?: OpsWorksString;
-    }
-
-    export interface OpsWorksUpdateRdsDbInstanceRequest {
-        RdsDbInstanceArn: OpsWorksString;
-        DbUser?: OpsWorksString;
-        DbPassword?: OpsWorksString;
-    }
-
-    export interface OpsWorksUpdateStackRequest {
-        StackId: OpsWorksString;
-        Name?: OpsWorksString;
-        Attributes?: OpsWorksStackAttributes;
-        ServiceRoleArn?: OpsWorksString;
-        DefaultInstanceProfileArn?: OpsWorksString;
-        DefaultOs?: OpsWorksString;
-        HostnameTheme?: OpsWorksString;
-        DefaultAvailabilityZone?: OpsWorksString;
-        DefaultSubnetId?: OpsWorksString;
-        CustomJson?: OpsWorksString;
-        ConfigurationManager?: OpsWorksStackConfigurationManager;
-        ChefConfiguration?: OpsWorksChefConfiguration;
-        UseCustomCookbooks?: OpsWorksBoolean;
-        CustomCookbooksSource?: OpsWorksSource;
-        DefaultSshKeyName?: OpsWorksString;
-        DefaultRootDeviceType?: OpsWorksRootDeviceType;
-        UseOpsworksSecurityGroups?: OpsWorksBoolean;
-        AgentVersion?: OpsWorksString;
-    }
-
-    export interface OpsWorksUpdateUserProfileRequest {
-        IamUserArn: OpsWorksString;
-        SshUsername?: OpsWorksString;
-        SshPublicKey?: OpsWorksString;
-        AllowSelfManagement?: OpsWorksBoolean;
-    }
-
-    export interface OpsWorksUpdateVolumeRequest {
-        VolumeId: OpsWorksString;
-        Name?: OpsWorksString;
-        MountPoint?: OpsWorksString;
-    }
+      assignInstance(params: OpsWorks.AssignInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      assignVolume(params: OpsWorks.AssignVolumeRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      associateElasticIp(params: OpsWorks.AssociateElasticIpRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      attachElasticLoadBalancer(params: OpsWorks.AttachElasticLoadBalancerRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      cloneStack(params: OpsWorks.CloneStackRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.CloneStackResult|any) => void): Request;
+      createApp(params: OpsWorks.CreateAppRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.CreateAppResult|any) => void): Request;
+      createDeployment(params: OpsWorks.CreateDeploymentRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.CreateDeploymentResult|any) => void): Request;
+      createInstance(params: OpsWorks.CreateInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.CreateInstanceResult|any) => void): Request;
+      createLayer(params: OpsWorks.CreateLayerRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.CreateLayerResult|any) => void): Request;
+      createStack(params: OpsWorks.CreateStackRequest, callback?: (err: OpsWorks.ValidationException|any, data: OpsWorks.CreateStackResult|any) => void): Request;
+      createUserProfile(params: OpsWorks.CreateUserProfileRequest, callback?: (err: OpsWorks.ValidationException|any, data: OpsWorks.CreateUserProfileResult|any) => void): Request;
+      deleteApp(params: OpsWorks.DeleteAppRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deleteInstance(params: OpsWorks.DeleteInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deleteLayer(params: OpsWorks.DeleteLayerRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deleteStack(params: OpsWorks.DeleteStackRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deleteUserProfile(params: OpsWorks.DeleteUserProfileRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deregisterEcsCluster(params: OpsWorks.DeregisterEcsClusterRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deregisterElasticIp(params: OpsWorks.DeregisterElasticIpRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deregisterInstance(params: OpsWorks.DeregisterInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deregisterRdsDbInstance(params: OpsWorks.DeregisterRdsDbInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      deregisterVolume(params: OpsWorks.DeregisterVolumeRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      describeAgentVersions(params: OpsWorks.DescribeAgentVersionsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeAgentVersionsResult|any) => void): Request;
+      describeApps(params: OpsWorks.DescribeAppsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeAppsResult|any) => void): Request;
+      describeCommands(params: OpsWorks.DescribeCommandsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeCommandsResult|any) => void): Request;
+      describeDeployments(params: OpsWorks.DescribeDeploymentsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeDeploymentsResult|any) => void): Request;
+      describeEcsClusters(params: OpsWorks.DescribeEcsClustersRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeEcsClustersResult|any) => void): Request;
+      describeElasticIps(params: OpsWorks.DescribeElasticIpsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeElasticIpsResult|any) => void): Request;
+      describeElasticLoadBalancers(params: OpsWorks.DescribeElasticLoadBalancersRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeElasticLoadBalancersResult|any) => void): Request;
+      describeInstances(params: OpsWorks.DescribeInstancesRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeInstancesResult|any) => void): Request;
+      describeLayers(params: OpsWorks.DescribeLayersRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeLayersResult|any) => void): Request;
+      describeLoadBasedAutoScaling(params: OpsWorks.DescribeLoadBasedAutoScalingRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeLoadBasedAutoScalingResult|any) => void): Request;
+      describeMyUserProfile(callback?: (err: any, data: OpsWorks.DescribeMyUserProfileResult|any) => void): Request;
+      describePermissions(params: OpsWorks.DescribePermissionsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribePermissionsResult|any) => void): Request;
+      describeRaidArrays(params: OpsWorks.DescribeRaidArraysRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeRaidArraysResult|any) => void): Request;
+      describeRdsDbInstances(params: OpsWorks.DescribeRdsDbInstancesRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeRdsDbInstancesResult|any) => void): Request;
+      describeServiceErrors(params: OpsWorks.DescribeServiceErrorsRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeServiceErrorsResult|any) => void): Request;
+      describeStackProvisioningParameters(params: OpsWorks.DescribeStackProvisioningParametersRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeStackProvisioningParametersResult|any) => void): Request;
+      describeStackSummary(params: OpsWorks.DescribeStackSummaryRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeStackSummaryResult|any) => void): Request;
+      describeStacks(params: OpsWorks.DescribeStacksRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeStacksResult|any) => void): Request;
+      describeTimeBasedAutoScaling(params: OpsWorks.DescribeTimeBasedAutoScalingRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeTimeBasedAutoScalingResult|any) => void): Request;
+      describeUserProfiles(params: OpsWorks.DescribeUserProfilesRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeUserProfilesResult|any) => void): Request;
+      describeVolumes(params: OpsWorks.DescribeVolumesRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.DescribeVolumesResult|any) => void): Request;
+      detachElasticLoadBalancer(params: OpsWorks.DetachElasticLoadBalancerRequest, callback?: (err: OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      disassociateElasticIp(params: OpsWorks.DisassociateElasticIpRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      getHostnameSuggestion(params: OpsWorks.GetHostnameSuggestionRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.GetHostnameSuggestionResult|any) => void): Request;
+      grantAccess(params: OpsWorks.GrantAccessRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.GrantAccessResult|any) => void): Request;
+      rebootInstance(params: OpsWorks.RebootInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      registerEcsCluster(params: OpsWorks.RegisterEcsClusterRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.RegisterEcsClusterResult|any) => void): Request;
+      registerElasticIp(params: OpsWorks.RegisterElasticIpRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.RegisterElasticIpResult|any) => void): Request;
+      registerInstance(params: OpsWorks.RegisterInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.RegisterInstanceResult|any) => void): Request;
+      registerRdsDbInstance(params: OpsWorks.RegisterRdsDbInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      registerVolume(params: OpsWorks.RegisterVolumeRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: OpsWorks.RegisterVolumeResult|any) => void): Request;
+      setLoadBasedAutoScaling(params: OpsWorks.SetLoadBasedAutoScalingRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      setPermission(params: OpsWorks.SetPermissionRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      setTimeBasedAutoScaling(params: OpsWorks.SetTimeBasedAutoScalingRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      startInstance(params: OpsWorks.StartInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      startStack(params: OpsWorks.StartStackRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      stopInstance(params: OpsWorks.StopInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      stopStack(params: OpsWorks.StopStackRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      unassignInstance(params: OpsWorks.UnassignInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      unassignVolume(params: OpsWorks.UnassignVolumeRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateApp(params: OpsWorks.UpdateAppRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateElasticIp(params: OpsWorks.UpdateElasticIpRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateInstance(params: OpsWorks.UpdateInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateLayer(params: OpsWorks.UpdateLayerRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateMyUserProfile(params: OpsWorks.UpdateMyUserProfileRequest, callback?: (err: OpsWorks.ValidationException|any, data: any) => void): Request;
+      updateRdsDbInstance(params: OpsWorks.UpdateRdsDbInstanceRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateStack(params: OpsWorks.UpdateStackRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateUserProfile(params: OpsWorks.UpdateUserProfileRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+      updateVolume(params: OpsWorks.UpdateVolumeRequest, callback?: (err: OpsWorks.ValidationException|OpsWorks.ResourceNotFoundException|any, data: any) => void): Request;
+    }
+    
+    export module OpsWorks {
+        export type AgentVersions = AgentVersion[];
+        export type AppAttributes = {[key:string]: String};
+        export type AppAttributesKeys = string;
+        export type AppType = string;
+        export type Apps = App[];
+        export type Architecture = string;
+        export type AutoScalingType = string;
+        export type BlockDeviceMappings = BlockDeviceMapping[];
+        export type Boolean = boolean;
+        export type Commands = Command[];
+        export type DailyAutoScalingSchedule = {[key:string]: Switch};
+        export type DataSources = DataSource[];
+        export type DateTime = string;
+        export type DeploymentCommandArgs = {[key:string]: Strings};
+        export type DeploymentCommandName = string;
+        export type Deployments = Deployment[];
+        export type Double = number;
+        export type EcsClusters = EcsCluster[];
+        export type ElasticIps = ElasticIp[];
+        export type ElasticLoadBalancers = ElasticLoadBalancer[];
+        export type EnvironmentVariables = EnvironmentVariable[];
+        export type Hour = string;
+        export type Instances = Instance[];
+        export type Integer = number;
+        export type LayerAttributes = {[key:string]: String};
+        export type LayerAttributesKeys = string;
+        export type LayerType = string;
+        export type Layers = Layer[];
+        export type LoadBasedAutoScalingConfigurations = LoadBasedAutoScalingConfiguration[];
+        export type Minute = number;    // max: 100, min: 1
+        export type Parameters = {[key:string]: String};
+        export type Permissions = Permission[];
+        export type RaidArrays = RaidArray[];
+        export type RdsDbInstances = RdsDbInstance[];
+        export type RootDeviceType = string;
+        export type ServiceErrors = ServiceError[];
+        export type SourceType = string;
+        export type StackAttributes = {[key:string]: String};
+        export type StackAttributesKeys = string;
+        export type Stacks = Stack[];
+        export type String = string;
+        export type Strings = String[];
+        export type Switch = string;
+        export type TimeBasedAutoScalingConfigurations = TimeBasedAutoScalingConfiguration[];
+        export type UserProfiles = UserProfile[];
+        export type ValidForInMinutes = number;    // max: 1440, min: 60
+        export type VirtualizationType = string;
+        export type VolumeConfigurations = VolumeConfiguration[];
+        export type VolumeType = string;
+        export type Volumes = Volume[];
+
+        export interface AgentVersion {
+            Version?: String;            
+            ConfigurationManager?: StackConfigurationManager;            
+        }
+        export interface App {
+            AppId?: String;            
+            StackId?: String;            
+            Shortname?: String;            
+            Name?: String;            
+            Description?: String;            
+            DataSources?: DataSources;            
+            Type?: AppType;            
+            AppSource?: Source;            
+            Domains?: Strings;            
+            EnableSsl?: Boolean;            
+            SslConfiguration?: SslConfiguration;            
+            Attributes?: AppAttributes;            
+            CreatedAt?: String;            
+            Environment?: EnvironmentVariables;            
+        }
+        export interface AssignInstanceRequest {
+            InstanceId: String;            
+            LayerIds: Strings;            
+        }
+        export interface AssignVolumeRequest {
+            VolumeId: String;            
+            InstanceId?: String;            
+        }
+        export interface AssociateElasticIpRequest {
+            ElasticIp: String;            
+            InstanceId?: String;            
+        }
+        export interface AttachElasticLoadBalancerRequest {
+            ElasticLoadBalancerName: String;            
+            LayerId: String;            
+        }
+        export interface AutoScalingThresholds {
+            InstanceCount?: Integer;            
+            ThresholdsWaitTime?: Minute;            
+            IgnoreMetricsTime?: Minute;            
+            CpuThreshold?: Double;            
+            MemoryThreshold?: Double;            
+            LoadThreshold?: Double;            
+            Alarms?: Strings;            
+        }
+        export interface BlockDeviceMapping {
+            DeviceName?: String;            
+            NoDevice?: String;            
+            VirtualName?: String;            
+            Ebs?: EbsBlockDevice;            
+        }
+        export interface ChefConfiguration {
+            ManageBerkshelf?: Boolean;            
+            BerkshelfVersion?: String;            
+        }
+        export interface CloneStackRequest {
+            SourceStackId: String;            
+            Name?: String;            
+            Region?: String;            
+            VpcId?: String;            
+            Attributes?: StackAttributes;            
+            ServiceRoleArn: String;            
+            DefaultInstanceProfileArn?: String;            
+            DefaultOs?: String;            
+            HostnameTheme?: String;            
+            DefaultAvailabilityZone?: String;            
+            DefaultSubnetId?: String;            
+            CustomJson?: String;            
+            ConfigurationManager?: StackConfigurationManager;            
+            ChefConfiguration?: ChefConfiguration;            
+            UseCustomCookbooks?: Boolean;            
+            UseOpsworksSecurityGroups?: Boolean;            
+            CustomCookbooksSource?: Source;            
+            DefaultSshKeyName?: String;            
+            ClonePermissions?: Boolean;            
+            CloneAppIds?: Strings;            
+            DefaultRootDeviceType?: RootDeviceType;            
+            AgentVersion?: String;            
+        }
+        export interface CloneStackResult {
+            StackId?: String;            
+        }
+        export interface Command {
+            CommandId?: String;            
+            InstanceId?: String;            
+            DeploymentId?: String;            
+            CreatedAt?: DateTime;            
+            AcknowledgedAt?: DateTime;            
+            CompletedAt?: DateTime;            
+            Status?: String;            
+            ExitCode?: Integer;            
+            LogUrl?: String;            
+            Type?: String;            
+        }
+        export interface CreateAppRequest {
+            StackId: String;            
+            Shortname?: String;            
+            Name: String;            
+            Description?: String;            
+            DataSources?: DataSources;            
+            Type: AppType;            
+            AppSource?: Source;            
+            Domains?: Strings;            
+            EnableSsl?: Boolean;            
+            SslConfiguration?: SslConfiguration;            
+            Attributes?: AppAttributes;            
+            Environment?: EnvironmentVariables;            
+        }
+        export interface CreateAppResult {
+            AppId?: String;            
+        }
+        export interface CreateDeploymentRequest {
+            StackId: String;            
+            AppId?: String;            
+            InstanceIds?: Strings;            
+            Command: DeploymentCommand;            
+            Comment?: String;            
+            CustomJson?: String;            
+        }
+        export interface CreateDeploymentResult {
+            DeploymentId?: String;            
+        }
+        export interface CreateInstanceRequest {
+            StackId: String;            
+            LayerIds: Strings;            
+            InstanceType: String;            
+            AutoScalingType?: AutoScalingType;            
+            Hostname?: String;            
+            Os?: String;            
+            AmiId?: String;            
+            SshKeyName?: String;            
+            AvailabilityZone?: String;            
+            VirtualizationType?: String;            
+            SubnetId?: String;            
+            Architecture?: Architecture;            
+            RootDeviceType?: RootDeviceType;            
+            BlockDeviceMappings?: BlockDeviceMappings;            
+            InstallUpdatesOnBoot?: Boolean;            
+            EbsOptimized?: Boolean;            
+            AgentVersion?: String;            
+        }
+        export interface CreateInstanceResult {
+            InstanceId?: String;            
+        }
+        export interface CreateLayerRequest {
+            StackId: String;            
+            Type: LayerType;            
+            Name: String;            
+            Shortname: String;            
+            Attributes?: LayerAttributes;            
+            CustomInstanceProfileArn?: String;            
+            CustomJson?: String;            
+            CustomSecurityGroupIds?: Strings;            
+            Packages?: Strings;            
+            VolumeConfigurations?: VolumeConfigurations;            
+            EnableAutoHealing?: Boolean;            
+            AutoAssignElasticIps?: Boolean;            
+            AutoAssignPublicIps?: Boolean;            
+            CustomRecipes?: Recipes;            
+            InstallUpdatesOnBoot?: Boolean;            
+            UseEbsOptimizedInstances?: Boolean;            
+            LifecycleEventConfiguration?: LifecycleEventConfiguration;            
+        }
+        export interface CreateLayerResult {
+            LayerId?: String;            
+        }
+        export interface CreateStackRequest {
+            Name: String;            
+            Region: String;            
+            VpcId?: String;            
+            Attributes?: StackAttributes;            
+            ServiceRoleArn: String;            
+            DefaultInstanceProfileArn: String;            
+            DefaultOs?: String;            
+            HostnameTheme?: String;            
+            DefaultAvailabilityZone?: String;            
+            DefaultSubnetId?: String;            
+            CustomJson?: String;            
+            ConfigurationManager?: StackConfigurationManager;            
+            ChefConfiguration?: ChefConfiguration;            
+            UseCustomCookbooks?: Boolean;            
+            UseOpsworksSecurityGroups?: Boolean;            
+            CustomCookbooksSource?: Source;            
+            DefaultSshKeyName?: String;            
+            DefaultRootDeviceType?: RootDeviceType;            
+            AgentVersion?: String;            
+        }
+        export interface CreateStackResult {
+            StackId?: String;            
+        }
+        export interface CreateUserProfileRequest {
+            IamUserArn: String;            
+            SshUsername?: String;            
+            SshPublicKey?: String;            
+            AllowSelfManagement?: Boolean;            
+        }
+        export interface CreateUserProfileResult {
+            IamUserArn?: String;            
+        }
+        export interface DataSource {
+            Type?: String;            
+            Arn?: String;            
+            DatabaseName?: String;            
+        }
+        export interface DeleteAppRequest {
+            AppId: String;            
+        }
+        export interface DeleteInstanceRequest {
+            InstanceId: String;            
+            DeleteElasticIp?: Boolean;            
+            DeleteVolumes?: Boolean;            
+        }
+        export interface DeleteLayerRequest {
+            LayerId: String;            
+        }
+        export interface DeleteStackRequest {
+            StackId: String;            
+        }
+        export interface DeleteUserProfileRequest {
+            IamUserArn: String;            
+        }
+        export interface Deployment {
+            DeploymentId?: String;            
+            StackId?: String;            
+            AppId?: String;            
+            CreatedAt?: DateTime;            
+            CompletedAt?: DateTime;            
+            Duration?: Integer;            
+            IamUserArn?: String;            
+            Comment?: String;            
+            Command?: DeploymentCommand;            
+            Status?: String;            
+            CustomJson?: String;            
+            InstanceIds?: Strings;            
+        }
+        export interface DeploymentCommand {
+            Name: DeploymentCommandName;            
+            Args?: DeploymentCommandArgs;            
+        }
+        export interface DeregisterEcsClusterRequest {
+            EcsClusterArn: String;            
+        }
+        export interface DeregisterElasticIpRequest {
+            ElasticIp: String;            
+        }
+        export interface DeregisterInstanceRequest {
+            InstanceId: String;            
+        }
+        export interface DeregisterRdsDbInstanceRequest {
+            RdsDbInstanceArn: String;            
+        }
+        export interface DeregisterVolumeRequest {
+            VolumeId: String;            
+        }
+        export interface DescribeAgentVersionsRequest {
+            StackId?: String;            
+            ConfigurationManager?: StackConfigurationManager;            
+        }
+        export interface DescribeAgentVersionsResult {
+            AgentVersions?: AgentVersions;            
+        }
+        export interface DescribeAppsRequest {
+            StackId?: String;            
+            AppIds?: Strings;            
+        }
+        export interface DescribeAppsResult {
+            Apps?: Apps;            
+        }
+        export interface DescribeCommandsRequest {
+            DeploymentId?: String;            
+            InstanceId?: String;            
+            CommandIds?: Strings;            
+        }
+        export interface DescribeCommandsResult {
+            Commands?: Commands;            
+        }
+        export interface DescribeDeploymentsRequest {
+            StackId?: String;            
+            AppId?: String;            
+            DeploymentIds?: Strings;            
+        }
+        export interface DescribeDeploymentsResult {
+            Deployments?: Deployments;            
+        }
+        export interface DescribeEcsClustersRequest {
+            EcsClusterArns?: Strings;            
+            StackId?: String;            
+            NextToken?: String;            
+            MaxResults?: Integer;            
+        }
+        export interface DescribeEcsClustersResult {
+            EcsClusters?: EcsClusters;            
+            NextToken?: String;            
+        }
+        export interface DescribeElasticIpsRequest {
+            InstanceId?: String;            
+            StackId?: String;            
+            Ips?: Strings;            
+        }
+        export interface DescribeElasticIpsResult {
+            ElasticIps?: ElasticIps;            
+        }
+        export interface DescribeElasticLoadBalancersRequest {
+            StackId?: String;            
+            LayerIds?: Strings;            
+        }
+        export interface DescribeElasticLoadBalancersResult {
+            ElasticLoadBalancers?: ElasticLoadBalancers;            
+        }
+        export interface DescribeInstancesRequest {
+            StackId?: String;            
+            LayerId?: String;            
+            InstanceIds?: Strings;            
+        }
+        export interface DescribeInstancesResult {
+            Instances?: Instances;            
+        }
+        export interface DescribeLayersRequest {
+            StackId?: String;            
+            LayerIds?: Strings;            
+        }
+        export interface DescribeLayersResult {
+            Layers?: Layers;            
+        }
+        export interface DescribeLoadBasedAutoScalingRequest {
+            LayerIds: Strings;            
+        }
+        export interface DescribeLoadBasedAutoScalingResult {
+            LoadBasedAutoScalingConfigurations?: LoadBasedAutoScalingConfigurations;            
+        }
+        export interface DescribeMyUserProfileResult {
+            UserProfile?: SelfUserProfile;            
+        }
+        export interface DescribePermissionsRequest {
+            IamUserArn?: String;            
+            StackId?: String;            
+        }
+        export interface DescribePermissionsResult {
+            Permissions?: Permissions;            
+        }
+        export interface DescribeRaidArraysRequest {
+            InstanceId?: String;            
+            StackId?: String;            
+            RaidArrayIds?: Strings;            
+        }
+        export interface DescribeRaidArraysResult {
+            RaidArrays?: RaidArrays;            
+        }
+        export interface DescribeRdsDbInstancesRequest {
+            StackId: String;            
+            RdsDbInstanceArns?: Strings;            
+        }
+        export interface DescribeRdsDbInstancesResult {
+            RdsDbInstances?: RdsDbInstances;            
+        }
+        export interface DescribeServiceErrorsRequest {
+            StackId?: String;            
+            InstanceId?: String;            
+            ServiceErrorIds?: Strings;            
+        }
+        export interface DescribeServiceErrorsResult {
+            ServiceErrors?: ServiceErrors;            
+        }
+        export interface DescribeStackProvisioningParametersRequest {
+            StackId: String;            
+        }
+        export interface DescribeStackProvisioningParametersResult {
+            AgentInstallerUrl?: String;            
+            Parameters?: Parameters;            
+        }
+        export interface DescribeStackSummaryRequest {
+            StackId: String;            
+        }
+        export interface DescribeStackSummaryResult {
+            StackSummary?: StackSummary;            
+        }
+        export interface DescribeStacksRequest {
+            StackIds?: Strings;            
+        }
+        export interface DescribeStacksResult {
+            Stacks?: Stacks;            
+        }
+        export interface DescribeTimeBasedAutoScalingRequest {
+            InstanceIds: Strings;            
+        }
+        export interface DescribeTimeBasedAutoScalingResult {
+            TimeBasedAutoScalingConfigurations?: TimeBasedAutoScalingConfigurations;            
+        }
+        export interface DescribeUserProfilesRequest {
+            IamUserArns?: Strings;            
+        }
+        export interface DescribeUserProfilesResult {
+            UserProfiles?: UserProfiles;            
+        }
+        export interface DescribeVolumesRequest {
+            InstanceId?: String;            
+            StackId?: String;            
+            RaidArrayId?: String;            
+            VolumeIds?: Strings;            
+        }
+        export interface DescribeVolumesResult {
+            Volumes?: Volumes;            
+        }
+        export interface DetachElasticLoadBalancerRequest {
+            ElasticLoadBalancerName: String;            
+            LayerId: String;            
+        }
+        export interface DisassociateElasticIpRequest {
+            ElasticIp: String;            
+        }
+        export interface EbsBlockDevice {
+            SnapshotId?: String;            
+            Iops?: Integer;            
+            VolumeSize?: Integer;            
+            VolumeType?: VolumeType;            
+            DeleteOnTermination?: Boolean;            
+        }
+        export interface EcsCluster {
+            EcsClusterArn?: String;            
+            EcsClusterName?: String;            
+            StackId?: String;            
+            RegisteredAt?: DateTime;            
+        }
+        export interface ElasticIp {
+            Ip?: String;            
+            Name?: String;            
+            Domain?: String;            
+            Region?: String;            
+            InstanceId?: String;            
+        }
+        export interface ElasticLoadBalancer {
+            ElasticLoadBalancerName?: String;            
+            Region?: String;            
+            DnsName?: String;            
+            StackId?: String;            
+            LayerId?: String;            
+            VpcId?: String;            
+            AvailabilityZones?: Strings;            
+            SubnetIds?: Strings;            
+            Ec2InstanceIds?: Strings;            
+        }
+        export interface EnvironmentVariable {
+            Key: String;            
+            Value: String;            
+            Secure?: Boolean;            
+        }
+        export interface GetHostnameSuggestionRequest {
+            LayerId: String;            
+        }
+        export interface GetHostnameSuggestionResult {
+            LayerId?: String;            
+            Hostname?: String;            
+        }
+        export interface GrantAccessRequest {
+            InstanceId: String;            
+            ValidForInMinutes?: ValidForInMinutes;            
+        }
+        export interface GrantAccessResult {
+            TemporaryCredential?: TemporaryCredential;            
+        }
+        export interface Instance {
+            AgentVersion?: String;            
+            AmiId?: String;            
+            Architecture?: Architecture;            
+            AutoScalingType?: AutoScalingType;            
+            AvailabilityZone?: String;            
+            BlockDeviceMappings?: BlockDeviceMappings;            
+            CreatedAt?: DateTime;            
+            EbsOptimized?: Boolean;            
+            Ec2InstanceId?: String;            
+            EcsClusterArn?: String;            
+            EcsContainerInstanceArn?: String;            
+            ElasticIp?: String;            
+            Hostname?: String;            
+            InfrastructureClass?: String;            
+            InstallUpdatesOnBoot?: Boolean;            
+            InstanceId?: String;            
+            InstanceProfileArn?: String;            
+            InstanceType?: String;            
+            LastServiceErrorId?: String;            
+            LayerIds?: Strings;            
+            Os?: String;            
+            Platform?: String;            
+            PrivateDns?: String;            
+            PrivateIp?: String;            
+            PublicDns?: String;            
+            PublicIp?: String;            
+            RegisteredBy?: String;            
+            ReportedAgentVersion?: String;            
+            ReportedOs?: ReportedOs;            
+            RootDeviceType?: RootDeviceType;            
+            RootDeviceVolumeId?: String;            
+            SecurityGroupIds?: Strings;            
+            SshHostDsaKeyFingerprint?: String;            
+            SshHostRsaKeyFingerprint?: String;            
+            SshKeyName?: String;            
+            StackId?: String;            
+            Status?: String;            
+            SubnetId?: String;            
+            VirtualizationType?: VirtualizationType;            
+        }
+        export interface InstanceIdentity {
+            Document?: String;            
+            Signature?: String;            
+        }
+        export interface InstancesCount {
+            Assigning?: Integer;            
+            Booting?: Integer;            
+            ConnectionLost?: Integer;            
+            Deregistering?: Integer;            
+            Online?: Integer;            
+            Pending?: Integer;            
+            Rebooting?: Integer;            
+            Registered?: Integer;            
+            Registering?: Integer;            
+            Requested?: Integer;            
+            RunningSetup?: Integer;            
+            SetupFailed?: Integer;            
+            ShuttingDown?: Integer;            
+            StartFailed?: Integer;            
+            Stopped?: Integer;            
+            Stopping?: Integer;            
+            Terminated?: Integer;            
+            Terminating?: Integer;            
+            Unassigning?: Integer;            
+        }
+        export interface Layer {
+            StackId?: String;            
+            LayerId?: String;            
+            Type?: LayerType;            
+            Name?: String;            
+            Shortname?: String;            
+            Attributes?: LayerAttributes;            
+            CustomInstanceProfileArn?: String;            
+            CustomJson?: String;            
+            CustomSecurityGroupIds?: Strings;            
+            DefaultSecurityGroupNames?: Strings;            
+            Packages?: Strings;            
+            VolumeConfigurations?: VolumeConfigurations;            
+            EnableAutoHealing?: Boolean;            
+            AutoAssignElasticIps?: Boolean;            
+            AutoAssignPublicIps?: Boolean;            
+            DefaultRecipes?: Recipes;            
+            CustomRecipes?: Recipes;            
+            CreatedAt?: DateTime;            
+            InstallUpdatesOnBoot?: Boolean;            
+            UseEbsOptimizedInstances?: Boolean;            
+            LifecycleEventConfiguration?: LifecycleEventConfiguration;            
+        }
+        export interface LifecycleEventConfiguration {
+            Shutdown?: ShutdownEventConfiguration;            
+        }
+        export interface LoadBasedAutoScalingConfiguration {
+            LayerId?: String;            
+            Enable?: Boolean;            
+            UpScaling?: AutoScalingThresholds;            
+            DownScaling?: AutoScalingThresholds;            
+        }
+        export interface Permission {
+            StackId?: String;            
+            IamUserArn?: String;            
+            AllowSsh?: Boolean;            
+            AllowSudo?: Boolean;            
+            Level?: String;            
+        }
+        export interface RaidArray {
+            RaidArrayId?: String;            
+            InstanceId?: String;            
+            Name?: String;            
+            RaidLevel?: Integer;            
+            NumberOfDisks?: Integer;            
+            Size?: Integer;            
+            Device?: String;            
+            MountPoint?: String;            
+            AvailabilityZone?: String;            
+            CreatedAt?: DateTime;            
+            StackId?: String;            
+            VolumeType?: String;            
+            Iops?: Integer;            
+        }
+        export interface RdsDbInstance {
+            RdsDbInstanceArn?: String;            
+            DbInstanceIdentifier?: String;            
+            DbUser?: String;            
+            DbPassword?: String;            
+            Region?: String;            
+            Address?: String;            
+            Engine?: String;            
+            StackId?: String;            
+            MissingOnRds?: Boolean;            
+        }
+        export interface RebootInstanceRequest {
+            InstanceId: String;            
+        }
+        export interface Recipes {
+            Setup?: Strings;            
+            Configure?: Strings;            
+            Deploy?: Strings;            
+            Undeploy?: Strings;            
+            Shutdown?: Strings;            
+        }
+        export interface RegisterEcsClusterRequest {
+            EcsClusterArn: String;            
+            StackId: String;            
+        }
+        export interface RegisterEcsClusterResult {
+            EcsClusterArn?: String;            
+        }
+        export interface RegisterElasticIpRequest {
+            ElasticIp: String;            
+            StackId: String;            
+        }
+        export interface RegisterElasticIpResult {
+            ElasticIp?: String;            
+        }
+        export interface RegisterInstanceRequest {
+            StackId: String;            
+            Hostname?: String;            
+            PublicIp?: String;            
+            PrivateIp?: String;            
+            RsaPublicKey?: String;            
+            RsaPublicKeyFingerprint?: String;            
+            InstanceIdentity?: InstanceIdentity;            
+        }
+        export interface RegisterInstanceResult {
+            InstanceId?: String;            
+        }
+        export interface RegisterRdsDbInstanceRequest {
+            StackId: String;            
+            RdsDbInstanceArn: String;            
+            DbUser: String;            
+            DbPassword: String;            
+        }
+        export interface RegisterVolumeRequest {
+            Ec2VolumeId?: String;            
+            StackId: String;            
+        }
+        export interface RegisterVolumeResult {
+            VolumeId?: String;            
+        }
+        export interface ReportedOs {
+            Family?: String;            
+            Name?: String;            
+            Version?: String;            
+        }
+        export interface ResourceNotFoundException {
+            message?: String;            
+        }
+        export interface SelfUserProfile {
+            IamUserArn?: String;            
+            Name?: String;            
+            SshUsername?: String;            
+            SshPublicKey?: String;            
+        }
+        export interface ServiceError {
+            ServiceErrorId?: String;            
+            StackId?: String;            
+            InstanceId?: String;            
+            Type?: String;            
+            Message?: String;            
+            CreatedAt?: DateTime;            
+        }
+        export interface SetLoadBasedAutoScalingRequest {
+            LayerId: String;            
+            Enable?: Boolean;            
+            UpScaling?: AutoScalingThresholds;            
+            DownScaling?: AutoScalingThresholds;            
+        }
+        export interface SetPermissionRequest {
+            StackId: String;            
+            IamUserArn: String;            
+            AllowSsh?: Boolean;            
+            AllowSudo?: Boolean;            
+            Level?: String;            
+        }
+        export interface SetTimeBasedAutoScalingRequest {
+            InstanceId: String;            
+            AutoScalingSchedule?: WeeklyAutoScalingSchedule;            
+        }
+        export interface ShutdownEventConfiguration {
+            ExecutionTimeout?: Integer;            
+            DelayUntilElbConnectionsDrained?: Boolean;            
+        }
+        export interface Source {
+            Type?: SourceType;            
+            Url?: String;            
+            Username?: String;            
+            Password?: String;            
+            SshKey?: String;            
+            Revision?: String;            
+        }
+        export interface SslConfiguration {
+            Certificate: String;            
+            PrivateKey: String;            
+            Chain?: String;            
+        }
+        export interface Stack {
+            StackId?: String;            
+            Name?: String;            
+            Arn?: String;            
+            Region?: String;            
+            VpcId?: String;            
+            Attributes?: StackAttributes;            
+            ServiceRoleArn?: String;            
+            DefaultInstanceProfileArn?: String;            
+            DefaultOs?: String;            
+            HostnameTheme?: String;            
+            DefaultAvailabilityZone?: String;            
+            DefaultSubnetId?: String;            
+            CustomJson?: String;            
+            ConfigurationManager?: StackConfigurationManager;            
+            ChefConfiguration?: ChefConfiguration;            
+            UseCustomCookbooks?: Boolean;            
+            UseOpsworksSecurityGroups?: Boolean;            
+            CustomCookbooksSource?: Source;            
+            DefaultSshKeyName?: String;            
+            CreatedAt?: DateTime;            
+            DefaultRootDeviceType?: RootDeviceType;            
+            AgentVersion?: String;            
+        }
+        export interface StackConfigurationManager {
+            Name?: String;            
+            Version?: String;            
+        }
+        export interface StackSummary {
+            StackId?: String;            
+            Name?: String;            
+            Arn?: String;            
+            LayersCount?: Integer;            
+            AppsCount?: Integer;            
+            InstancesCount?: InstancesCount;            
+        }
+        export interface StartInstanceRequest {
+            InstanceId: String;            
+        }
+        export interface StartStackRequest {
+            StackId: String;            
+        }
+        export interface StopInstanceRequest {
+            InstanceId: String;            
+        }
+        export interface StopStackRequest {
+            StackId: String;            
+        }
+        export interface TemporaryCredential {
+            Username?: String;            
+            Password?: String;            
+            ValidForInMinutes?: Integer;            
+            InstanceId?: String;            
+        }
+        export interface TimeBasedAutoScalingConfiguration {
+            InstanceId?: String;            
+            AutoScalingSchedule?: WeeklyAutoScalingSchedule;            
+        }
+        export interface UnassignInstanceRequest {
+            InstanceId: String;            
+        }
+        export interface UnassignVolumeRequest {
+            VolumeId: String;            
+        }
+        export interface UpdateAppRequest {
+            AppId: String;            
+            Name?: String;            
+            Description?: String;            
+            DataSources?: DataSources;            
+            Type?: AppType;            
+            AppSource?: Source;            
+            Domains?: Strings;            
+            EnableSsl?: Boolean;            
+            SslConfiguration?: SslConfiguration;            
+            Attributes?: AppAttributes;            
+            Environment?: EnvironmentVariables;            
+        }
+        export interface UpdateElasticIpRequest {
+            ElasticIp: String;            
+            Name?: String;            
+        }
+        export interface UpdateInstanceRequest {
+            InstanceId: String;            
+            LayerIds?: Strings;            
+            InstanceType?: String;            
+            AutoScalingType?: AutoScalingType;            
+            Hostname?: String;            
+            Os?: String;            
+            AmiId?: String;            
+            SshKeyName?: String;            
+            Architecture?: Architecture;            
+            InstallUpdatesOnBoot?: Boolean;            
+            EbsOptimized?: Boolean;            
+            AgentVersion?: String;            
+        }
+        export interface UpdateLayerRequest {
+            LayerId: String;            
+            Name?: String;            
+            Shortname?: String;            
+            Attributes?: LayerAttributes;            
+            CustomInstanceProfileArn?: String;            
+            CustomJson?: String;            
+            CustomSecurityGroupIds?: Strings;            
+            Packages?: Strings;            
+            VolumeConfigurations?: VolumeConfigurations;            
+            EnableAutoHealing?: Boolean;            
+            AutoAssignElasticIps?: Boolean;            
+            AutoAssignPublicIps?: Boolean;            
+            CustomRecipes?: Recipes;            
+            InstallUpdatesOnBoot?: Boolean;            
+            UseEbsOptimizedInstances?: Boolean;            
+            LifecycleEventConfiguration?: LifecycleEventConfiguration;            
+        }
+        export interface UpdateMyUserProfileRequest {
+            SshPublicKey?: String;            
+        }
+        export interface UpdateRdsDbInstanceRequest {
+            RdsDbInstanceArn: String;            
+            DbUser?: String;            
+            DbPassword?: String;            
+        }
+        export interface UpdateStackRequest {
+            StackId: String;            
+            Name?: String;            
+            Attributes?: StackAttributes;            
+            ServiceRoleArn?: String;            
+            DefaultInstanceProfileArn?: String;            
+            DefaultOs?: String;            
+            HostnameTheme?: String;            
+            DefaultAvailabilityZone?: String;            
+            DefaultSubnetId?: String;            
+            CustomJson?: String;            
+            ConfigurationManager?: StackConfigurationManager;            
+            ChefConfiguration?: ChefConfiguration;            
+            UseCustomCookbooks?: Boolean;            
+            CustomCookbooksSource?: Source;            
+            DefaultSshKeyName?: String;            
+            DefaultRootDeviceType?: RootDeviceType;            
+            UseOpsworksSecurityGroups?: Boolean;            
+            AgentVersion?: String;            
+        }
+        export interface UpdateUserProfileRequest {
+            IamUserArn: String;            
+            SshUsername?: String;            
+            SshPublicKey?: String;            
+            AllowSelfManagement?: Boolean;            
+        }
+        export interface UpdateVolumeRequest {
+            VolumeId: String;            
+            Name?: String;            
+            MountPoint?: String;            
+        }
+        export interface UserProfile {
+            IamUserArn?: String;            
+            Name?: String;            
+            SshUsername?: String;            
+            SshPublicKey?: String;            
+            AllowSelfManagement?: Boolean;            
+        }
+        export interface ValidationException {
+            message?: String;            
+        }
+        export interface Volume {
+            VolumeId?: String;            
+            Ec2VolumeId?: String;            
+            Name?: String;            
+            RaidArrayId?: String;            
+            InstanceId?: String;            
+            Status?: String;            
+            Size?: Integer;            
+            Device?: String;            
+            MountPoint?: String;            
+            Region?: String;            
+            AvailabilityZone?: String;            
+            VolumeType?: String;            
+            Iops?: Integer;            
+        }
+        export interface VolumeConfiguration {
+            MountPoint: String;            
+            RaidLevel?: Integer;            
+            NumberOfDisks: Integer;            
+            Size: Integer;            
+            VolumeType?: String;            
+            Iops?: Integer;            
+        }
+        export interface WeeklyAutoScalingSchedule {
+            Monday?: DailyAutoScalingSchedule;            
+            Tuesday?: DailyAutoScalingSchedule;            
+            Wednesday?: DailyAutoScalingSchedule;            
+            Thursday?: DailyAutoScalingSchedule;            
+            Friday?: DailyAutoScalingSchedule;            
+            Saturday?: DailyAutoScalingSchedule;            
+            Sunday?: DailyAutoScalingSchedule;            
+        }
 
-    export interface OpsWorksUserProfile {
-        IamUserArn?: OpsWorksString;
-        Name?: OpsWorksString;
-        SshUsername?: OpsWorksString;
-        SshPublicKey?: OpsWorksString;
-        AllowSelfManagement?: OpsWorksBoolean;
     }
-
-    export type OpsWorksUserProfiles = Array<OpsWorksUserProfile>;
-    export type OpsWorksValidForInMinutes = number;
-    export interface OpsWorksValidationException {
-        message?: OpsWorksString;
-    }
-
-    export type OpsWorksVirtualizationType = string;
-    export interface OpsWorksVolume {
-        VolumeId?: OpsWorksString;
-        Ec2VolumeId?: OpsWorksString;
-        Name?: OpsWorksString;
-        RaidArrayId?: OpsWorksString;
-        InstanceId?: OpsWorksString;
-        Status?: OpsWorksString;
-        Size?: OpsWorksInteger;
-        Device?: OpsWorksString;
-        MountPoint?: OpsWorksString;
-        Region?: OpsWorksString;
-        AvailabilityZone?: OpsWorksString;
-        VolumeType?: OpsWorksString;
-        Iops?: OpsWorksInteger;
-    }
-
-    export interface OpsWorksVolumeConfiguration {
-        MountPoint: OpsWorksString;
-        RaidLevel?: OpsWorksInteger;
-        NumberOfDisks: OpsWorksInteger;
-        Size: OpsWorksInteger;
-        VolumeType?: OpsWorksString;
-        Iops?: OpsWorksInteger;
-    }
-
-    export type OpsWorksVolumeConfigurations = Array<OpsWorksVolumeConfiguration>;
-    export type OpsWorksVolumeType = string;
-    export type OpsWorksVolumes = Array<OpsWorksVolume>;
-    export interface OpsWorksWeeklyAutoScalingSchedule {
-        Monday?: OpsWorksDailyAutoScalingSchedule;
-        Tuesday?: OpsWorksDailyAutoScalingSchedule;
-        Wednesday?: OpsWorksDailyAutoScalingSchedule;
-        Thursday?: OpsWorksDailyAutoScalingSchedule;
-        Friday?: OpsWorksDailyAutoScalingSchedule;
-        Saturday?: OpsWorksDailyAutoScalingSchedule;
-        Sunday?: OpsWorksDailyAutoScalingSchedule;
-    }
-
 }

--- a/output/aws-rds.d.ts
+++ b/output/aws-rds.d.ts
@@ -6,1109 +6,936 @@ declare module "aws-sdk" {
 
     export class RDS extends Service {
       constructor(options?: any);
-      addSourceIdentifierToSubscription(params: RDSAddSourceIdentifierToSubscriptionMessage, callback?: (err: RDSSubscriptionNotFoundFault|RDSSourceNotFoundFault|any, data: RDSAddSourceIdentifierToSubscriptionResult|any) => void): Request;
-      addTagsToResource(params: RDSAddTagsToResourceMessage, callback?: (err: RDSDBInstanceNotFoundFault|RDSDBSnapshotNotFoundFault|any, data: any) => void): Request;
-      authorizeDBSecurityGroupIngress(params: RDSAuthorizeDBSecurityGroupIngressMessage, callback?: (err: RDSDBSecurityGroupNotFoundFault|RDSInvalidDBSecurityGroupStateFault|RDSAuthorizationAlreadyExistsFault|RDSAuthorizationQuotaExceededFault|any, data: RDSAuthorizeDBSecurityGroupIngressResult|any) => void): Request;
-      copyDBSnapshot(params: RDSCopyDBSnapshotMessage, callback?: (err: RDSDBSnapshotAlreadyExistsFault|RDSDBSnapshotNotFoundFault|RDSInvalidDBSnapshotStateFault|RDSSnapshotQuotaExceededFault|any, data: RDSCopyDBSnapshotResult|any) => void): Request;
-      createDBInstance(params: RDSCreateDBInstanceMessage, callback?: (err: RDSDBInstanceAlreadyExistsFault|RDSInsufficientDBInstanceCapacityFault|RDSDBParameterGroupNotFoundFault|RDSDBSecurityGroupNotFoundFault|RDSInstanceQuotaExceededFault|RDSStorageQuotaExceededFault|RDSDBSubnetGroupNotFoundFault|RDSDBSubnetGroupDoesNotCoverEnoughAZs|RDSInvalidSubnet|RDSInvalidVPCNetworkStateFault|RDSProvisionedIopsNotAvailableInAZFault|RDSOptionGroupNotFoundFault|any, data: RDSCreateDBInstanceResult|any) => void): Request;
-      createDBInstanceReadReplica(params: RDSCreateDBInstanceReadReplicaMessage, callback?: (err: RDSDBInstanceAlreadyExistsFault|RDSInsufficientDBInstanceCapacityFault|RDSDBParameterGroupNotFoundFault|RDSDBSecurityGroupNotFoundFault|RDSInstanceQuotaExceededFault|RDSStorageQuotaExceededFault|RDSDBInstanceNotFoundFault|RDSInvalidDBInstanceStateFault|RDSDBSubnetGroupNotFoundFault|RDSDBSubnetGroupDoesNotCoverEnoughAZs|RDSInvalidSubnet|RDSInvalidVPCNetworkStateFault|RDSProvisionedIopsNotAvailableInAZFault|RDSOptionGroupNotFoundFault|any, data: RDSCreateDBInstanceReadReplicaResult|any) => void): Request;
-      createDBParameterGroup(params: RDSCreateDBParameterGroupMessage, callback?: (err: RDSDBParameterGroupQuotaExceededFault|RDSDBParameterGroupAlreadyExistsFault|any, data: RDSCreateDBParameterGroupResult|any) => void): Request;
-      createDBSecurityGroup(params: RDSCreateDBSecurityGroupMessage, callback?: (err: RDSDBSecurityGroupAlreadyExistsFault|RDSDBSecurityGroupQuotaExceededFault|RDSDBSecurityGroupNotSupportedFault|any, data: RDSCreateDBSecurityGroupResult|any) => void): Request;
-      createDBSnapshot(params: RDSCreateDBSnapshotMessage, callback?: (err: RDSDBSnapshotAlreadyExistsFault|RDSInvalidDBInstanceStateFault|RDSDBInstanceNotFoundFault|RDSSnapshotQuotaExceededFault|any, data: RDSCreateDBSnapshotResult|any) => void): Request;
-      createDBSubnetGroup(params: RDSCreateDBSubnetGroupMessage, callback?: (err: RDSDBSubnetGroupAlreadyExistsFault|RDSDBSubnetGroupQuotaExceededFault|RDSDBSubnetQuotaExceededFault|RDSDBSubnetGroupDoesNotCoverEnoughAZs|RDSInvalidSubnet|any, data: RDSCreateDBSubnetGroupResult|any) => void): Request;
-      createEventSubscription(params: RDSCreateEventSubscriptionMessage, callback?: (err: RDSEventSubscriptionQuotaExceededFault|RDSSubscriptionAlreadyExistFault|RDSSNSInvalidTopicFault|RDSSNSNoAuthorizationFault|RDSSNSTopicArnNotFoundFault|RDSSubscriptionCategoryNotFoundFault|RDSSourceNotFoundFault|any, data: RDSCreateEventSubscriptionResult|any) => void): Request;
-      createOptionGroup(params: RDSCreateOptionGroupMessage, callback?: (err: RDSOptionGroupAlreadyExistsFault|RDSOptionGroupQuotaExceededFault|any, data: RDSCreateOptionGroupResult|any) => void): Request;
-      deleteDBInstance(params: RDSDeleteDBInstanceMessage, callback?: (err: RDSDBInstanceNotFoundFault|RDSInvalidDBInstanceStateFault|RDSDBSnapshotAlreadyExistsFault|RDSSnapshotQuotaExceededFault|any, data: RDSDeleteDBInstanceResult|any) => void): Request;
-      deleteDBParameterGroup(params: RDSDeleteDBParameterGroupMessage, callback?: (err: RDSInvalidDBParameterGroupStateFault|RDSDBParameterGroupNotFoundFault|any, data: any) => void): Request;
-      deleteDBSecurityGroup(params: RDSDeleteDBSecurityGroupMessage, callback?: (err: RDSInvalidDBSecurityGroupStateFault|RDSDBSecurityGroupNotFoundFault|any, data: any) => void): Request;
-      deleteDBSnapshot(params: RDSDeleteDBSnapshotMessage, callback?: (err: RDSInvalidDBSnapshotStateFault|RDSDBSnapshotNotFoundFault|any, data: RDSDeleteDBSnapshotResult|any) => void): Request;
-      deleteDBSubnetGroup(params: RDSDeleteDBSubnetGroupMessage, callback?: (err: RDSInvalidDBSubnetGroupStateFault|RDSInvalidDBSubnetStateFault|RDSDBSubnetGroupNotFoundFault|any, data: any) => void): Request;
-      deleteEventSubscription(params: RDSDeleteEventSubscriptionMessage, callback?: (err: RDSSubscriptionNotFoundFault|RDSInvalidEventSubscriptionStateFault|any, data: RDSDeleteEventSubscriptionResult|any) => void): Request;
-      deleteOptionGroup(params: RDSDeleteOptionGroupMessage, callback?: (err: RDSOptionGroupNotFoundFault|RDSInvalidOptionGroupStateFault|any, data: any) => void): Request;
-      describeDBEngineVersions(params: RDSDescribeDBEngineVersionsMessage, callback?: (err: any, data: RDSDBEngineVersionMessage|any) => void): Request;
-      describeDBInstances(params: RDSDescribeDBInstancesMessage, callback?: (err: RDSDBInstanceNotFoundFault|any, data: RDSDBInstanceMessage|any) => void): Request;
-      describeDBParameterGroups(params: RDSDescribeDBParameterGroupsMessage, callback?: (err: RDSDBParameterGroupNotFoundFault|any, data: RDSDBParameterGroupsMessage|any) => void): Request;
-      describeDBParameters(params: RDSDescribeDBParametersMessage, callback?: (err: RDSDBParameterGroupNotFoundFault|any, data: RDSDBParameterGroupDetails|any) => void): Request;
-      describeDBSecurityGroups(params: RDSDescribeDBSecurityGroupsMessage, callback?: (err: RDSDBSecurityGroupNotFoundFault|any, data: RDSDBSecurityGroupMessage|any) => void): Request;
-      describeDBSnapshots(params: RDSDescribeDBSnapshotsMessage, callback?: (err: RDSDBSnapshotNotFoundFault|any, data: RDSDBSnapshotMessage|any) => void): Request;
-      describeDBSubnetGroups(params: RDSDescribeDBSubnetGroupsMessage, callback?: (err: RDSDBSubnetGroupNotFoundFault|any, data: RDSDBSubnetGroupMessage|any) => void): Request;
-      describeEngineDefaultParameters(params: RDSDescribeEngineDefaultParametersMessage, callback?: (err: any, data: RDSDescribeEngineDefaultParametersResult|any) => void): Request;
-      describeEventCategories(params: RDSDescribeEventCategoriesMessage, callback?: (err: any, data: RDSEventCategoriesMessage|any) => void): Request;
-      describeEventSubscriptions(params: RDSDescribeEventSubscriptionsMessage, callback?: (err: RDSSubscriptionNotFoundFault|any, data: RDSEventSubscriptionsMessage|any) => void): Request;
-      describeEvents(params: RDSDescribeEventsMessage, callback?: (err: any, data: RDSEventsMessage|any) => void): Request;
-      describeOptionGroupOptions(params: RDSDescribeOptionGroupOptionsMessage, callback?: (err: any, data: RDSOptionGroupOptionsMessage|any) => void): Request;
-      describeOptionGroups(params: RDSDescribeOptionGroupsMessage, callback?: (err: RDSOptionGroupNotFoundFault|any, data: RDSOptionGroups|any) => void): Request;
-      describeOrderableDBInstanceOptions(params: RDSDescribeOrderableDBInstanceOptionsMessage, callback?: (err: any, data: RDSOrderableDBInstanceOptionsMessage|any) => void): Request;
-      describeReservedDBInstances(params: RDSDescribeReservedDBInstancesMessage, callback?: (err: RDSReservedDBInstanceNotFoundFault|any, data: RDSReservedDBInstanceMessage|any) => void): Request;
-      describeReservedDBInstancesOfferings(params: RDSDescribeReservedDBInstancesOfferingsMessage, callback?: (err: RDSReservedDBInstancesOfferingNotFoundFault|any, data: RDSReservedDBInstancesOfferingMessage|any) => void): Request;
-      listTagsForResource(params: RDSListTagsForResourceMessage, callback?: (err: RDSDBInstanceNotFoundFault|RDSDBSnapshotNotFoundFault|any, data: RDSTagListMessage|any) => void): Request;
-      modifyDBInstance(params: RDSModifyDBInstanceMessage, callback?: (err: RDSInvalidDBInstanceStateFault|RDSInvalidDBSecurityGroupStateFault|RDSDBInstanceAlreadyExistsFault|RDSDBInstanceNotFoundFault|RDSDBSecurityGroupNotFoundFault|RDSDBParameterGroupNotFoundFault|RDSInsufficientDBInstanceCapacityFault|RDSStorageQuotaExceededFault|RDSInvalidVPCNetworkStateFault|RDSProvisionedIopsNotAvailableInAZFault|RDSOptionGroupNotFoundFault|RDSDBUpgradeDependencyFailureFault|any, data: RDSModifyDBInstanceResult|any) => void): Request;
-      modifyDBParameterGroup(params: RDSModifyDBParameterGroupMessage, callback?: (err: RDSDBParameterGroupNotFoundFault|RDSInvalidDBParameterGroupStateFault|any, data: RDSDBParameterGroupNameMessage|any) => void): Request;
-      modifyDBSubnetGroup(params: RDSModifyDBSubnetGroupMessage, callback?: (err: RDSDBSubnetGroupNotFoundFault|RDSDBSubnetQuotaExceededFault|RDSSubnetAlreadyInUse|RDSDBSubnetGroupDoesNotCoverEnoughAZs|RDSInvalidSubnet|any, data: RDSModifyDBSubnetGroupResult|any) => void): Request;
-      modifyEventSubscription(params: RDSModifyEventSubscriptionMessage, callback?: (err: RDSEventSubscriptionQuotaExceededFault|RDSSubscriptionNotFoundFault|RDSSNSInvalidTopicFault|RDSSNSNoAuthorizationFault|RDSSNSTopicArnNotFoundFault|RDSSubscriptionCategoryNotFoundFault|any, data: RDSModifyEventSubscriptionResult|any) => void): Request;
-      modifyOptionGroup(params: RDSModifyOptionGroupMessage, callback?: (err: RDSInvalidOptionGroupStateFault|RDSOptionGroupNotFoundFault|any, data: RDSModifyOptionGroupResult|any) => void): Request;
-      promoteReadReplica(params: RDSPromoteReadReplicaMessage, callback?: (err: RDSInvalidDBInstanceStateFault|RDSDBInstanceNotFoundFault|any, data: RDSPromoteReadReplicaResult|any) => void): Request;
-      purchaseReservedDBInstancesOffering(params: RDSPurchaseReservedDBInstancesOfferingMessage, callback?: (err: RDSReservedDBInstancesOfferingNotFoundFault|RDSReservedDBInstanceAlreadyExistsFault|RDSReservedDBInstanceQuotaExceededFault|any, data: RDSPurchaseReservedDBInstancesOfferingResult|any) => void): Request;
-      rebootDBInstance(params: RDSRebootDBInstanceMessage, callback?: (err: RDSInvalidDBInstanceStateFault|RDSDBInstanceNotFoundFault|any, data: RDSRebootDBInstanceResult|any) => void): Request;
-      removeSourceIdentifierFromSubscription(params: RDSRemoveSourceIdentifierFromSubscriptionMessage, callback?: (err: RDSSubscriptionNotFoundFault|RDSSourceNotFoundFault|any, data: RDSRemoveSourceIdentifierFromSubscriptionResult|any) => void): Request;
-      removeTagsFromResource(params: RDSRemoveTagsFromResourceMessage, callback?: (err: RDSDBInstanceNotFoundFault|RDSDBSnapshotNotFoundFault|any, data: any) => void): Request;
-      resetDBParameterGroup(params: RDSResetDBParameterGroupMessage, callback?: (err: RDSInvalidDBParameterGroupStateFault|RDSDBParameterGroupNotFoundFault|any, data: RDSDBParameterGroupNameMessage|any) => void): Request;
-      restoreDBInstanceFromDBSnapshot(params: RDSRestoreDBInstanceFromDBSnapshotMessage, callback?: (err: RDSDBInstanceAlreadyExistsFault|RDSDBSnapshotNotFoundFault|RDSInstanceQuotaExceededFault|RDSInsufficientDBInstanceCapacityFault|RDSInvalidDBSnapshotStateFault|RDSStorageQuotaExceededFault|RDSInvalidVPCNetworkStateFault|RDSInvalidRestoreFault|RDSDBSubnetGroupNotFoundFault|RDSDBSubnetGroupDoesNotCoverEnoughAZs|RDSInvalidSubnet|RDSProvisionedIopsNotAvailableInAZFault|RDSOptionGroupNotFoundFault|any, data: RDSRestoreDBInstanceFromDBSnapshotResult|any) => void): Request;
-      restoreDBInstanceToPointInTime(params: RDSRestoreDBInstanceToPointInTimeMessage, callback?: (err: RDSDBInstanceAlreadyExistsFault|RDSDBInstanceNotFoundFault|RDSInstanceQuotaExceededFault|RDSInsufficientDBInstanceCapacityFault|RDSInvalidDBInstanceStateFault|RDSPointInTimeRestoreNotEnabledFault|RDSStorageQuotaExceededFault|RDSInvalidVPCNetworkStateFault|RDSInvalidRestoreFault|RDSDBSubnetGroupNotFoundFault|RDSDBSubnetGroupDoesNotCoverEnoughAZs|RDSInvalidSubnet|RDSProvisionedIopsNotAvailableInAZFault|RDSOptionGroupNotFoundFault|any, data: RDSRestoreDBInstanceToPointInTimeResult|any) => void): Request;
-      revokeDBSecurityGroupIngress(params: RDSRevokeDBSecurityGroupIngressMessage, callback?: (err: RDSDBSecurityGroupNotFoundFault|RDSAuthorizationNotFoundFault|RDSInvalidDBSecurityGroupStateFault|any, data: RDSRevokeDBSecurityGroupIngressResult|any) => void): Request;
-    }
-
-    export interface RDSAddSourceIdentifierToSubscriptionMessage {
-        SubscriptionName: RDSString;
-        SourceIdentifier: RDSString;
-    }
-
-    export interface RDSAddTagsToResourceMessage {
-        ResourceName: RDSString;
-        Tags: RDSTagList;
-    }
-
-    export type RDSApplyMethod = string;
-    export interface RDSAuthorizationAlreadyExistsFault {
-    }
-
-    export interface RDSAuthorizationNotFoundFault {
-    }
-
-    export interface RDSAuthorizationQuotaExceededFault {
-    }
-
-    export interface RDSAuthorizeDBSecurityGroupIngressMessage {
-        DBSecurityGroupName: RDSString;
-        CIDRIP?: RDSString;
-        EC2SecurityGroupName?: RDSString;
-        EC2SecurityGroupId?: RDSString;
-        EC2SecurityGroupOwnerId?: RDSString;
-    }
-
-    export interface RDSAvailabilityZone {
-        Name?: RDSString;
-        ProvisionedIopsCapable?: RDSBoolean;
-    }
-
-    export type RDSAvailabilityZoneList = Array<RDSAvailabilityZone>;
-    export type RDSBoolean = boolean;
-    export type RDSBooleanOptional = boolean;
-    export interface RDSCharacterSet {
-        CharacterSetName?: RDSString;
-        CharacterSetDescription?: RDSString;
-    }
-
-    export interface RDSCopyDBSnapshotMessage {
-        SourceDBSnapshotIdentifier: RDSString;
-        TargetDBSnapshotIdentifier: RDSString;
-    }
-
-    export interface RDSCreateDBInstanceMessage {
-        DBName?: RDSString;
-        DBInstanceIdentifier: RDSString;
-        AllocatedStorage: RDSIntegerOptional;
-        DBInstanceClass: RDSString;
-        Engine: RDSString;
-        MasterUsername: RDSString;
-        MasterUserPassword: RDSString;
-        DBSecurityGroups?: RDSDBSecurityGroupNameList;
-        VpcSecurityGroupIds?: RDSVpcSecurityGroupIdList;
-        AvailabilityZone?: RDSString;
-        DBSubnetGroupName?: RDSString;
-        PreferredMaintenanceWindow?: RDSString;
-        DBParameterGroupName?: RDSString;
-        BackupRetentionPeriod?: RDSIntegerOptional;
-        PreferredBackupWindow?: RDSString;
-        Port?: RDSIntegerOptional;
-        MultiAZ?: RDSBooleanOptional;
-        EngineVersion?: RDSString;
-        AutoMinorVersionUpgrade?: RDSBooleanOptional;
-        LicenseModel?: RDSString;
-        Iops?: RDSIntegerOptional;
-        OptionGroupName?: RDSString;
-        CharacterSetName?: RDSString;
-        PubliclyAccessible?: RDSBooleanOptional;
-    }
-
-    export interface RDSCreateDBInstanceReadReplicaMessage {
-        DBInstanceIdentifier: RDSString;
-        SourceDBInstanceIdentifier: RDSString;
-        DBInstanceClass?: RDSString;
-        AvailabilityZone?: RDSString;
-        Port?: RDSIntegerOptional;
-        AutoMinorVersionUpgrade?: RDSBooleanOptional;
-        Iops?: RDSIntegerOptional;
-        OptionGroupName?: RDSString;
-        PubliclyAccessible?: RDSBooleanOptional;
-    }
-
-    export interface RDSCreateDBParameterGroupMessage {
-        DBParameterGroupName: RDSString;
-        DBParameterGroupFamily: RDSString;
-        Description: RDSString;
-    }
-
-    export interface RDSCreateDBSecurityGroupMessage {
-        DBSecurityGroupName: RDSString;
-        DBSecurityGroupDescription: RDSString;
-    }
-
-    export interface RDSCreateDBSnapshotMessage {
-        DBSnapshotIdentifier: RDSString;
-        DBInstanceIdentifier: RDSString;
-    }
-
-    export interface RDSCreateDBSubnetGroupMessage {
-        DBSubnetGroupName: RDSString;
-        DBSubnetGroupDescription: RDSString;
-        SubnetIds: RDSSubnetIdentifierList;
-    }
-
-    export interface RDSCreateEventSubscriptionMessage {
-        SubscriptionName: RDSString;
-        SnsTopicArn: RDSString;
-        SourceType?: RDSString;
-        EventCategories?: RDSEventCategoriesList;
-        SourceIds?: RDSSourceIdsList;
-        Enabled?: RDSBooleanOptional;
-    }
-
-    export interface RDSCreateOptionGroupMessage {
-        OptionGroupName: RDSString;
-        EngineName: RDSString;
-        MajorEngineVersion: RDSString;
-        OptionGroupDescription: RDSString;
-    }
-
-    export interface RDSDBEngineVersion {
-        Engine?: RDSString;
-        EngineVersion?: RDSString;
-        DBParameterGroupFamily?: RDSString;
-        DBEngineDescription?: RDSString;
-        DBEngineVersionDescription?: RDSString;
-        DefaultCharacterSet?: RDSCharacterSet;
-        SupportedCharacterSets?: RDSSupportedCharacterSetsList;
-    }
-
-    export type RDSDBEngineVersionList = Array<RDSDBEngineVersion>;
-    export interface RDSDBEngineVersionMessage {
-        Marker?: RDSString;
-        DBEngineVersions?: RDSDBEngineVersionList;
-    }
-
-    export interface RDSDBInstance {
-        DBInstanceIdentifier?: RDSString;
-        DBInstanceClass?: RDSString;
-        Engine?: RDSString;
-        DBInstanceStatus?: RDSString;
-        MasterUsername?: RDSString;
-        DBName?: RDSString;
-        Endpoint?: RDSEndpoint;
-        AllocatedStorage?: RDSInteger;
-        InstanceCreateTime?: RDSTStamp;
-        PreferredBackupWindow?: RDSString;
-        BackupRetentionPeriod?: RDSInteger;
-        DBSecurityGroups?: RDSDBSecurityGroupMembershipList;
-        VpcSecurityGroups?: RDSVpcSecurityGroupMembershipList;
-        DBParameterGroups?: RDSDBParameterGroupStatusList;
-        AvailabilityZone?: RDSString;
-        DBSubnetGroup?: RDSDBSubnetGroup;
-        PreferredMaintenanceWindow?: RDSString;
-        PendingModifiedValues?: RDSPendingModifiedValues;
-        LatestRestorableTime?: RDSTStamp;
-        MultiAZ?: RDSBoolean;
-        EngineVersion?: RDSString;
-        AutoMinorVersionUpgrade?: RDSBoolean;
-        ReadReplicaSourceDBInstanceIdentifier?: RDSString;
-        ReadReplicaDBInstanceIdentifiers?: RDSReadReplicaDBInstanceIdentifierList;
-        LicenseModel?: RDSString;
-        Iops?: RDSIntegerOptional;
-        OptionGroupMembership?: RDSOptionGroupMembership;
-        CharacterSetName?: RDSString;
-        SecondaryAvailabilityZone?: RDSString;
-        PubliclyAccessible?: RDSBoolean;
-    }
-
-    export interface RDSDBInstanceAlreadyExistsFault {
-    }
-
-    export type RDSDBInstanceList = Array<RDSDBInstance>;
-    export interface RDSDBInstanceMessage {
-        Marker?: RDSString;
-        DBInstances?: RDSDBInstanceList;
-    }
-
-    export interface RDSDBInstanceNotFoundFault {
-    }
-
-    export interface RDSDBParameterGroup {
-        DBParameterGroupName?: RDSString;
-        DBParameterGroupFamily?: RDSString;
-        Description?: RDSString;
-    }
-
-    export interface RDSDBParameterGroupAlreadyExistsFault {
-    }
-
-    export interface RDSDBParameterGroupDetails {
-        Parameters?: RDSParametersList;
-        Marker?: RDSString;
-    }
-
-    export type RDSDBParameterGroupList = Array<RDSDBParameterGroup>;
-    export interface RDSDBParameterGroupNameMessage {
-        DBParameterGroupName?: RDSString;
-    }
-
-    export interface RDSDBParameterGroupNotFoundFault {
-    }
-
-    export interface RDSDBParameterGroupQuotaExceededFault {
-    }
-
-    export interface RDSDBParameterGroupStatus {
-        DBParameterGroupName?: RDSString;
-        ParameterApplyStatus?: RDSString;
-    }
-
-    export type RDSDBParameterGroupStatusList = Array<RDSDBParameterGroupStatus>;
-    export interface RDSDBParameterGroupsMessage {
-        Marker?: RDSString;
-        DBParameterGroups?: RDSDBParameterGroupList;
-    }
-
-    export interface RDSDBSecurityGroup {
-        OwnerId?: RDSString;
-        DBSecurityGroupName?: RDSString;
-        DBSecurityGroupDescription?: RDSString;
-        VpcId?: RDSString;
-        EC2SecurityGroups?: RDSEC2SecurityGroupList;
-        IPRanges?: RDSIPRangeList;
-    }
-
-    export interface RDSDBSecurityGroupAlreadyExistsFault {
-    }
-
-    export interface RDSDBSecurityGroupMembership {
-        DBSecurityGroupName?: RDSString;
-        Status?: RDSString;
-    }
-
-    export type RDSDBSecurityGroupMembershipList = Array<RDSDBSecurityGroupMembership>;
-    export interface RDSDBSecurityGroupMessage {
-        Marker?: RDSString;
-        DBSecurityGroups?: RDSDBSecurityGroups;
-    }
-
-    export type RDSDBSecurityGroupNameList = Array<RDSString>;
-    export interface RDSDBSecurityGroupNotFoundFault {
-    }
-
-    export interface RDSDBSecurityGroupNotSupportedFault {
-    }
-
-    export interface RDSDBSecurityGroupQuotaExceededFault {
-    }
-
-    export type RDSDBSecurityGroups = Array<RDSDBSecurityGroup>;
-    export interface RDSDBSnapshot {
-        DBSnapshotIdentifier?: RDSString;
-        DBInstanceIdentifier?: RDSString;
-        SnapshotCreateTime?: RDSTStamp;
-        Engine?: RDSString;
-        AllocatedStorage?: RDSInteger;
-        Status?: RDSString;
-        Port?: RDSInteger;
-        AvailabilityZone?: RDSString;
-        VpcId?: RDSString;
-        InstanceCreateTime?: RDSTStamp;
-        MasterUsername?: RDSString;
-        EngineVersion?: RDSString;
-        LicenseModel?: RDSString;
-        SnapshotType?: RDSString;
-        Iops?: RDSIntegerOptional;
-    }
-
-    export interface RDSDBSnapshotAlreadyExistsFault {
-    }
-
-    export type RDSDBSnapshotList = Array<RDSDBSnapshot>;
-    export interface RDSDBSnapshotMessage {
-        Marker?: RDSString;
-        DBSnapshots?: RDSDBSnapshotList;
-    }
-
-    export interface RDSDBSnapshotNotFoundFault {
-    }
-
-    export interface RDSDBSubnetGroup {
-        DBSubnetGroupName?: RDSString;
-        DBSubnetGroupDescription?: RDSString;
-        VpcId?: RDSString;
-        SubnetGroupStatus?: RDSString;
-        Subnets?: RDSSubnetList;
-    }
-
-    export interface RDSDBSubnetGroupAlreadyExistsFault {
-    }
-
-    export interface RDSDBSubnetGroupDoesNotCoverEnoughAZs {
-    }
-
-    export interface RDSDBSubnetGroupMessage {
-        Marker?: RDSString;
-        DBSubnetGroups?: RDSDBSubnetGroups;
-    }
-
-    export interface RDSDBSubnetGroupNotFoundFault {
-    }
-
-    export interface RDSDBSubnetGroupQuotaExceededFault {
-    }
-
-    export type RDSDBSubnetGroups = Array<RDSDBSubnetGroup>;
-    export interface RDSDBSubnetQuotaExceededFault {
-    }
-
-    export interface RDSDBUpgradeDependencyFailureFault {
-    }
-
-    export interface RDSDeleteDBInstanceMessage {
-        DBInstanceIdentifier: RDSString;
-        SkipFinalSnapshot?: RDSBoolean;
-        FinalDBSnapshotIdentifier?: RDSString;
-    }
-
-    export interface RDSDeleteDBParameterGroupMessage {
-        DBParameterGroupName: RDSString;
-    }
-
-    export interface RDSDeleteDBSecurityGroupMessage {
-        DBSecurityGroupName: RDSString;
-    }
-
-    export interface RDSDeleteDBSnapshotMessage {
-        DBSnapshotIdentifier: RDSString;
-    }
-
-    export interface RDSDeleteDBSubnetGroupMessage {
-        DBSubnetGroupName: RDSString;
-    }
-
-    export interface RDSDeleteEventSubscriptionMessage {
-        SubscriptionName: RDSString;
-    }
-
-    export interface RDSDeleteOptionGroupMessage {
-        OptionGroupName: RDSString;
-    }
-
-    export interface RDSDescribeDBEngineVersionsMessage {
-        Engine?: RDSString;
-        EngineVersion?: RDSString;
-        DBParameterGroupFamily?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-        DefaultOnly?: RDSBoolean;
-        ListSupportedCharacterSets?: RDSBooleanOptional;
-    }
-
-    export interface RDSDescribeDBInstancesMessage {
-        DBInstanceIdentifier?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeDBParameterGroupsMessage {
-        DBParameterGroupName?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeDBParametersMessage {
-        DBParameterGroupName: RDSString;
-        Source?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeDBSecurityGroupsMessage {
-        DBSecurityGroupName?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeDBSnapshotsMessage {
-        DBInstanceIdentifier?: RDSString;
-        DBSnapshotIdentifier?: RDSString;
-        SnapshotType?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeDBSubnetGroupsMessage {
-        DBSubnetGroupName?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeEngineDefaultParametersMessage {
-        DBParameterGroupFamily: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeEventCategoriesMessage {
-        SourceType?: RDSString;
-    }
-
-    export interface RDSDescribeEventSubscriptionsMessage {
-        SubscriptionName?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeEventsMessage {
-        SourceIdentifier?: RDSString;
-        SourceType?: RDSSourceType;
-        StartTime?: RDSTStamp;
-        EndTime?: RDSTStamp;
-        Duration?: RDSIntegerOptional;
-        EventCategories?: RDSEventCategoriesList;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeOptionGroupOptionsMessage {
-        EngineName: RDSString;
-        MajorEngineVersion?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeOptionGroupsMessage {
-        OptionGroupName?: RDSString;
-        Marker?: RDSString;
-        MaxRecords?: RDSIntegerOptional;
-        EngineName?: RDSString;
-        MajorEngineVersion?: RDSString;
-    }
-
-    export interface RDSDescribeOrderableDBInstanceOptionsMessage {
-        Engine: RDSString;
-        EngineVersion?: RDSString;
-        DBInstanceClass?: RDSString;
-        LicenseModel?: RDSString;
-        Vpc?: RDSBooleanOptional;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeReservedDBInstancesMessage {
-        ReservedDBInstanceId?: RDSString;
-        ReservedDBInstancesOfferingId?: RDSString;
-        DBInstanceClass?: RDSString;
-        Duration?: RDSString;
-        ProductDescription?: RDSString;
-        OfferingType?: RDSString;
-        MultiAZ?: RDSBooleanOptional;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export interface RDSDescribeReservedDBInstancesOfferingsMessage {
-        ReservedDBInstancesOfferingId?: RDSString;
-        DBInstanceClass?: RDSString;
-        Duration?: RDSString;
-        ProductDescription?: RDSString;
-        OfferingType?: RDSString;
-        MultiAZ?: RDSBooleanOptional;
-        MaxRecords?: RDSIntegerOptional;
-        Marker?: RDSString;
-    }
-
-    export type RDSDouble = number;
-    export interface RDSEC2SecurityGroup {
-        Status?: RDSString;
-        EC2SecurityGroupName?: RDSString;
-        EC2SecurityGroupId?: RDSString;
-        EC2SecurityGroupOwnerId?: RDSString;
-    }
-
-    export type RDSEC2SecurityGroupList = Array<RDSEC2SecurityGroup>;
-    export interface RDSEndpoint {
-        Address?: RDSString;
-        Port?: RDSInteger;
-    }
-
-    export interface RDSEngineDefaults {
-        DBParameterGroupFamily?: RDSString;
-        Marker?: RDSString;
-        Parameters?: RDSParametersList;
-    }
-
-    export interface RDSEvent {
-        SourceIdentifier?: RDSString;
-        SourceType?: RDSSourceType;
-        Message?: RDSString;
-        EventCategories?: RDSEventCategoriesList;
-        Date?: RDSTStamp;
-    }
-
-    export type RDSEventCategoriesList = Array<RDSString>;
-    export interface RDSEventCategoriesMap {
-        SourceType?: RDSString;
-        EventCategories?: RDSEventCategoriesList;
-    }
-
-    export type RDSEventCategoriesMapList = Array<RDSEventCategoriesMap>;
-    export interface RDSEventCategoriesMessage {
-        EventCategoriesMapList?: RDSEventCategoriesMapList;
-    }
-
-    export type RDSEventList = Array<RDSEvent>;
-    export interface RDSEventSubscription {
-        Id?: RDSString;
-        CustomerAwsId?: RDSString;
-        CustSubscriptionId?: RDSString;
-        SnsTopicArn?: RDSString;
-        Status?: RDSString;
-        SubscriptionCreationTime?: RDSString;
-        SourceType?: RDSString;
-        SourceIdsList?: RDSSourceIdsList;
-        EventCategoriesList?: RDSEventCategoriesList;
-        Enabled?: RDSBoolean;
-    }
-
-    export interface RDSEventSubscriptionQuotaExceededFault {
-    }
-
-    export type RDSEventSubscriptionsList = Array<RDSEventSubscription>;
-    export interface RDSEventSubscriptionsMessage {
-        Marker?: RDSString;
-        EventSubscriptionsList?: RDSEventSubscriptionsList;
-    }
-
-    export interface RDSEventsMessage {
-        Marker?: RDSString;
-        Events?: RDSEventList;
-    }
-
-    export interface RDSIPRange {
-        Status?: RDSString;
-        CIDRIP?: RDSString;
-    }
-
-    export type RDSIPRangeList = Array<RDSIPRange>;
-    export interface RDSInstanceQuotaExceededFault {
-    }
-
-    export interface RDSInsufficientDBInstanceCapacityFault {
-    }
-
-    export type RDSInteger = number;
-    export type RDSIntegerOptional = number;
-    export interface RDSInvalidDBInstanceStateFault {
-    }
-
-    export interface RDSInvalidDBParameterGroupStateFault {
-    }
+      addSourceIdentifierToSubscription(params: RDS.AddSourceIdentifierToSubscriptionMessage, callback?: (err: RDS.SubscriptionNotFoundFault|RDS.SourceNotFoundFault|any, data: RDS.AddSourceIdentifierToSubscriptionResult|any) => void): Request;
+      addTagsToResource(params: RDS.AddTagsToResourceMessage, callback?: (err: RDS.DBInstanceNotFoundFault|RDS.DBSnapshotNotFoundFault|any, data: any) => void): Request;
+      authorizeDBSecurityGroupIngress(params: RDS.AuthorizeDBSecurityGroupIngressMessage, callback?: (err: RDS.DBSecurityGroupNotFoundFault|RDS.InvalidDBSecurityGroupStateFault|RDS.AuthorizationAlreadyExistsFault|RDS.AuthorizationQuotaExceededFault|any, data: RDS.AuthorizeDBSecurityGroupIngressResult|any) => void): Request;
+      copyDBSnapshot(params: RDS.CopyDBSnapshotMessage, callback?: (err: RDS.DBSnapshotAlreadyExistsFault|RDS.DBSnapshotNotFoundFault|RDS.InvalidDBSnapshotStateFault|RDS.SnapshotQuotaExceededFault|any, data: RDS.CopyDBSnapshotResult|any) => void): Request;
+      createDBInstance(params: RDS.CreateDBInstanceMessage, callback?: (err: RDS.DBInstanceAlreadyExistsFault|RDS.InsufficientDBInstanceCapacityFault|RDS.DBParameterGroupNotFoundFault|RDS.DBSecurityGroupNotFoundFault|RDS.InstanceQuotaExceededFault|RDS.StorageQuotaExceededFault|RDS.DBSubnetGroupNotFoundFault|RDS.DBSubnetGroupDoesNotCoverEnoughAZs|RDS.InvalidSubnet|RDS.InvalidVPCNetworkStateFault|RDS.ProvisionedIopsNotAvailableInAZFault|RDS.OptionGroupNotFoundFault|any, data: RDS.CreateDBInstanceResult|any) => void): Request;
+      createDBInstanceReadReplica(params: RDS.CreateDBInstanceReadReplicaMessage, callback?: (err: RDS.DBInstanceAlreadyExistsFault|RDS.InsufficientDBInstanceCapacityFault|RDS.DBParameterGroupNotFoundFault|RDS.DBSecurityGroupNotFoundFault|RDS.InstanceQuotaExceededFault|RDS.StorageQuotaExceededFault|RDS.DBInstanceNotFoundFault|RDS.InvalidDBInstanceStateFault|RDS.DBSubnetGroupNotFoundFault|RDS.DBSubnetGroupDoesNotCoverEnoughAZs|RDS.InvalidSubnet|RDS.InvalidVPCNetworkStateFault|RDS.ProvisionedIopsNotAvailableInAZFault|RDS.OptionGroupNotFoundFault|any, data: RDS.CreateDBInstanceReadReplicaResult|any) => void): Request;
+      createDBParameterGroup(params: RDS.CreateDBParameterGroupMessage, callback?: (err: RDS.DBParameterGroupQuotaExceededFault|RDS.DBParameterGroupAlreadyExistsFault|any, data: RDS.CreateDBParameterGroupResult|any) => void): Request;
+      createDBSecurityGroup(params: RDS.CreateDBSecurityGroupMessage, callback?: (err: RDS.DBSecurityGroupAlreadyExistsFault|RDS.DBSecurityGroupQuotaExceededFault|RDS.DBSecurityGroupNotSupportedFault|any, data: RDS.CreateDBSecurityGroupResult|any) => void): Request;
+      createDBSnapshot(params: RDS.CreateDBSnapshotMessage, callback?: (err: RDS.DBSnapshotAlreadyExistsFault|RDS.InvalidDBInstanceStateFault|RDS.DBInstanceNotFoundFault|RDS.SnapshotQuotaExceededFault|any, data: RDS.CreateDBSnapshotResult|any) => void): Request;
+      createDBSubnetGroup(params: RDS.CreateDBSubnetGroupMessage, callback?: (err: RDS.DBSubnetGroupAlreadyExistsFault|RDS.DBSubnetGroupQuotaExceededFault|RDS.DBSubnetQuotaExceededFault|RDS.DBSubnetGroupDoesNotCoverEnoughAZs|RDS.InvalidSubnet|any, data: RDS.CreateDBSubnetGroupResult|any) => void): Request;
+      createEventSubscription(params: RDS.CreateEventSubscriptionMessage, callback?: (err: RDS.EventSubscriptionQuotaExceededFault|RDS.SubscriptionAlreadyExistFault|RDS.SNSInvalidTopicFault|RDS.SNSNoAuthorizationFault|RDS.SNSTopicArnNotFoundFault|RDS.SubscriptionCategoryNotFoundFault|RDS.SourceNotFoundFault|any, data: RDS.CreateEventSubscriptionResult|any) => void): Request;
+      createOptionGroup(params: RDS.CreateOptionGroupMessage, callback?: (err: RDS.OptionGroupAlreadyExistsFault|RDS.OptionGroupQuotaExceededFault|any, data: RDS.CreateOptionGroupResult|any) => void): Request;
+      deleteDBInstance(params: RDS.DeleteDBInstanceMessage, callback?: (err: RDS.DBInstanceNotFoundFault|RDS.InvalidDBInstanceStateFault|RDS.DBSnapshotAlreadyExistsFault|RDS.SnapshotQuotaExceededFault|any, data: RDS.DeleteDBInstanceResult|any) => void): Request;
+      deleteDBParameterGroup(params: RDS.DeleteDBParameterGroupMessage, callback?: (err: RDS.InvalidDBParameterGroupStateFault|RDS.DBParameterGroupNotFoundFault|any, data: any) => void): Request;
+      deleteDBSecurityGroup(params: RDS.DeleteDBSecurityGroupMessage, callback?: (err: RDS.InvalidDBSecurityGroupStateFault|RDS.DBSecurityGroupNotFoundFault|any, data: any) => void): Request;
+      deleteDBSnapshot(params: RDS.DeleteDBSnapshotMessage, callback?: (err: RDS.InvalidDBSnapshotStateFault|RDS.DBSnapshotNotFoundFault|any, data: RDS.DeleteDBSnapshotResult|any) => void): Request;
+      deleteDBSubnetGroup(params: RDS.DeleteDBSubnetGroupMessage, callback?: (err: RDS.InvalidDBSubnetGroupStateFault|RDS.InvalidDBSubnetStateFault|RDS.DBSubnetGroupNotFoundFault|any, data: any) => void): Request;
+      deleteEventSubscription(params: RDS.DeleteEventSubscriptionMessage, callback?: (err: RDS.SubscriptionNotFoundFault|RDS.InvalidEventSubscriptionStateFault|any, data: RDS.DeleteEventSubscriptionResult|any) => void): Request;
+      deleteOptionGroup(params: RDS.DeleteOptionGroupMessage, callback?: (err: RDS.OptionGroupNotFoundFault|RDS.InvalidOptionGroupStateFault|any, data: any) => void): Request;
+      describeDBEngineVersions(params: RDS.DescribeDBEngineVersionsMessage, callback?: (err: any, data: RDS.DBEngineVersionMessage|any) => void): Request;
+      describeDBInstances(params: RDS.DescribeDBInstancesMessage, callback?: (err: RDS.DBInstanceNotFoundFault|any, data: RDS.DBInstanceMessage|any) => void): Request;
+      describeDBParameterGroups(params: RDS.DescribeDBParameterGroupsMessage, callback?: (err: RDS.DBParameterGroupNotFoundFault|any, data: RDS.DBParameterGroupsMessage|any) => void): Request;
+      describeDBParameters(params: RDS.DescribeDBParametersMessage, callback?: (err: RDS.DBParameterGroupNotFoundFault|any, data: RDS.DBParameterGroupDetails|any) => void): Request;
+      describeDBSecurityGroups(params: RDS.DescribeDBSecurityGroupsMessage, callback?: (err: RDS.DBSecurityGroupNotFoundFault|any, data: RDS.DBSecurityGroupMessage|any) => void): Request;
+      describeDBSnapshots(params: RDS.DescribeDBSnapshotsMessage, callback?: (err: RDS.DBSnapshotNotFoundFault|any, data: RDS.DBSnapshotMessage|any) => void): Request;
+      describeDBSubnetGroups(params: RDS.DescribeDBSubnetGroupsMessage, callback?: (err: RDS.DBSubnetGroupNotFoundFault|any, data: RDS.DBSubnetGroupMessage|any) => void): Request;
+      describeEngineDefaultParameters(params: RDS.DescribeEngineDefaultParametersMessage, callback?: (err: any, data: RDS.DescribeEngineDefaultParametersResult|any) => void): Request;
+      describeEventCategories(params: RDS.DescribeEventCategoriesMessage, callback?: (err: any, data: RDS.EventCategoriesMessage|any) => void): Request;
+      describeEventSubscriptions(params: RDS.DescribeEventSubscriptionsMessage, callback?: (err: RDS.SubscriptionNotFoundFault|any, data: RDS.EventSubscriptionsMessage|any) => void): Request;
+      describeEvents(params: RDS.DescribeEventsMessage, callback?: (err: any, data: RDS.EventsMessage|any) => void): Request;
+      describeOptionGroupOptions(params: RDS.DescribeOptionGroupOptionsMessage, callback?: (err: any, data: RDS.OptionGroupOptionsMessage|any) => void): Request;
+      describeOptionGroups(params: RDS.DescribeOptionGroupsMessage, callback?: (err: RDS.OptionGroupNotFoundFault|any, data: RDS.OptionGroups|any) => void): Request;
+      describeOrderableDBInstanceOptions(params: RDS.DescribeOrderableDBInstanceOptionsMessage, callback?: (err: any, data: RDS.OrderableDBInstanceOptionsMessage|any) => void): Request;
+      describeReservedDBInstances(params: RDS.DescribeReservedDBInstancesMessage, callback?: (err: RDS.ReservedDBInstanceNotFoundFault|any, data: RDS.ReservedDBInstanceMessage|any) => void): Request;
+      describeReservedDBInstancesOfferings(params: RDS.DescribeReservedDBInstancesOfferingsMessage, callback?: (err: RDS.ReservedDBInstancesOfferingNotFoundFault|any, data: RDS.ReservedDBInstancesOfferingMessage|any) => void): Request;
+      listTagsForResource(params: RDS.ListTagsForResourceMessage, callback?: (err: RDS.DBInstanceNotFoundFault|RDS.DBSnapshotNotFoundFault|any, data: RDS.TagListMessage|any) => void): Request;
+      modifyDBInstance(params: RDS.ModifyDBInstanceMessage, callback?: (err: RDS.InvalidDBInstanceStateFault|RDS.InvalidDBSecurityGroupStateFault|RDS.DBInstanceAlreadyExistsFault|RDS.DBInstanceNotFoundFault|RDS.DBSecurityGroupNotFoundFault|RDS.DBParameterGroupNotFoundFault|RDS.InsufficientDBInstanceCapacityFault|RDS.StorageQuotaExceededFault|RDS.InvalidVPCNetworkStateFault|RDS.ProvisionedIopsNotAvailableInAZFault|RDS.OptionGroupNotFoundFault|RDS.DBUpgradeDependencyFailureFault|any, data: RDS.ModifyDBInstanceResult|any) => void): Request;
+      modifyDBParameterGroup(params: RDS.ModifyDBParameterGroupMessage, callback?: (err: RDS.DBParameterGroupNotFoundFault|RDS.InvalidDBParameterGroupStateFault|any, data: RDS.DBParameterGroupNameMessage|any) => void): Request;
+      modifyDBSubnetGroup(params: RDS.ModifyDBSubnetGroupMessage, callback?: (err: RDS.DBSubnetGroupNotFoundFault|RDS.DBSubnetQuotaExceededFault|RDS.SubnetAlreadyInUse|RDS.DBSubnetGroupDoesNotCoverEnoughAZs|RDS.InvalidSubnet|any, data: RDS.ModifyDBSubnetGroupResult|any) => void): Request;
+      modifyEventSubscription(params: RDS.ModifyEventSubscriptionMessage, callback?: (err: RDS.EventSubscriptionQuotaExceededFault|RDS.SubscriptionNotFoundFault|RDS.SNSInvalidTopicFault|RDS.SNSNoAuthorizationFault|RDS.SNSTopicArnNotFoundFault|RDS.SubscriptionCategoryNotFoundFault|any, data: RDS.ModifyEventSubscriptionResult|any) => void): Request;
+      modifyOptionGroup(params: RDS.ModifyOptionGroupMessage, callback?: (err: RDS.InvalidOptionGroupStateFault|RDS.OptionGroupNotFoundFault|any, data: RDS.ModifyOptionGroupResult|any) => void): Request;
+      promoteReadReplica(params: RDS.PromoteReadReplicaMessage, callback?: (err: RDS.InvalidDBInstanceStateFault|RDS.DBInstanceNotFoundFault|any, data: RDS.PromoteReadReplicaResult|any) => void): Request;
+      purchaseReservedDBInstancesOffering(params: RDS.PurchaseReservedDBInstancesOfferingMessage, callback?: (err: RDS.ReservedDBInstancesOfferingNotFoundFault|RDS.ReservedDBInstanceAlreadyExistsFault|RDS.ReservedDBInstanceQuotaExceededFault|any, data: RDS.PurchaseReservedDBInstancesOfferingResult|any) => void): Request;
+      rebootDBInstance(params: RDS.RebootDBInstanceMessage, callback?: (err: RDS.InvalidDBInstanceStateFault|RDS.DBInstanceNotFoundFault|any, data: RDS.RebootDBInstanceResult|any) => void): Request;
+      removeSourceIdentifierFromSubscription(params: RDS.RemoveSourceIdentifierFromSubscriptionMessage, callback?: (err: RDS.SubscriptionNotFoundFault|RDS.SourceNotFoundFault|any, data: RDS.RemoveSourceIdentifierFromSubscriptionResult|any) => void): Request;
+      removeTagsFromResource(params: RDS.RemoveTagsFromResourceMessage, callback?: (err: RDS.DBInstanceNotFoundFault|RDS.DBSnapshotNotFoundFault|any, data: any) => void): Request;
+      resetDBParameterGroup(params: RDS.ResetDBParameterGroupMessage, callback?: (err: RDS.InvalidDBParameterGroupStateFault|RDS.DBParameterGroupNotFoundFault|any, data: RDS.DBParameterGroupNameMessage|any) => void): Request;
+      restoreDBInstanceFromDBSnapshot(params: RDS.RestoreDBInstanceFromDBSnapshotMessage, callback?: (err: RDS.DBInstanceAlreadyExistsFault|RDS.DBSnapshotNotFoundFault|RDS.InstanceQuotaExceededFault|RDS.InsufficientDBInstanceCapacityFault|RDS.InvalidDBSnapshotStateFault|RDS.StorageQuotaExceededFault|RDS.InvalidVPCNetworkStateFault|RDS.InvalidRestoreFault|RDS.DBSubnetGroupNotFoundFault|RDS.DBSubnetGroupDoesNotCoverEnoughAZs|RDS.InvalidSubnet|RDS.ProvisionedIopsNotAvailableInAZFault|RDS.OptionGroupNotFoundFault|any, data: RDS.RestoreDBInstanceFromDBSnapshotResult|any) => void): Request;
+      restoreDBInstanceToPointInTime(params: RDS.RestoreDBInstanceToPointInTimeMessage, callback?: (err: RDS.DBInstanceAlreadyExistsFault|RDS.DBInstanceNotFoundFault|RDS.InstanceQuotaExceededFault|RDS.InsufficientDBInstanceCapacityFault|RDS.InvalidDBInstanceStateFault|RDS.PointInTimeRestoreNotEnabledFault|RDS.StorageQuotaExceededFault|RDS.InvalidVPCNetworkStateFault|RDS.InvalidRestoreFault|RDS.DBSubnetGroupNotFoundFault|RDS.DBSubnetGroupDoesNotCoverEnoughAZs|RDS.InvalidSubnet|RDS.ProvisionedIopsNotAvailableInAZFault|RDS.OptionGroupNotFoundFault|any, data: RDS.RestoreDBInstanceToPointInTimeResult|any) => void): Request;
+      revokeDBSecurityGroupIngress(params: RDS.RevokeDBSecurityGroupIngressMessage, callback?: (err: RDS.DBSecurityGroupNotFoundFault|RDS.AuthorizationNotFoundFault|RDS.InvalidDBSecurityGroupStateFault|any, data: RDS.RevokeDBSecurityGroupIngressResult|any) => void): Request;
+    }
+    
+    export module RDS {
+        export type ApplyMethod = string;
+        export type AvailabilityZoneList = AvailabilityZone[];
+        export type Boolean = boolean;
+        export type BooleanOptional = boolean;
+        export type DBEngineVersionList = DBEngineVersion[];
+        export type DBInstanceList = DBInstance[];
+        export type DBParameterGroupList = DBParameterGroup[];
+        export type DBParameterGroupStatusList = DBParameterGroupStatus[];
+        export type DBSecurityGroupMembershipList = DBSecurityGroupMembership[];
+        export type DBSecurityGroupNameList = String[];
+        export type DBSecurityGroups = DBSecurityGroup[];
+        export type DBSnapshotList = DBSnapshot[];
+        export type DBSubnetGroups = DBSubnetGroup[];
+        export type Double = number;
+        export type EC2SecurityGroupList = EC2SecurityGroup[];
+        export type EventCategoriesList = String[];
+        export type EventCategoriesMapList = EventCategoriesMap[];
+        export type EventList = Event[];
+        export type EventSubscriptionsList = EventSubscription[];
+        export type IPRangeList = IPRange[];
+        export type Integer = number;
+        export type IntegerOptional = number;
+        export type KeyList = String[];
+        export type OptionConfigurationList = OptionConfiguration[];
+        export type OptionGroupOptionsList = OptionGroupOption[];
+        export type OptionGroupsList = OptionGroup[];
+        export type OptionNamesList = String[];
+        export type OptionsDependedOn = String[];
+        export type OptionsList = Option[];
+        export type OrderableDBInstanceOptionsList = OrderableDBInstanceOption[];
+        export type ParametersList = Parameter[];
+        export type ReadReplicaDBInstanceIdentifierList = String[];
+        export type RecurringChargeList = RecurringCharge[];
+        export type ReservedDBInstanceList = ReservedDBInstance[];
+        export type ReservedDBInstancesOfferingList = ReservedDBInstancesOffering[];
+        export type SourceIdsList = String[];
+        export type SourceType = string;
+        export type String = string;
+        export type SubnetIdentifierList = String[];
+        export type SubnetList = Subnet[];
+        export type SupportedCharacterSetsList = CharacterSet[];
+        export type TStamp = number;
+        export type TagList = Tag[];
+        export type VpcSecurityGroupIdList = String[];
+        export type VpcSecurityGroupMembershipList = VpcSecurityGroupMembership[];
+
+        export interface AddSourceIdentifierToSubscriptionMessage {
+            SubscriptionName: String;            
+            SourceIdentifier: String;            
+        }
+        export interface AddTagsToResourceMessage {
+            ResourceName: String;            
+            Tags: TagList;            
+        }
+        export interface AuthorizationAlreadyExistsFault {
+        }
+        export interface AuthorizationNotFoundFault {
+        }
+        export interface AuthorizationQuotaExceededFault {
+        }
+        export interface AuthorizeDBSecurityGroupIngressMessage {
+            DBSecurityGroupName: String;            
+            CIDRIP?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupId?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+        }
+        export interface AvailabilityZone {
+            Name?: String;            
+            ProvisionedIopsCapable?: Boolean;            
+        }
+        export interface CharacterSet {
+            CharacterSetName?: String;            
+            CharacterSetDescription?: String;            
+        }
+        export interface CopyDBSnapshotMessage {
+            SourceDBSnapshotIdentifier: String;            
+            TargetDBSnapshotIdentifier: String;            
+        }
+        export interface CreateDBInstanceMessage {
+            DBName?: String;            
+            DBInstanceIdentifier: String;            
+            AllocatedStorage: IntegerOptional;            
+            DBInstanceClass: String;            
+            Engine: String;            
+            MasterUsername: String;            
+            MasterUserPassword: String;            
+            DBSecurityGroups?: DBSecurityGroupNameList;            
+            VpcSecurityGroupIds?: VpcSecurityGroupIdList;            
+            AvailabilityZone?: String;            
+            DBSubnetGroupName?: String;            
+            PreferredMaintenanceWindow?: String;            
+            DBParameterGroupName?: String;            
+            BackupRetentionPeriod?: IntegerOptional;            
+            PreferredBackupWindow?: String;            
+            Port?: IntegerOptional;            
+            MultiAZ?: BooleanOptional;            
+            EngineVersion?: String;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            LicenseModel?: String;            
+            Iops?: IntegerOptional;            
+            OptionGroupName?: String;            
+            CharacterSetName?: String;            
+            PubliclyAccessible?: BooleanOptional;            
+        }
+        export interface CreateDBInstanceReadReplicaMessage {
+            DBInstanceIdentifier: String;            
+            SourceDBInstanceIdentifier: String;            
+            DBInstanceClass?: String;            
+            AvailabilityZone?: String;            
+            Port?: IntegerOptional;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            Iops?: IntegerOptional;            
+            OptionGroupName?: String;            
+            PubliclyAccessible?: BooleanOptional;            
+        }
+        export interface CreateDBParameterGroupMessage {
+            DBParameterGroupName: String;            
+            DBParameterGroupFamily: String;            
+            Description: String;            
+        }
+        export interface CreateDBSecurityGroupMessage {
+            DBSecurityGroupName: String;            
+            DBSecurityGroupDescription: String;            
+        }
+        export interface CreateDBSnapshotMessage {
+            DBSnapshotIdentifier: String;            
+            DBInstanceIdentifier: String;            
+        }
+        export interface CreateDBSubnetGroupMessage {
+            DBSubnetGroupName: String;            
+            DBSubnetGroupDescription: String;            
+            SubnetIds: SubnetIdentifierList;            
+        }
+        export interface CreateEventSubscriptionMessage {
+            SubscriptionName: String;            
+            SnsTopicArn: String;            
+            SourceType?: String;            
+            EventCategories?: EventCategoriesList;            
+            SourceIds?: SourceIdsList;            
+            Enabled?: BooleanOptional;            
+        }
+        export interface CreateOptionGroupMessage {
+            OptionGroupName: String;            
+            EngineName: String;            
+            MajorEngineVersion: String;            
+            OptionGroupDescription: String;            
+        }
+        export interface DBEngineVersion {
+            Engine?: String;            
+            EngineVersion?: String;            
+            DBParameterGroupFamily?: String;            
+            DBEngineDescription?: String;            
+            DBEngineVersionDescription?: String;            
+            DefaultCharacterSet?: CharacterSet;            
+            SupportedCharacterSets?: SupportedCharacterSetsList;            
+        }
+        export interface DBEngineVersionMessage {
+            Marker?: String;            
+            DBEngineVersions?: DBEngineVersionList;            
+        }
+        export interface DBInstance {
+            DBInstanceIdentifier?: String;            
+            DBInstanceClass?: String;            
+            Engine?: String;            
+            DBInstanceStatus?: String;            
+            MasterUsername?: String;            
+            DBName?: String;            
+            Endpoint?: Endpoint;            
+            AllocatedStorage?: Integer;            
+            InstanceCreateTime?: TStamp;            
+            PreferredBackupWindow?: String;            
+            BackupRetentionPeriod?: Integer;            
+            DBSecurityGroups?: DBSecurityGroupMembershipList;            
+            VpcSecurityGroups?: VpcSecurityGroupMembershipList;            
+            DBParameterGroups?: DBParameterGroupStatusList;            
+            AvailabilityZone?: String;            
+            DBSubnetGroup?: DBSubnetGroup;            
+            PreferredMaintenanceWindow?: String;            
+            PendingModifiedValues?: PendingModifiedValues;            
+            LatestRestorableTime?: TStamp;            
+            MultiAZ?: Boolean;            
+            EngineVersion?: String;            
+            AutoMinorVersionUpgrade?: Boolean;            
+            ReadReplicaSourceDBInstanceIdentifier?: String;            
+            ReadReplicaDBInstanceIdentifiers?: ReadReplicaDBInstanceIdentifierList;            
+            LicenseModel?: String;            
+            Iops?: IntegerOptional;            
+            OptionGroupMembership?: OptionGroupMembership;            
+            CharacterSetName?: String;            
+            SecondaryAvailabilityZone?: String;            
+            PubliclyAccessible?: Boolean;            
+        }
+        export interface DBInstanceAlreadyExistsFault {
+        }
+        export interface DBInstanceMessage {
+            Marker?: String;            
+            DBInstances?: DBInstanceList;            
+        }
+        export interface DBInstanceNotFoundFault {
+        }
+        export interface DBParameterGroup {
+            DBParameterGroupName?: String;            
+            DBParameterGroupFamily?: String;            
+            Description?: String;            
+        }
+        export interface DBParameterGroupAlreadyExistsFault {
+        }
+        export interface DBParameterGroupDetails {
+            Parameters?: ParametersList;            
+            Marker?: String;            
+        }
+        export interface DBParameterGroupNameMessage {
+            DBParameterGroupName?: String;            
+        }
+        export interface DBParameterGroupNotFoundFault {
+        }
+        export interface DBParameterGroupQuotaExceededFault {
+        }
+        export interface DBParameterGroupStatus {
+            DBParameterGroupName?: String;            
+            ParameterApplyStatus?: String;            
+        }
+        export interface DBParameterGroupsMessage {
+            Marker?: String;            
+            DBParameterGroups?: DBParameterGroupList;            
+        }
+        export interface DBSecurityGroup {
+            OwnerId?: String;            
+            DBSecurityGroupName?: String;            
+            DBSecurityGroupDescription?: String;            
+            VpcId?: String;            
+            EC2SecurityGroups?: EC2SecurityGroupList;            
+            IPRanges?: IPRangeList;            
+        }
+        export interface DBSecurityGroupAlreadyExistsFault {
+        }
+        export interface DBSecurityGroupMembership {
+            DBSecurityGroupName?: String;            
+            Status?: String;            
+        }
+        export interface DBSecurityGroupMessage {
+            Marker?: String;            
+            DBSecurityGroups?: DBSecurityGroups;            
+        }
+        export interface DBSecurityGroupNotFoundFault {
+        }
+        export interface DBSecurityGroupNotSupportedFault {
+        }
+        export interface DBSecurityGroupQuotaExceededFault {
+        }
+        export interface DBSnapshot {
+            DBSnapshotIdentifier?: String;            
+            DBInstanceIdentifier?: String;            
+            SnapshotCreateTime?: TStamp;            
+            Engine?: String;            
+            AllocatedStorage?: Integer;            
+            Status?: String;            
+            Port?: Integer;            
+            AvailabilityZone?: String;            
+            VpcId?: String;            
+            InstanceCreateTime?: TStamp;            
+            MasterUsername?: String;            
+            EngineVersion?: String;            
+            LicenseModel?: String;            
+            SnapshotType?: String;            
+            Iops?: IntegerOptional;            
+        }
+        export interface DBSnapshotAlreadyExistsFault {
+        }
+        export interface DBSnapshotMessage {
+            Marker?: String;            
+            DBSnapshots?: DBSnapshotList;            
+        }
+        export interface DBSnapshotNotFoundFault {
+        }
+        export interface DBSubnetGroup {
+            DBSubnetGroupName?: String;            
+            DBSubnetGroupDescription?: String;            
+            VpcId?: String;            
+            SubnetGroupStatus?: String;            
+            Subnets?: SubnetList;            
+        }
+        export interface DBSubnetGroupAlreadyExistsFault {
+        }
+        export interface DBSubnetGroupDoesNotCoverEnoughAZs {
+        }
+        export interface DBSubnetGroupMessage {
+            Marker?: String;            
+            DBSubnetGroups?: DBSubnetGroups;            
+        }
+        export interface DBSubnetGroupNotFoundFault {
+        }
+        export interface DBSubnetGroupQuotaExceededFault {
+        }
+        export interface DBSubnetQuotaExceededFault {
+        }
+        export interface DBUpgradeDependencyFailureFault {
+        }
+        export interface DeleteDBInstanceMessage {
+            DBInstanceIdentifier: String;            
+            SkipFinalSnapshot?: Boolean;            
+            FinalDBSnapshotIdentifier?: String;            
+        }
+        export interface DeleteDBParameterGroupMessage {
+            DBParameterGroupName: String;            
+        }
+        export interface DeleteDBSecurityGroupMessage {
+            DBSecurityGroupName: String;            
+        }
+        export interface DeleteDBSnapshotMessage {
+            DBSnapshotIdentifier: String;            
+        }
+        export interface DeleteDBSubnetGroupMessage {
+            DBSubnetGroupName: String;            
+        }
+        export interface DeleteEventSubscriptionMessage {
+            SubscriptionName: String;            
+        }
+        export interface DeleteOptionGroupMessage {
+            OptionGroupName: String;            
+        }
+        export interface DescribeDBEngineVersionsMessage {
+            Engine?: String;            
+            EngineVersion?: String;            
+            DBParameterGroupFamily?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            DefaultOnly?: Boolean;            
+            ListSupportedCharacterSets?: BooleanOptional;            
+        }
+        export interface DescribeDBInstancesMessage {
+            DBInstanceIdentifier?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeDBParameterGroupsMessage {
+            DBParameterGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeDBParametersMessage {
+            DBParameterGroupName: String;            
+            Source?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeDBSecurityGroupsMessage {
+            DBSecurityGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeDBSnapshotsMessage {
+            DBInstanceIdentifier?: String;            
+            DBSnapshotIdentifier?: String;            
+            SnapshotType?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeDBSubnetGroupsMessage {
+            DBSubnetGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEngineDefaultParametersMessage {
+            DBParameterGroupFamily: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEventCategoriesMessage {
+            SourceType?: String;            
+        }
+        export interface DescribeEventSubscriptionsMessage {
+            SubscriptionName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEventsMessage {
+            SourceIdentifier?: String;            
+            SourceType?: SourceType;            
+            StartTime?: TStamp;            
+            EndTime?: TStamp;            
+            Duration?: IntegerOptional;            
+            EventCategories?: EventCategoriesList;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeOptionGroupOptionsMessage {
+            EngineName: String;            
+            MajorEngineVersion?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeOptionGroupsMessage {
+            OptionGroupName?: String;            
+            Marker?: String;            
+            MaxRecords?: IntegerOptional;            
+            EngineName?: String;            
+            MajorEngineVersion?: String;            
+        }
+        export interface DescribeOrderableDBInstanceOptionsMessage {
+            Engine: String;            
+            EngineVersion?: String;            
+            DBInstanceClass?: String;            
+            LicenseModel?: String;            
+            Vpc?: BooleanOptional;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReservedDBInstancesMessage {
+            ReservedDBInstanceId?: String;            
+            ReservedDBInstancesOfferingId?: String;            
+            DBInstanceClass?: String;            
+            Duration?: String;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            MultiAZ?: BooleanOptional;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReservedDBInstancesOfferingsMessage {
+            ReservedDBInstancesOfferingId?: String;            
+            DBInstanceClass?: String;            
+            Duration?: String;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            MultiAZ?: BooleanOptional;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface EC2SecurityGroup {
+            Status?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupId?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+        }
+        export interface Endpoint {
+            Address?: String;            
+            Port?: Integer;            
+        }
+        export interface EngineDefaults {
+            DBParameterGroupFamily?: String;            
+            Marker?: String;            
+            Parameters?: ParametersList;            
+        }
+        export interface Event {
+            SourceIdentifier?: String;            
+            SourceType?: SourceType;            
+            Message?: String;            
+            EventCategories?: EventCategoriesList;            
+            Date?: TStamp;            
+        }
+        export interface EventCategoriesMap {
+            SourceType?: String;            
+            EventCategories?: EventCategoriesList;            
+        }
+        export interface EventCategoriesMessage {
+            EventCategoriesMapList?: EventCategoriesMapList;            
+        }
+        export interface EventSubscription {
+            Id?: String;            
+            CustomerAwsId?: String;            
+            CustSubscriptionId?: String;            
+            SnsTopicArn?: String;            
+            Status?: String;            
+            SubscriptionCreationTime?: String;            
+            SourceType?: String;            
+            SourceIdsList?: SourceIdsList;            
+            EventCategoriesList?: EventCategoriesList;            
+            Enabled?: Boolean;            
+        }
+        export interface EventSubscriptionQuotaExceededFault {
+        }
+        export interface EventSubscriptionsMessage {
+            Marker?: String;            
+            EventSubscriptionsList?: EventSubscriptionsList;            
+        }
+        export interface EventsMessage {
+            Marker?: String;            
+            Events?: EventList;            
+        }
+        export interface IPRange {
+            Status?: String;            
+            CIDRIP?: String;            
+        }
+        export interface InstanceQuotaExceededFault {
+        }
+        export interface InsufficientDBInstanceCapacityFault {
+        }
+        export interface InvalidDBInstanceStateFault {
+        }
+        export interface InvalidDBParameterGroupStateFault {
+        }
+        export interface InvalidDBSecurityGroupStateFault {
+        }
+        export interface InvalidDBSnapshotStateFault {
+        }
+        export interface InvalidDBSubnetGroupStateFault {
+        }
+        export interface InvalidDBSubnetStateFault {
+        }
+        export interface InvalidEventSubscriptionStateFault {
+        }
+        export interface InvalidOptionGroupStateFault {
+        }
+        export interface InvalidRestoreFault {
+        }
+        export interface InvalidSubnet {
+        }
+        export interface InvalidVPCNetworkStateFault {
+        }
+        export interface ListTagsForResourceMessage {
+            ResourceName: String;            
+        }
+        export interface ModifyDBInstanceMessage {
+            DBInstanceIdentifier: String;            
+            AllocatedStorage?: IntegerOptional;            
+            DBInstanceClass?: String;            
+            DBSecurityGroups?: DBSecurityGroupNameList;            
+            VpcSecurityGroupIds?: VpcSecurityGroupIdList;            
+            ApplyImmediately?: Boolean;            
+            MasterUserPassword?: String;            
+            DBParameterGroupName?: String;            
+            BackupRetentionPeriod?: IntegerOptional;            
+            PreferredBackupWindow?: String;            
+            PreferredMaintenanceWindow?: String;            
+            MultiAZ?: BooleanOptional;            
+            EngineVersion?: String;            
+            AllowMajorVersionUpgrade?: Boolean;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            Iops?: IntegerOptional;            
+            OptionGroupName?: String;            
+            NewDBInstanceIdentifier?: String;            
+        }
+        export interface ModifyDBParameterGroupMessage {
+            DBParameterGroupName: String;            
+            Parameters: ParametersList;            
+        }
+        export interface ModifyDBSubnetGroupMessage {
+            DBSubnetGroupName: String;            
+            DBSubnetGroupDescription?: String;            
+            SubnetIds: SubnetIdentifierList;            
+        }
+        export interface ModifyEventSubscriptionMessage {
+            SubscriptionName: String;            
+            SnsTopicArn?: String;            
+            SourceType?: String;            
+            EventCategories?: EventCategoriesList;            
+            Enabled?: BooleanOptional;            
+        }
+        export interface ModifyOptionGroupMessage {
+            OptionGroupName: String;            
+            OptionsToInclude?: OptionConfigurationList;            
+            OptionsToRemove?: OptionNamesList;            
+            ApplyImmediately?: Boolean;            
+        }
+        export interface Option {
+            OptionName?: String;            
+            OptionDescription?: String;            
+            Port?: IntegerOptional;            
+            DBSecurityGroupMemberships?: DBSecurityGroupMembershipList;            
+            VpcSecurityGroupMemberships?: VpcSecurityGroupMembershipList;            
+        }
+        export interface OptionConfiguration {
+            OptionName: String;            
+            Port?: IntegerOptional;            
+            DBSecurityGroupMemberships?: DBSecurityGroupNameList;            
+            VpcSecurityGroupMemberships?: VpcSecurityGroupIdList;            
+        }
+        export interface OptionGroup {
+            OptionGroupName?: String;            
+            OptionGroupDescription?: String;            
+            EngineName?: String;            
+            MajorEngineVersion?: String;            
+            Options?: OptionsList;            
+            AllowsVpcAndNonVpcInstanceMemberships?: Boolean;            
+            VpcId?: String;            
+        }
+        export interface OptionGroupAlreadyExistsFault {
+        }
+        export interface OptionGroupMembership {
+            OptionGroupName?: String;            
+            Status?: String;            
+        }
+        export interface OptionGroupNotFoundFault {
+        }
+        export interface OptionGroupOption {
+            Name?: String;            
+            Description?: String;            
+            EngineName?: String;            
+            MajorEngineVersion?: String;            
+            MinimumRequiredMinorEngineVersion?: String;            
+            PortRequired?: Boolean;            
+            DefaultPort?: IntegerOptional;            
+            OptionsDependedOn?: OptionsDependedOn;            
+        }
+        export interface OptionGroupOptionsMessage {
+            OptionGroupOptions?: OptionGroupOptionsList;            
+            Marker?: String;            
+        }
+        export interface OptionGroupQuotaExceededFault {
+        }
+        export interface OptionGroups {
+            OptionGroupsList?: OptionGroupsList;            
+            Marker?: String;            
+        }
+        export interface OrderableDBInstanceOption {
+            Engine?: String;            
+            EngineVersion?: String;            
+            DBInstanceClass?: String;            
+            LicenseModel?: String;            
+            AvailabilityZones?: AvailabilityZoneList;            
+            MultiAZCapable?: Boolean;            
+            ReadReplicaCapable?: Boolean;            
+            Vpc?: Boolean;            
+        }
+        export interface OrderableDBInstanceOptionsMessage {
+            OrderableDBInstanceOptions?: OrderableDBInstanceOptionsList;            
+            Marker?: String;            
+        }
+        export interface Parameter {
+            ParameterName?: String;            
+            ParameterValue?: String;            
+            Description?: String;            
+            Source?: String;            
+            ApplyType?: String;            
+            DataType?: String;            
+            AllowedValues?: String;            
+            IsModifiable?: Boolean;            
+            MinimumEngineVersion?: String;            
+            ApplyMethod?: ApplyMethod;            
+        }
+        export interface PendingModifiedValues {
+            DBInstanceClass?: String;            
+            AllocatedStorage?: IntegerOptional;            
+            MasterUserPassword?: String;            
+            Port?: IntegerOptional;            
+            BackupRetentionPeriod?: IntegerOptional;            
+            MultiAZ?: BooleanOptional;            
+            EngineVersion?: String;            
+            Iops?: IntegerOptional;            
+            DBInstanceIdentifier?: String;            
+        }
+        export interface PointInTimeRestoreNotEnabledFault {
+        }
+        export interface PromoteReadReplicaMessage {
+            DBInstanceIdentifier: String;            
+            BackupRetentionPeriod?: IntegerOptional;            
+            PreferredBackupWindow?: String;            
+        }
+        export interface ProvisionedIopsNotAvailableInAZFault {
+        }
+        export interface PurchaseReservedDBInstancesOfferingMessage {
+            ReservedDBInstancesOfferingId: String;            
+            ReservedDBInstanceId?: String;            
+            DBInstanceCount?: IntegerOptional;            
+        }
+        export interface RebootDBInstanceMessage {
+            DBInstanceIdentifier: String;            
+            ForceFailover?: BooleanOptional;            
+        }
+        export interface RecurringCharge {
+            RecurringChargeAmount?: Double;            
+            RecurringChargeFrequency?: String;            
+        }
+        export interface RemoveSourceIdentifierFromSubscriptionMessage {
+            SubscriptionName: String;            
+            SourceIdentifier: String;            
+        }
+        export interface RemoveTagsFromResourceMessage {
+            ResourceName: String;            
+            TagKeys: KeyList;            
+        }
+        export interface ReservedDBInstance {
+            ReservedDBInstanceId?: String;            
+            ReservedDBInstancesOfferingId?: String;            
+            DBInstanceClass?: String;            
+            StartTime?: TStamp;            
+            Duration?: Integer;            
+            FixedPrice?: Double;            
+            UsagePrice?: Double;            
+            CurrencyCode?: String;            
+            DBInstanceCount?: Integer;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            MultiAZ?: Boolean;            
+            State?: String;            
+            RecurringCharges?: RecurringChargeList;            
+        }
+        export interface ReservedDBInstanceAlreadyExistsFault {
+        }
+        export interface ReservedDBInstanceMessage {
+            Marker?: String;            
+            ReservedDBInstances?: ReservedDBInstanceList;            
+        }
+        export interface ReservedDBInstanceNotFoundFault {
+        }
+        export interface ReservedDBInstanceQuotaExceededFault {
+        }
+        export interface ReservedDBInstancesOffering {
+            ReservedDBInstancesOfferingId?: String;            
+            DBInstanceClass?: String;            
+            Duration?: Integer;            
+            FixedPrice?: Double;            
+            UsagePrice?: Double;            
+            CurrencyCode?: String;            
+            ProductDescription?: String;            
+            OfferingType?: String;            
+            MultiAZ?: Boolean;            
+            RecurringCharges?: RecurringChargeList;            
+        }
+        export interface ReservedDBInstancesOfferingMessage {
+            Marker?: String;            
+            ReservedDBInstancesOfferings?: ReservedDBInstancesOfferingList;            
+        }
+        export interface ReservedDBInstancesOfferingNotFoundFault {
+        }
+        export interface ResetDBParameterGroupMessage {
+            DBParameterGroupName: String;            
+            ResetAllParameters?: Boolean;            
+            Parameters?: ParametersList;            
+        }
+        export interface RestoreDBInstanceFromDBSnapshotMessage {
+            DBInstanceIdentifier: String;            
+            DBSnapshotIdentifier: String;            
+            DBInstanceClass?: String;            
+            Port?: IntegerOptional;            
+            AvailabilityZone?: String;            
+            DBSubnetGroupName?: String;            
+            MultiAZ?: BooleanOptional;            
+            PubliclyAccessible?: BooleanOptional;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            LicenseModel?: String;            
+            DBName?: String;            
+            Engine?: String;            
+            Iops?: IntegerOptional;            
+            OptionGroupName?: String;            
+        }
+        export interface RestoreDBInstanceToPointInTimeMessage {
+            SourceDBInstanceIdentifier: String;            
+            TargetDBInstanceIdentifier: String;            
+            RestoreTime?: TStamp;            
+            UseLatestRestorableTime?: Boolean;            
+            DBInstanceClass?: String;            
+            Port?: IntegerOptional;            
+            AvailabilityZone?: String;            
+            DBSubnetGroupName?: String;            
+            MultiAZ?: BooleanOptional;            
+            PubliclyAccessible?: BooleanOptional;            
+            AutoMinorVersionUpgrade?: BooleanOptional;            
+            LicenseModel?: String;            
+            DBName?: String;            
+            Engine?: String;            
+            Iops?: IntegerOptional;            
+            OptionGroupName?: String;            
+        }
+        export interface RevokeDBSecurityGroupIngressMessage {
+            DBSecurityGroupName: String;            
+            CIDRIP?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupId?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+        }
+        export interface SNSInvalidTopicFault {
+        }
+        export interface SNSNoAuthorizationFault {
+        }
+        export interface SNSTopicArnNotFoundFault {
+        }
+        export interface SnapshotQuotaExceededFault {
+        }
+        export interface SourceNotFoundFault {
+        }
+        export interface StorageQuotaExceededFault {
+        }
+        export interface Subnet {
+            SubnetIdentifier?: String;            
+            SubnetAvailabilityZone?: AvailabilityZone;            
+            SubnetStatus?: String;            
+        }
+        export interface SubnetAlreadyInUse {
+        }
+        export interface SubscriptionAlreadyExistFault {
+        }
+        export interface SubscriptionCategoryNotFoundFault {
+        }
+        export interface SubscriptionNotFoundFault {
+        }
+        export interface Tag {
+            Key?: String;            
+            Value?: String;            
+        }
+        export interface TagListMessage {
+            TagList?: TagList;            
+        }
+        export interface VpcSecurityGroupMembership {
+            VpcSecurityGroupId?: String;            
+            Status?: String;            
+        }
+        export interface AddSourceIdentifierToSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface AuthorizeDBSecurityGroupIngressResult {
+            DBSecurityGroup?: DBSecurityGroup;            
+        }
+        export interface CopyDBSnapshotResult {
+            DBSnapshot?: DBSnapshot;            
+        }
+        export interface CreateDBInstanceResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface CreateDBInstanceReadReplicaResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface CreateDBParameterGroupResult {
+            DBParameterGroup?: DBParameterGroup;            
+        }
+        export interface CreateDBSecurityGroupResult {
+            DBSecurityGroup?: DBSecurityGroup;            
+        }
+        export interface CreateDBSnapshotResult {
+            DBSnapshot?: DBSnapshot;            
+        }
+        export interface CreateDBSubnetGroupResult {
+            DBSubnetGroup?: DBSubnetGroup;            
+        }
+        export interface CreateEventSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface CreateOptionGroupResult {
+            OptionGroup?: OptionGroup;            
+        }
+        export interface DeleteDBInstanceResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface DeleteDBSnapshotResult {
+            DBSnapshot?: DBSnapshot;            
+        }
+        export interface DeleteEventSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface DescribeEngineDefaultParametersResult {
+            EngineDefaults?: EngineDefaults;            
+        }
+        export interface ModifyDBInstanceResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface ModifyDBSubnetGroupResult {
+            DBSubnetGroup?: DBSubnetGroup;            
+        }
+        export interface ModifyEventSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface ModifyOptionGroupResult {
+            OptionGroup?: OptionGroup;            
+        }
+        export interface PromoteReadReplicaResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface PurchaseReservedDBInstancesOfferingResult {
+            ReservedDBInstance?: ReservedDBInstance;            
+        }
+        export interface RebootDBInstanceResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface RemoveSourceIdentifierFromSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface RestoreDBInstanceFromDBSnapshotResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface RestoreDBInstanceToPointInTimeResult {
+            DBInstance?: DBInstance;            
+        }
+        export interface RevokeDBSecurityGroupIngressResult {
+            DBSecurityGroup?: DBSecurityGroup;            
+        }
 
-    export interface RDSInvalidDBSecurityGroupStateFault {
     }
-
-    export interface RDSInvalidDBSnapshotStateFault {
-    }
-
-    export interface RDSInvalidDBSubnetGroupStateFault {
-    }
-
-    export interface RDSInvalidDBSubnetStateFault {
-    }
-
-    export interface RDSInvalidEventSubscriptionStateFault {
-    }
-
-    export interface RDSInvalidOptionGroupStateFault {
-    }
-
-    export interface RDSInvalidRestoreFault {
-    }
-
-    export interface RDSInvalidSubnet {
-    }
-
-    export interface RDSInvalidVPCNetworkStateFault {
-    }
-
-    export type RDSKeyList = Array<RDSString>;
-    export interface RDSListTagsForResourceMessage {
-        ResourceName: RDSString;
-    }
-
-    export interface RDSModifyDBInstanceMessage {
-        DBInstanceIdentifier: RDSString;
-        AllocatedStorage?: RDSIntegerOptional;
-        DBInstanceClass?: RDSString;
-        DBSecurityGroups?: RDSDBSecurityGroupNameList;
-        VpcSecurityGroupIds?: RDSVpcSecurityGroupIdList;
-        ApplyImmediately?: RDSBoolean;
-        MasterUserPassword?: RDSString;
-        DBParameterGroupName?: RDSString;
-        BackupRetentionPeriod?: RDSIntegerOptional;
-        PreferredBackupWindow?: RDSString;
-        PreferredMaintenanceWindow?: RDSString;
-        MultiAZ?: RDSBooleanOptional;
-        EngineVersion?: RDSString;
-        AllowMajorVersionUpgrade?: RDSBoolean;
-        AutoMinorVersionUpgrade?: RDSBooleanOptional;
-        Iops?: RDSIntegerOptional;
-        OptionGroupName?: RDSString;
-        NewDBInstanceIdentifier?: RDSString;
-    }
-
-    export interface RDSModifyDBParameterGroupMessage {
-        DBParameterGroupName: RDSString;
-        Parameters: RDSParametersList;
-    }
-
-    export interface RDSModifyDBSubnetGroupMessage {
-        DBSubnetGroupName: RDSString;
-        DBSubnetGroupDescription?: RDSString;
-        SubnetIds: RDSSubnetIdentifierList;
-    }
-
-    export interface RDSModifyEventSubscriptionMessage {
-        SubscriptionName: RDSString;
-        SnsTopicArn?: RDSString;
-        SourceType?: RDSString;
-        EventCategories?: RDSEventCategoriesList;
-        Enabled?: RDSBooleanOptional;
-    }
-
-    export interface RDSModifyOptionGroupMessage {
-        OptionGroupName: RDSString;
-        OptionsToInclude?: RDSOptionConfigurationList;
-        OptionsToRemove?: RDSOptionNamesList;
-        ApplyImmediately?: RDSBoolean;
-    }
-
-    export interface RDSOption {
-        OptionName?: RDSString;
-        OptionDescription?: RDSString;
-        Port?: RDSIntegerOptional;
-        DBSecurityGroupMemberships?: RDSDBSecurityGroupMembershipList;
-        VpcSecurityGroupMemberships?: RDSVpcSecurityGroupMembershipList;
-    }
-
-    export interface RDSOptionConfiguration {
-        OptionName: RDSString;
-        Port?: RDSIntegerOptional;
-        DBSecurityGroupMemberships?: RDSDBSecurityGroupNameList;
-        VpcSecurityGroupMemberships?: RDSVpcSecurityGroupIdList;
-    }
-
-    export type RDSOptionConfigurationList = Array<RDSOptionConfiguration>;
-    export interface RDSOptionGroup {
-        OptionGroupName?: RDSString;
-        OptionGroupDescription?: RDSString;
-        EngineName?: RDSString;
-        MajorEngineVersion?: RDSString;
-        Options?: RDSOptionsList;
-        AllowsVpcAndNonVpcInstanceMemberships?: RDSBoolean;
-        VpcId?: RDSString;
-    }
-
-    export interface RDSOptionGroupAlreadyExistsFault {
-    }
-
-    export interface RDSOptionGroupMembership {
-        OptionGroupName?: RDSString;
-        Status?: RDSString;
-    }
-
-    export interface RDSOptionGroupNotFoundFault {
-    }
-
-    export interface RDSOptionGroupOption {
-        Name?: RDSString;
-        Description?: RDSString;
-        EngineName?: RDSString;
-        MajorEngineVersion?: RDSString;
-        MinimumRequiredMinorEngineVersion?: RDSString;
-        PortRequired?: RDSBoolean;
-        DefaultPort?: RDSIntegerOptional;
-        OptionsDependedOn?: RDSOptionsDependedOn;
-    }
-
-    export type RDSOptionGroupOptionsList = Array<RDSOptionGroupOption>;
-    export interface RDSOptionGroupOptionsMessage {
-        OptionGroupOptions?: RDSOptionGroupOptionsList;
-        Marker?: RDSString;
-    }
-
-    export interface RDSOptionGroupQuotaExceededFault {
-    }
-
-    export interface RDSOptionGroups {
-        OptionGroupsList?: RDSOptionGroupsList;
-        Marker?: RDSString;
-    }
-
-    export type RDSOptionGroupsList = Array<RDSOptionGroup>;
-    export type RDSOptionNamesList = Array<RDSString>;
-    export type RDSOptionsDependedOn = Array<RDSString>;
-    export type RDSOptionsList = Array<RDSOption>;
-    export interface RDSOrderableDBInstanceOption {
-        Engine?: RDSString;
-        EngineVersion?: RDSString;
-        DBInstanceClass?: RDSString;
-        LicenseModel?: RDSString;
-        AvailabilityZones?: RDSAvailabilityZoneList;
-        MultiAZCapable?: RDSBoolean;
-        ReadReplicaCapable?: RDSBoolean;
-        Vpc?: RDSBoolean;
-    }
-
-    export type RDSOrderableDBInstanceOptionsList = Array<RDSOrderableDBInstanceOption>;
-    export interface RDSOrderableDBInstanceOptionsMessage {
-        OrderableDBInstanceOptions?: RDSOrderableDBInstanceOptionsList;
-        Marker?: RDSString;
-    }
-
-    export interface RDSParameter {
-        ParameterName?: RDSString;
-        ParameterValue?: RDSString;
-        Description?: RDSString;
-        Source?: RDSString;
-        ApplyType?: RDSString;
-        DataType?: RDSString;
-        AllowedValues?: RDSString;
-        IsModifiable?: RDSBoolean;
-        MinimumEngineVersion?: RDSString;
-        ApplyMethod?: RDSApplyMethod;
-    }
-
-    export type RDSParametersList = Array<RDSParameter>;
-    export interface RDSPendingModifiedValues {
-        DBInstanceClass?: RDSString;
-        AllocatedStorage?: RDSIntegerOptional;
-        MasterUserPassword?: RDSString;
-        Port?: RDSIntegerOptional;
-        BackupRetentionPeriod?: RDSIntegerOptional;
-        MultiAZ?: RDSBooleanOptional;
-        EngineVersion?: RDSString;
-        Iops?: RDSIntegerOptional;
-        DBInstanceIdentifier?: RDSString;
-    }
-
-    export interface RDSPointInTimeRestoreNotEnabledFault {
-    }
-
-    export interface RDSPromoteReadReplicaMessage {
-        DBInstanceIdentifier: RDSString;
-        BackupRetentionPeriod?: RDSIntegerOptional;
-        PreferredBackupWindow?: RDSString;
-    }
-
-    export interface RDSProvisionedIopsNotAvailableInAZFault {
-    }
-
-    export interface RDSPurchaseReservedDBInstancesOfferingMessage {
-        ReservedDBInstancesOfferingId: RDSString;
-        ReservedDBInstanceId?: RDSString;
-        DBInstanceCount?: RDSIntegerOptional;
-    }
-
-    export type RDSReadReplicaDBInstanceIdentifierList = Array<RDSString>;
-    export interface RDSRebootDBInstanceMessage {
-        DBInstanceIdentifier: RDSString;
-        ForceFailover?: RDSBooleanOptional;
-    }
-
-    export interface RDSRecurringCharge {
-        RecurringChargeAmount?: RDSDouble;
-        RecurringChargeFrequency?: RDSString;
-    }
-
-    export type RDSRecurringChargeList = Array<RDSRecurringCharge>;
-    export interface RDSRemoveSourceIdentifierFromSubscriptionMessage {
-        SubscriptionName: RDSString;
-        SourceIdentifier: RDSString;
-    }
-
-    export interface RDSRemoveTagsFromResourceMessage {
-        ResourceName: RDSString;
-        TagKeys: RDSKeyList;
-    }
-
-    export interface RDSReservedDBInstance {
-        ReservedDBInstanceId?: RDSString;
-        ReservedDBInstancesOfferingId?: RDSString;
-        DBInstanceClass?: RDSString;
-        StartTime?: RDSTStamp;
-        Duration?: RDSInteger;
-        FixedPrice?: RDSDouble;
-        UsagePrice?: RDSDouble;
-        CurrencyCode?: RDSString;
-        DBInstanceCount?: RDSInteger;
-        ProductDescription?: RDSString;
-        OfferingType?: RDSString;
-        MultiAZ?: RDSBoolean;
-        State?: RDSString;
-        RecurringCharges?: RDSRecurringChargeList;
-    }
-
-    export interface RDSReservedDBInstanceAlreadyExistsFault {
-    }
-
-    export type RDSReservedDBInstanceList = Array<RDSReservedDBInstance>;
-    export interface RDSReservedDBInstanceMessage {
-        Marker?: RDSString;
-        ReservedDBInstances?: RDSReservedDBInstanceList;
-    }
-
-    export interface RDSReservedDBInstanceNotFoundFault {
-    }
-
-    export interface RDSReservedDBInstanceQuotaExceededFault {
-    }
-
-    export interface RDSReservedDBInstancesOffering {
-        ReservedDBInstancesOfferingId?: RDSString;
-        DBInstanceClass?: RDSString;
-        Duration?: RDSInteger;
-        FixedPrice?: RDSDouble;
-        UsagePrice?: RDSDouble;
-        CurrencyCode?: RDSString;
-        ProductDescription?: RDSString;
-        OfferingType?: RDSString;
-        MultiAZ?: RDSBoolean;
-        RecurringCharges?: RDSRecurringChargeList;
-    }
-
-    export type RDSReservedDBInstancesOfferingList = Array<RDSReservedDBInstancesOffering>;
-    export interface RDSReservedDBInstancesOfferingMessage {
-        Marker?: RDSString;
-        ReservedDBInstancesOfferings?: RDSReservedDBInstancesOfferingList;
-    }
-
-    export interface RDSReservedDBInstancesOfferingNotFoundFault {
-    }
-
-    export interface RDSResetDBParameterGroupMessage {
-        DBParameterGroupName: RDSString;
-        ResetAllParameters?: RDSBoolean;
-        Parameters?: RDSParametersList;
-    }
-
-    export interface RDSRestoreDBInstanceFromDBSnapshotMessage {
-        DBInstanceIdentifier: RDSString;
-        DBSnapshotIdentifier: RDSString;
-        DBInstanceClass?: RDSString;
-        Port?: RDSIntegerOptional;
-        AvailabilityZone?: RDSString;
-        DBSubnetGroupName?: RDSString;
-        MultiAZ?: RDSBooleanOptional;
-        PubliclyAccessible?: RDSBooleanOptional;
-        AutoMinorVersionUpgrade?: RDSBooleanOptional;
-        LicenseModel?: RDSString;
-        DBName?: RDSString;
-        Engine?: RDSString;
-        Iops?: RDSIntegerOptional;
-        OptionGroupName?: RDSString;
-    }
-
-    export interface RDSRestoreDBInstanceToPointInTimeMessage {
-        SourceDBInstanceIdentifier: RDSString;
-        TargetDBInstanceIdentifier: RDSString;
-        RestoreTime?: RDSTStamp;
-        UseLatestRestorableTime?: RDSBoolean;
-        DBInstanceClass?: RDSString;
-        Port?: RDSIntegerOptional;
-        AvailabilityZone?: RDSString;
-        DBSubnetGroupName?: RDSString;
-        MultiAZ?: RDSBooleanOptional;
-        PubliclyAccessible?: RDSBooleanOptional;
-        AutoMinorVersionUpgrade?: RDSBooleanOptional;
-        LicenseModel?: RDSString;
-        DBName?: RDSString;
-        Engine?: RDSString;
-        Iops?: RDSIntegerOptional;
-        OptionGroupName?: RDSString;
-    }
-
-    export interface RDSRevokeDBSecurityGroupIngressMessage {
-        DBSecurityGroupName: RDSString;
-        CIDRIP?: RDSString;
-        EC2SecurityGroupName?: RDSString;
-        EC2SecurityGroupId?: RDSString;
-        EC2SecurityGroupOwnerId?: RDSString;
-    }
-
-    export interface RDSSNSInvalidTopicFault {
-    }
-
-    export interface RDSSNSNoAuthorizationFault {
-    }
-
-    export interface RDSSNSTopicArnNotFoundFault {
-    }
-
-    export interface RDSSnapshotQuotaExceededFault {
-    }
-
-    export type RDSSourceIdsList = Array<RDSString>;
-    export interface RDSSourceNotFoundFault {
-    }
-
-    export type RDSSourceType = string;
-    export interface RDSStorageQuotaExceededFault {
-    }
-
-    export type RDSString = string;
-    export interface RDSSubnet {
-        SubnetIdentifier?: RDSString;
-        SubnetAvailabilityZone?: RDSAvailabilityZone;
-        SubnetStatus?: RDSString;
-    }
-
-    export interface RDSSubnetAlreadyInUse {
-    }
-
-    export type RDSSubnetIdentifierList = Array<RDSString>;
-    export type RDSSubnetList = Array<RDSSubnet>;
-    export interface RDSSubscriptionAlreadyExistFault {
-    }
-
-    export interface RDSSubscriptionCategoryNotFoundFault {
-    }
-
-    export interface RDSSubscriptionNotFoundFault {
-    }
-
-    export type RDSSupportedCharacterSetsList = Array<RDSCharacterSet>;
-    export type RDSTStamp = number;
-    export interface RDSTag {
-        Key?: RDSString;
-        Value?: RDSString;
-    }
-
-    export type RDSTagList = Array<RDSTag>;
-    export interface RDSTagListMessage {
-        TagList?: RDSTagList;
-    }
-
-    export type RDSVpcSecurityGroupIdList = Array<RDSString>;
-    export interface RDSVpcSecurityGroupMembership {
-        VpcSecurityGroupId?: RDSString;
-        Status?: RDSString;
-    }
-
-    export type RDSVpcSecurityGroupMembershipList = Array<RDSVpcSecurityGroupMembership>;
-    export interface RDSAddSourceIdentifierToSubscriptionResult {
-        EventSubscription?: RDSEventSubscription;
-    }
-
-    export interface RDSAuthorizeDBSecurityGroupIngressResult {
-        DBSecurityGroup?: RDSDBSecurityGroup;
-    }
-
-    export interface RDSCopyDBSnapshotResult {
-        DBSnapshot?: RDSDBSnapshot;
-    }
-
-    export interface RDSCreateDBInstanceResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSCreateDBInstanceReadReplicaResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSCreateDBParameterGroupResult {
-        DBParameterGroup?: RDSDBParameterGroup;
-    }
-
-    export interface RDSCreateDBSecurityGroupResult {
-        DBSecurityGroup?: RDSDBSecurityGroup;
-    }
-
-    export interface RDSCreateDBSnapshotResult {
-        DBSnapshot?: RDSDBSnapshot;
-    }
-
-    export interface RDSCreateDBSubnetGroupResult {
-        DBSubnetGroup?: RDSDBSubnetGroup;
-    }
-
-    export interface RDSCreateEventSubscriptionResult {
-        EventSubscription?: RDSEventSubscription;
-    }
-
-    export interface RDSCreateOptionGroupResult {
-        OptionGroup?: RDSOptionGroup;
-    }
-
-    export interface RDSDeleteDBInstanceResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSDeleteDBSnapshotResult {
-        DBSnapshot?: RDSDBSnapshot;
-    }
-
-    export interface RDSDeleteEventSubscriptionResult {
-        EventSubscription?: RDSEventSubscription;
-    }
-
-    export interface RDSDescribeEngineDefaultParametersResult {
-        EngineDefaults?: RDSEngineDefaults;
-    }
-
-    export interface RDSModifyDBInstanceResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSModifyDBSubnetGroupResult {
-        DBSubnetGroup?: RDSDBSubnetGroup;
-    }
-
-    export interface RDSModifyEventSubscriptionResult {
-        EventSubscription?: RDSEventSubscription;
-    }
-
-    export interface RDSModifyOptionGroupResult {
-        OptionGroup?: RDSOptionGroup;
-    }
-
-    export interface RDSPromoteReadReplicaResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSPurchaseReservedDBInstancesOfferingResult {
-        ReservedDBInstance?: RDSReservedDBInstance;
-    }
-
-    export interface RDSRebootDBInstanceResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSRemoveSourceIdentifierFromSubscriptionResult {
-        EventSubscription?: RDSEventSubscription;
-    }
-
-    export interface RDSRestoreDBInstanceFromDBSnapshotResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSRestoreDBInstanceToPointInTimeResult {
-        DBInstance?: RDSDBInstance;
-    }
-
-    export interface RDSRevokeDBSecurityGroupIngressResult {
-        DBSecurityGroup?: RDSDBSecurityGroup;
-    }
-
 }

--- a/output/aws-redshift.d.ts
+++ b/output/aws-redshift.d.ts
@@ -6,1307 +6,1089 @@ declare module "aws-sdk" {
 
     export class Redshift extends Service {
       constructor(options?: any);
-      authorizeClusterSecurityGroupIngress(params: RedshiftAuthorizeClusterSecurityGroupIngressMessage, callback?: (err: RedshiftClusterSecurityGroupNotFoundFault|RedshiftInvalidClusterSecurityGroupStateFault|RedshiftAuthorizationAlreadyExistsFault|RedshiftAuthorizationQuotaExceededFault|any, data: RedshiftAuthorizeClusterSecurityGroupIngressResult|any) => void): Request;
-      authorizeSnapshotAccess(params: RedshiftAuthorizeSnapshotAccessMessage, callback?: (err: RedshiftClusterSnapshotNotFoundFault|RedshiftAuthorizationAlreadyExistsFault|RedshiftAuthorizationQuotaExceededFault|any, data: RedshiftAuthorizeSnapshotAccessResult|any) => void): Request;
-      copyClusterSnapshot(params: RedshiftCopyClusterSnapshotMessage, callback?: (err: RedshiftClusterSnapshotAlreadyExistsFault|RedshiftClusterSnapshotNotFoundFault|RedshiftInvalidClusterSnapshotStateFault|RedshiftClusterSnapshotQuotaExceededFault|any, data: RedshiftCopyClusterSnapshotResult|any) => void): Request;
-      createCluster(params: RedshiftCreateClusterMessage, callback?: (err: RedshiftClusterAlreadyExistsFault|RedshiftInsufficientClusterCapacityFault|RedshiftClusterParameterGroupNotFoundFault|RedshiftClusterSecurityGroupNotFoundFault|RedshiftClusterQuotaExceededFault|RedshiftNumberOfNodesQuotaExceededFault|RedshiftNumberOfNodesPerClusterLimitExceededFault|RedshiftClusterSubnetGroupNotFoundFault|RedshiftInvalidVPCNetworkStateFault|RedshiftInvalidClusterSubnetGroupStateFault|RedshiftInvalidSubnet|RedshiftUnauthorizedOperation|RedshiftHsmClientCertificateNotFoundFault|RedshiftHsmConfigurationNotFoundFault|RedshiftInvalidElasticIpFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|RedshiftLimitExceededFault|any, data: RedshiftCreateClusterResult|any) => void): Request;
-      createClusterParameterGroup(params: RedshiftCreateClusterParameterGroupMessage, callback?: (err: RedshiftClusterParameterGroupQuotaExceededFault|RedshiftClusterParameterGroupAlreadyExistsFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateClusterParameterGroupResult|any) => void): Request;
-      createClusterSecurityGroup(params: RedshiftCreateClusterSecurityGroupMessage, callback?: (err: RedshiftClusterSecurityGroupAlreadyExistsFault|RedshiftClusterSecurityGroupQuotaExceededFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateClusterSecurityGroupResult|any) => void): Request;
-      createClusterSnapshot(params: RedshiftCreateClusterSnapshotMessage, callback?: (err: RedshiftClusterSnapshotAlreadyExistsFault|RedshiftInvalidClusterStateFault|RedshiftClusterNotFoundFault|RedshiftClusterSnapshotQuotaExceededFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateClusterSnapshotResult|any) => void): Request;
-      createClusterSubnetGroup(params: RedshiftCreateClusterSubnetGroupMessage, callback?: (err: RedshiftClusterSubnetGroupAlreadyExistsFault|RedshiftClusterSubnetGroupQuotaExceededFault|RedshiftClusterSubnetQuotaExceededFault|RedshiftInvalidSubnet|RedshiftUnauthorizedOperation|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateClusterSubnetGroupResult|any) => void): Request;
-      createEventSubscription(params: RedshiftCreateEventSubscriptionMessage, callback?: (err: RedshiftEventSubscriptionQuotaExceededFault|RedshiftSubscriptionAlreadyExistFault|RedshiftSNSInvalidTopicFault|RedshiftSNSNoAuthorizationFault|RedshiftSNSTopicArnNotFoundFault|RedshiftSubscriptionEventIdNotFoundFault|RedshiftSubscriptionCategoryNotFoundFault|RedshiftSubscriptionSeverityNotFoundFault|RedshiftSourceNotFoundFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateEventSubscriptionResult|any) => void): Request;
-      createHsmClientCertificate(params: RedshiftCreateHsmClientCertificateMessage, callback?: (err: RedshiftHsmClientCertificateAlreadyExistsFault|RedshiftHsmClientCertificateQuotaExceededFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateHsmClientCertificateResult|any) => void): Request;
-      createHsmConfiguration(params: RedshiftCreateHsmConfigurationMessage, callback?: (err: RedshiftHsmConfigurationAlreadyExistsFault|RedshiftHsmConfigurationQuotaExceededFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateHsmConfigurationResult|any) => void): Request;
-      createSnapshotCopyGrant(params: RedshiftCreateSnapshotCopyGrantMessage, callback?: (err: RedshiftSnapshotCopyGrantAlreadyExistsFault|RedshiftSnapshotCopyGrantQuotaExceededFault|RedshiftLimitExceededFault|RedshiftTagLimitExceededFault|RedshiftInvalidTagFault|any, data: RedshiftCreateSnapshotCopyGrantResult|any) => void): Request;
-      createTags(params: RedshiftCreateTagsMessage, callback?: (err: RedshiftTagLimitExceededFault|RedshiftResourceNotFoundFault|RedshiftInvalidTagFault|any, data: any) => void): Request;
-      deleteCluster(params: RedshiftDeleteClusterMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftInvalidClusterStateFault|RedshiftClusterSnapshotAlreadyExistsFault|RedshiftClusterSnapshotQuotaExceededFault|any, data: RedshiftDeleteClusterResult|any) => void): Request;
-      deleteClusterParameterGroup(params: RedshiftDeleteClusterParameterGroupMessage, callback?: (err: RedshiftInvalidClusterParameterGroupStateFault|RedshiftClusterParameterGroupNotFoundFault|any, data: any) => void): Request;
-      deleteClusterSecurityGroup(params: RedshiftDeleteClusterSecurityGroupMessage, callback?: (err: RedshiftInvalidClusterSecurityGroupStateFault|RedshiftClusterSecurityGroupNotFoundFault|any, data: any) => void): Request;
-      deleteClusterSnapshot(params: RedshiftDeleteClusterSnapshotMessage, callback?: (err: RedshiftInvalidClusterSnapshotStateFault|RedshiftClusterSnapshotNotFoundFault|any, data: RedshiftDeleteClusterSnapshotResult|any) => void): Request;
-      deleteClusterSubnetGroup(params: RedshiftDeleteClusterSubnetGroupMessage, callback?: (err: RedshiftInvalidClusterSubnetGroupStateFault|RedshiftInvalidClusterSubnetStateFault|RedshiftClusterSubnetGroupNotFoundFault|any, data: any) => void): Request;
-      deleteEventSubscription(params: RedshiftDeleteEventSubscriptionMessage, callback?: (err: RedshiftSubscriptionNotFoundFault|RedshiftInvalidSubscriptionStateFault|any, data: any) => void): Request;
-      deleteHsmClientCertificate(params: RedshiftDeleteHsmClientCertificateMessage, callback?: (err: RedshiftInvalidHsmClientCertificateStateFault|RedshiftHsmClientCertificateNotFoundFault|any, data: any) => void): Request;
-      deleteHsmConfiguration(params: RedshiftDeleteHsmConfigurationMessage, callback?: (err: RedshiftInvalidHsmConfigurationStateFault|RedshiftHsmConfigurationNotFoundFault|any, data: any) => void): Request;
-      deleteSnapshotCopyGrant(params: RedshiftDeleteSnapshotCopyGrantMessage, callback?: (err: RedshiftInvalidSnapshotCopyGrantStateFault|RedshiftSnapshotCopyGrantNotFoundFault|any, data: any) => void): Request;
-      deleteTags(params: RedshiftDeleteTagsMessage, callback?: (err: RedshiftResourceNotFoundFault|RedshiftInvalidTagFault|any, data: any) => void): Request;
-      describeClusterParameterGroups(params: RedshiftDescribeClusterParameterGroupsMessage, callback?: (err: RedshiftClusterParameterGroupNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftClusterParameterGroupsMessage|any) => void): Request;
-      describeClusterParameters(params: RedshiftDescribeClusterParametersMessage, callback?: (err: RedshiftClusterParameterGroupNotFoundFault|any, data: RedshiftClusterParameterGroupDetails|any) => void): Request;
-      describeClusterSecurityGroups(params: RedshiftDescribeClusterSecurityGroupsMessage, callback?: (err: RedshiftClusterSecurityGroupNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftClusterSecurityGroupMessage|any) => void): Request;
-      describeClusterSnapshots(params: RedshiftDescribeClusterSnapshotsMessage, callback?: (err: RedshiftClusterSnapshotNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftSnapshotMessage|any) => void): Request;
-      describeClusterSubnetGroups(params: RedshiftDescribeClusterSubnetGroupsMessage, callback?: (err: RedshiftClusterSubnetGroupNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftClusterSubnetGroupMessage|any) => void): Request;
-      describeClusterVersions(params: RedshiftDescribeClusterVersionsMessage, callback?: (err: any, data: RedshiftClusterVersionsMessage|any) => void): Request;
-      describeClusters(params: RedshiftDescribeClustersMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftClustersMessage|any) => void): Request;
-      describeDefaultClusterParameters(params: RedshiftDescribeDefaultClusterParametersMessage, callback?: (err: any, data: RedshiftDescribeDefaultClusterParametersResult|any) => void): Request;
-      describeEventCategories(params: RedshiftDescribeEventCategoriesMessage, callback?: (err: any, data: RedshiftEventCategoriesMessage|any) => void): Request;
-      describeEventSubscriptions(params: RedshiftDescribeEventSubscriptionsMessage, callback?: (err: RedshiftSubscriptionNotFoundFault|any, data: RedshiftEventSubscriptionsMessage|any) => void): Request;
-      describeEvents(params: RedshiftDescribeEventsMessage, callback?: (err: any, data: RedshiftEventsMessage|any) => void): Request;
-      describeHsmClientCertificates(params: RedshiftDescribeHsmClientCertificatesMessage, callback?: (err: RedshiftHsmClientCertificateNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftHsmClientCertificateMessage|any) => void): Request;
-      describeHsmConfigurations(params: RedshiftDescribeHsmConfigurationsMessage, callback?: (err: RedshiftHsmConfigurationNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftHsmConfigurationMessage|any) => void): Request;
-      describeLoggingStatus(params: RedshiftDescribeLoggingStatusMessage, callback?: (err: RedshiftClusterNotFoundFault|any, data: RedshiftLoggingStatus|any) => void): Request;
-      describeOrderableClusterOptions(params: RedshiftDescribeOrderableClusterOptionsMessage, callback?: (err: any, data: RedshiftOrderableClusterOptionsMessage|any) => void): Request;
-      describeReservedNodeOfferings(params: RedshiftDescribeReservedNodeOfferingsMessage, callback?: (err: RedshiftReservedNodeOfferingNotFoundFault|RedshiftUnsupportedOperationFault|any, data: RedshiftReservedNodeOfferingsMessage|any) => void): Request;
-      describeReservedNodes(params: RedshiftDescribeReservedNodesMessage, callback?: (err: RedshiftReservedNodeNotFoundFault|any, data: RedshiftReservedNodesMessage|any) => void): Request;
-      describeResize(params: RedshiftDescribeResizeMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftResizeNotFoundFault|any, data: RedshiftResizeProgressMessage|any) => void): Request;
-      describeSnapshotCopyGrants(params: RedshiftDescribeSnapshotCopyGrantsMessage, callback?: (err: RedshiftSnapshotCopyGrantNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftSnapshotCopyGrantMessage|any) => void): Request;
-      describeTags(params: RedshiftDescribeTagsMessage, callback?: (err: RedshiftResourceNotFoundFault|RedshiftInvalidTagFault|any, data: RedshiftTaggedResourceListMessage|any) => void): Request;
-      disableLogging(params: RedshiftDisableLoggingMessage, callback?: (err: RedshiftClusterNotFoundFault|any, data: RedshiftLoggingStatus|any) => void): Request;
-      disableSnapshotCopy(params: RedshiftDisableSnapshotCopyMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftSnapshotCopyAlreadyDisabledFault|RedshiftInvalidClusterStateFault|RedshiftUnauthorizedOperation|any, data: RedshiftDisableSnapshotCopyResult|any) => void): Request;
-      enableLogging(params: RedshiftEnableLoggingMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftBucketNotFoundFault|RedshiftInsufficientS3BucketPolicyFault|RedshiftInvalidS3KeyPrefixFault|RedshiftInvalidS3BucketNameFault|any, data: RedshiftLoggingStatus|any) => void): Request;
-      enableSnapshotCopy(params: RedshiftEnableSnapshotCopyMessage, callback?: (err: RedshiftIncompatibleOrderableOptions|RedshiftInvalidClusterStateFault|RedshiftClusterNotFoundFault|RedshiftCopyToRegionDisabledFault|RedshiftSnapshotCopyAlreadyEnabledFault|RedshiftUnknownSnapshotCopyRegionFault|RedshiftUnauthorizedOperation|RedshiftSnapshotCopyGrantNotFoundFault|RedshiftLimitExceededFault|any, data: RedshiftEnableSnapshotCopyResult|any) => void): Request;
-      modifyCluster(params: RedshiftModifyClusterMessage, callback?: (err: RedshiftInvalidClusterStateFault|RedshiftInvalidClusterSecurityGroupStateFault|RedshiftClusterNotFoundFault|RedshiftNumberOfNodesQuotaExceededFault|RedshiftClusterSecurityGroupNotFoundFault|RedshiftClusterParameterGroupNotFoundFault|RedshiftInsufficientClusterCapacityFault|RedshiftUnsupportedOptionFault|RedshiftUnauthorizedOperation|RedshiftHsmClientCertificateNotFoundFault|RedshiftHsmConfigurationNotFoundFault|RedshiftClusterAlreadyExistsFault|RedshiftLimitExceededFault|any, data: RedshiftModifyClusterResult|any) => void): Request;
-      modifyClusterParameterGroup(params: RedshiftModifyClusterParameterGroupMessage, callback?: (err: RedshiftClusterParameterGroupNotFoundFault|RedshiftInvalidClusterParameterGroupStateFault|any, data: RedshiftClusterParameterGroupNameMessage|any) => void): Request;
-      modifyClusterSubnetGroup(params: RedshiftModifyClusterSubnetGroupMessage, callback?: (err: RedshiftClusterSubnetGroupNotFoundFault|RedshiftClusterSubnetQuotaExceededFault|RedshiftSubnetAlreadyInUse|RedshiftInvalidSubnet|RedshiftUnauthorizedOperation|any, data: RedshiftModifyClusterSubnetGroupResult|any) => void): Request;
-      modifyEventSubscription(params: RedshiftModifyEventSubscriptionMessage, callback?: (err: RedshiftSubscriptionNotFoundFault|RedshiftSNSInvalidTopicFault|RedshiftSNSNoAuthorizationFault|RedshiftSNSTopicArnNotFoundFault|RedshiftSubscriptionEventIdNotFoundFault|RedshiftSubscriptionCategoryNotFoundFault|RedshiftSubscriptionSeverityNotFoundFault|RedshiftSourceNotFoundFault|RedshiftInvalidSubscriptionStateFault|any, data: RedshiftModifyEventSubscriptionResult|any) => void): Request;
-      modifySnapshotCopyRetentionPeriod(params: RedshiftModifySnapshotCopyRetentionPeriodMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftSnapshotCopyDisabledFault|RedshiftUnauthorizedOperation|RedshiftInvalidClusterStateFault|any, data: RedshiftModifySnapshotCopyRetentionPeriodResult|any) => void): Request;
-      purchaseReservedNodeOffering(params: RedshiftPurchaseReservedNodeOfferingMessage, callback?: (err: RedshiftReservedNodeOfferingNotFoundFault|RedshiftReservedNodeAlreadyExistsFault|RedshiftReservedNodeQuotaExceededFault|RedshiftUnsupportedOperationFault|any, data: RedshiftPurchaseReservedNodeOfferingResult|any) => void): Request;
-      rebootCluster(params: RedshiftRebootClusterMessage, callback?: (err: RedshiftInvalidClusterStateFault|RedshiftClusterNotFoundFault|any, data: RedshiftRebootClusterResult|any) => void): Request;
-      resetClusterParameterGroup(params: RedshiftResetClusterParameterGroupMessage, callback?: (err: RedshiftInvalidClusterParameterGroupStateFault|RedshiftClusterParameterGroupNotFoundFault|any, data: RedshiftClusterParameterGroupNameMessage|any) => void): Request;
-      restoreFromClusterSnapshot(params: RedshiftRestoreFromClusterSnapshotMessage, callback?: (err: RedshiftAccessToSnapshotDeniedFault|RedshiftClusterAlreadyExistsFault|RedshiftClusterSnapshotNotFoundFault|RedshiftClusterQuotaExceededFault|RedshiftInsufficientClusterCapacityFault|RedshiftInvalidClusterSnapshotStateFault|RedshiftInvalidRestoreFault|RedshiftNumberOfNodesQuotaExceededFault|RedshiftNumberOfNodesPerClusterLimitExceededFault|RedshiftInvalidVPCNetworkStateFault|RedshiftInvalidClusterSubnetGroupStateFault|RedshiftInvalidSubnet|RedshiftClusterSubnetGroupNotFoundFault|RedshiftUnauthorizedOperation|RedshiftHsmClientCertificateNotFoundFault|RedshiftHsmConfigurationNotFoundFault|RedshiftInvalidElasticIpFault|RedshiftClusterParameterGroupNotFoundFault|RedshiftClusterSecurityGroupNotFoundFault|RedshiftLimitExceededFault|any, data: RedshiftRestoreFromClusterSnapshotResult|any) => void): Request;
-      revokeClusterSecurityGroupIngress(params: RedshiftRevokeClusterSecurityGroupIngressMessage, callback?: (err: RedshiftClusterSecurityGroupNotFoundFault|RedshiftAuthorizationNotFoundFault|RedshiftInvalidClusterSecurityGroupStateFault|any, data: RedshiftRevokeClusterSecurityGroupIngressResult|any) => void): Request;
-      revokeSnapshotAccess(params: RedshiftRevokeSnapshotAccessMessage, callback?: (err: RedshiftAccessToSnapshotDeniedFault|RedshiftAuthorizationNotFoundFault|RedshiftClusterSnapshotNotFoundFault|any, data: RedshiftRevokeSnapshotAccessResult|any) => void): Request;
-      rotateEncryptionKey(params: RedshiftRotateEncryptionKeyMessage, callback?: (err: RedshiftClusterNotFoundFault|RedshiftInvalidClusterStateFault|any, data: RedshiftRotateEncryptionKeyResult|any) => void): Request;
-    }
-
-    export interface RedshiftAccessToSnapshotDeniedFault {
-    }
-
-    export interface RedshiftAccountWithRestoreAccess {
-        AccountId?: RedshiftString;
-    }
-
-    export type RedshiftAccountsWithRestoreAccessList = Array<RedshiftAccountWithRestoreAccess>;
-    export interface RedshiftAuthorizationAlreadyExistsFault {
-    }
-
-    export interface RedshiftAuthorizationNotFoundFault {
-    }
-
-    export interface RedshiftAuthorizationQuotaExceededFault {
-    }
-
-    export interface RedshiftAuthorizeClusterSecurityGroupIngressMessage {
-        ClusterSecurityGroupName: RedshiftString;
-        CIDRIP?: RedshiftString;
-        EC2SecurityGroupName?: RedshiftString;
-        EC2SecurityGroupOwnerId?: RedshiftString;
-    }
-
-    export interface RedshiftAuthorizeSnapshotAccessMessage {
-        SnapshotIdentifier: RedshiftString;
-        SnapshotClusterIdentifier?: RedshiftString;
-        AccountWithRestoreAccess: RedshiftString;
-    }
-
-    export interface RedshiftAvailabilityZone {
-        Name?: RedshiftString;
-    }
-
-    export type RedshiftAvailabilityZoneList = Array<RedshiftAvailabilityZone>;
-    export type RedshiftBoolean = boolean;
-    export type RedshiftBooleanOptional = boolean;
-    export interface RedshiftBucketNotFoundFault {
-    }
-
-    export interface RedshiftCluster {
-        ClusterIdentifier?: RedshiftString;
-        NodeType?: RedshiftString;
-        ClusterStatus?: RedshiftString;
-        ModifyStatus?: RedshiftString;
-        MasterUsername?: RedshiftString;
-        DBName?: RedshiftString;
-        Endpoint?: RedshiftEndpoint;
-        ClusterCreateTime?: RedshiftTStamp;
-        AutomatedSnapshotRetentionPeriod?: RedshiftInteger;
-        ClusterSecurityGroups?: RedshiftClusterSecurityGroupMembershipList;
-        VpcSecurityGroups?: RedshiftVpcSecurityGroupMembershipList;
-        ClusterParameterGroups?: RedshiftClusterParameterGroupStatusList;
-        ClusterSubnetGroupName?: RedshiftString;
-        VpcId?: RedshiftString;
-        AvailabilityZone?: RedshiftString;
-        PreferredMaintenanceWindow?: RedshiftString;
-        PendingModifiedValues?: RedshiftPendingModifiedValues;
-        ClusterVersion?: RedshiftString;
-        AllowVersionUpgrade?: RedshiftBoolean;
-        NumberOfNodes?: RedshiftInteger;
-        PubliclyAccessible?: RedshiftBoolean;
-        Encrypted?: RedshiftBoolean;
-        RestoreStatus?: RedshiftRestoreStatus;
-        HsmStatus?: RedshiftHsmStatus;
-        ClusterSnapshotCopyStatus?: RedshiftClusterSnapshotCopyStatus;
-        ClusterPublicKey?: RedshiftString;
-        ClusterNodes?: RedshiftClusterNodesList;
-        ElasticIpStatus?: RedshiftElasticIpStatus;
-        ClusterRevisionNumber?: RedshiftString;
-        Tags?: RedshiftTagList;
-        KmsKeyId?: RedshiftString;
-    }
-
-    export interface RedshiftClusterAlreadyExistsFault {
-    }
-
-    export type RedshiftClusterList = Array<RedshiftCluster>;
-    export interface RedshiftClusterNode {
-        NodeRole?: RedshiftString;
-        PrivateIPAddress?: RedshiftString;
-        PublicIPAddress?: RedshiftString;
-    }
-
-    export type RedshiftClusterNodesList = Array<RedshiftClusterNode>;
-    export interface RedshiftClusterNotFoundFault {
-    }
-
-    export interface RedshiftClusterParameterGroup {
-        ParameterGroupName?: RedshiftString;
-        ParameterGroupFamily?: RedshiftString;
-        Description?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftClusterParameterGroupAlreadyExistsFault {
-    }
-
-    export interface RedshiftClusterParameterGroupDetails {
-        Parameters?: RedshiftParametersList;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftClusterParameterGroupNameMessage {
-        ParameterGroupName?: RedshiftString;
-        ParameterGroupStatus?: RedshiftString;
-    }
-
-    export interface RedshiftClusterParameterGroupNotFoundFault {
-    }
-
-    export interface RedshiftClusterParameterGroupQuotaExceededFault {
-    }
-
-    export interface RedshiftClusterParameterGroupStatus {
-        ParameterGroupName?: RedshiftString;
-        ParameterApplyStatus?: RedshiftString;
-        ClusterParameterStatusList?: RedshiftClusterParameterStatusList;
-    }
-
-    export type RedshiftClusterParameterGroupStatusList = Array<RedshiftClusterParameterGroupStatus>;
-    export interface RedshiftClusterParameterGroupsMessage {
-        Marker?: RedshiftString;
-        ParameterGroups?: RedshiftParameterGroupList;
-    }
-
-    export interface RedshiftClusterParameterStatus {
-        ParameterName?: RedshiftString;
-        ParameterApplyStatus?: RedshiftString;
-        ParameterApplyErrorDescription?: RedshiftString;
-    }
-
-    export type RedshiftClusterParameterStatusList = Array<RedshiftClusterParameterStatus>;
-    export interface RedshiftClusterQuotaExceededFault {
-    }
-
-    export interface RedshiftClusterSecurityGroup {
-        ClusterSecurityGroupName?: RedshiftString;
-        Description?: RedshiftString;
-        EC2SecurityGroups?: RedshiftEC2SecurityGroupList;
-        IPRanges?: RedshiftIPRangeList;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftClusterSecurityGroupAlreadyExistsFault {
-    }
-
-    export interface RedshiftClusterSecurityGroupMembership {
-        ClusterSecurityGroupName?: RedshiftString;
-        Status?: RedshiftString;
-    }
-
-    export type RedshiftClusterSecurityGroupMembershipList = Array<RedshiftClusterSecurityGroupMembership>;
-    export interface RedshiftClusterSecurityGroupMessage {
-        Marker?: RedshiftString;
-        ClusterSecurityGroups?: RedshiftClusterSecurityGroups;
-    }
-
-    export type RedshiftClusterSecurityGroupNameList = Array<RedshiftString>;
-    export interface RedshiftClusterSecurityGroupNotFoundFault {
-    }
-
-    export interface RedshiftClusterSecurityGroupQuotaExceededFault {
-    }
-
-    export type RedshiftClusterSecurityGroups = Array<RedshiftClusterSecurityGroup>;
-    export interface RedshiftClusterSnapshotAlreadyExistsFault {
-    }
-
-    export interface RedshiftClusterSnapshotCopyStatus {
-        DestinationRegion?: RedshiftString;
-        RetentionPeriod?: RedshiftLong;
-        SnapshotCopyGrantName?: RedshiftString;
-    }
-
-    export interface RedshiftClusterSnapshotNotFoundFault {
-    }
-
-    export interface RedshiftClusterSnapshotQuotaExceededFault {
-    }
-
-    export interface RedshiftClusterSubnetGroup {
-        ClusterSubnetGroupName?: RedshiftString;
-        Description?: RedshiftString;
-        VpcId?: RedshiftString;
-        SubnetGroupStatus?: RedshiftString;
-        Subnets?: RedshiftSubnetList;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftClusterSubnetGroupAlreadyExistsFault {
-    }
-
-    export interface RedshiftClusterSubnetGroupMessage {
-        Marker?: RedshiftString;
-        ClusterSubnetGroups?: RedshiftClusterSubnetGroups;
-    }
-
-    export interface RedshiftClusterSubnetGroupNotFoundFault {
-    }
-
-    export interface RedshiftClusterSubnetGroupQuotaExceededFault {
-    }
-
-    export type RedshiftClusterSubnetGroups = Array<RedshiftClusterSubnetGroup>;
-    export interface RedshiftClusterSubnetQuotaExceededFault {
-    }
-
-    export interface RedshiftClusterVersion {
-        ClusterVersion?: RedshiftString;
-        ClusterParameterGroupFamily?: RedshiftString;
-        Description?: RedshiftString;
-    }
-
-    export type RedshiftClusterVersionList = Array<RedshiftClusterVersion>;
-    export interface RedshiftClusterVersionsMessage {
-        Marker?: RedshiftString;
-        ClusterVersions?: RedshiftClusterVersionList;
-    }
-
-    export interface RedshiftClustersMessage {
-        Marker?: RedshiftString;
-        Clusters?: RedshiftClusterList;
-    }
-
-    export interface RedshiftCopyClusterSnapshotMessage {
-        SourceSnapshotIdentifier: RedshiftString;
-        SourceSnapshotClusterIdentifier?: RedshiftString;
-        TargetSnapshotIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftCopyToRegionDisabledFault {
-    }
-
-    export interface RedshiftCreateClusterMessage {
-        DBName?: RedshiftString;
-        ClusterIdentifier: RedshiftString;
-        ClusterType?: RedshiftString;
-        NodeType: RedshiftString;
-        MasterUsername: RedshiftString;
-        MasterUserPassword: RedshiftString;
-        ClusterSecurityGroups?: RedshiftClusterSecurityGroupNameList;
-        VpcSecurityGroupIds?: RedshiftVpcSecurityGroupIdList;
-        ClusterSubnetGroupName?: RedshiftString;
-        AvailabilityZone?: RedshiftString;
-        PreferredMaintenanceWindow?: RedshiftString;
-        ClusterParameterGroupName?: RedshiftString;
-        AutomatedSnapshotRetentionPeriod?: RedshiftIntegerOptional;
-        Port?: RedshiftIntegerOptional;
-        ClusterVersion?: RedshiftString;
-        AllowVersionUpgrade?: RedshiftBooleanOptional;
-        NumberOfNodes?: RedshiftIntegerOptional;
-        PubliclyAccessible?: RedshiftBooleanOptional;
-        Encrypted?: RedshiftBooleanOptional;
-        HsmClientCertificateIdentifier?: RedshiftString;
-        HsmConfigurationIdentifier?: RedshiftString;
-        ElasticIp?: RedshiftString;
-        Tags?: RedshiftTagList;
-        KmsKeyId?: RedshiftString;
-    }
-
-    export interface RedshiftCreateClusterParameterGroupMessage {
-        ParameterGroupName: RedshiftString;
-        ParameterGroupFamily: RedshiftString;
-        Description: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateClusterSecurityGroupMessage {
-        ClusterSecurityGroupName: RedshiftString;
-        Description: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateClusterSnapshotMessage {
-        SnapshotIdentifier: RedshiftString;
-        ClusterIdentifier: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateClusterSubnetGroupMessage {
-        ClusterSubnetGroupName: RedshiftString;
-        Description: RedshiftString;
-        SubnetIds: RedshiftSubnetIdentifierList;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateEventSubscriptionMessage {
-        SubscriptionName: RedshiftString;
-        SnsTopicArn: RedshiftString;
-        SourceType?: RedshiftString;
-        SourceIds?: RedshiftSourceIdsList;
-        EventCategories?: RedshiftEventCategoriesList;
-        Severity?: RedshiftString;
-        Enabled?: RedshiftBooleanOptional;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateHsmClientCertificateMessage {
-        HsmClientCertificateIdentifier: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateHsmConfigurationMessage {
-        HsmConfigurationIdentifier: RedshiftString;
-        Description: RedshiftString;
-        HsmIpAddress: RedshiftString;
-        HsmPartitionName: RedshiftString;
-        HsmPartitionPassword: RedshiftString;
-        HsmServerPublicCertificate: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateSnapshotCopyGrantMessage {
-        SnapshotCopyGrantName: RedshiftString;
-        KmsKeyId?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftCreateTagsMessage {
-        ResourceName: RedshiftString;
-        Tags: RedshiftTagList;
-    }
-
-    export interface RedshiftDefaultClusterParameters {
-        ParameterGroupFamily?: RedshiftString;
-        Marker?: RedshiftString;
-        Parameters?: RedshiftParametersList;
-    }
-
-    export interface RedshiftDeleteClusterMessage {
-        ClusterIdentifier: RedshiftString;
-        SkipFinalClusterSnapshot?: RedshiftBoolean;
-        FinalClusterSnapshotIdentifier?: RedshiftString;
-    }
-
-    export interface RedshiftDeleteClusterParameterGroupMessage {
-        ParameterGroupName: RedshiftString;
-    }
-
-    export interface RedshiftDeleteClusterSecurityGroupMessage {
-        ClusterSecurityGroupName: RedshiftString;
-    }
-
-    export interface RedshiftDeleteClusterSnapshotMessage {
-        SnapshotIdentifier: RedshiftString;
-        SnapshotClusterIdentifier?: RedshiftString;
-    }
-
-    export interface RedshiftDeleteClusterSubnetGroupMessage {
-        ClusterSubnetGroupName: RedshiftString;
-    }
-
-    export interface RedshiftDeleteEventSubscriptionMessage {
-        SubscriptionName: RedshiftString;
-    }
-
-    export interface RedshiftDeleteHsmClientCertificateMessage {
-        HsmClientCertificateIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftDeleteHsmConfigurationMessage {
-        HsmConfigurationIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftDeleteSnapshotCopyGrantMessage {
-        SnapshotCopyGrantName: RedshiftString;
-    }
-
-    export interface RedshiftDeleteTagsMessage {
-        ResourceName: RedshiftString;
-        TagKeys: RedshiftTagKeyList;
-    }
-
-    export interface RedshiftDescribeClusterParameterGroupsMessage {
-        ParameterGroupName?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeClusterParametersMessage {
-        ParameterGroupName: RedshiftString;
-        Source?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeClusterSecurityGroupsMessage {
-        ClusterSecurityGroupName?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeClusterSnapshotsMessage {
-        ClusterIdentifier?: RedshiftString;
-        SnapshotIdentifier?: RedshiftString;
-        SnapshotType?: RedshiftString;
-        StartTime?: RedshiftTStamp;
-        EndTime?: RedshiftTStamp;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        OwnerAccount?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeClusterSubnetGroupsMessage {
-        ClusterSubnetGroupName?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeClusterVersionsMessage {
-        ClusterVersion?: RedshiftString;
-        ClusterParameterGroupFamily?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeClustersMessage {
-        ClusterIdentifier?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeDefaultClusterParametersMessage {
-        ParameterGroupFamily: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeEventCategoriesMessage {
-        SourceType?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeEventSubscriptionsMessage {
-        SubscriptionName?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeEventsMessage {
-        SourceIdentifier?: RedshiftString;
-        SourceType?: RedshiftSourceType;
-        StartTime?: RedshiftTStamp;
-        EndTime?: RedshiftTStamp;
-        Duration?: RedshiftIntegerOptional;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeHsmClientCertificatesMessage {
-        HsmClientCertificateIdentifier?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeHsmConfigurationsMessage {
-        HsmConfigurationIdentifier?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeLoggingStatusMessage {
-        ClusterIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftDescribeOrderableClusterOptionsMessage {
-        ClusterVersion?: RedshiftString;
-        NodeType?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeReservedNodeOfferingsMessage {
-        ReservedNodeOfferingId?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeReservedNodesMessage {
-        ReservedNodeId?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftDescribeResizeMessage {
-        ClusterIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftDescribeSnapshotCopyGrantsMessage {
-        SnapshotCopyGrantName?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDescribeTagsMessage {
-        ResourceName?: RedshiftString;
-        ResourceType?: RedshiftString;
-        MaxRecords?: RedshiftIntegerOptional;
-        Marker?: RedshiftString;
-        TagKeys?: RedshiftTagKeyList;
-        TagValues?: RedshiftTagValueList;
-    }
-
-    export interface RedshiftDisableLoggingMessage {
-        ClusterIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftDisableSnapshotCopyMessage {
-        ClusterIdentifier: RedshiftString;
-    }
-
-    export type RedshiftDouble = number;
-    export type RedshiftDoubleOptional = number;
-    export interface RedshiftEC2SecurityGroup {
-        Status?: RedshiftString;
-        EC2SecurityGroupName?: RedshiftString;
-        EC2SecurityGroupOwnerId?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export type RedshiftEC2SecurityGroupList = Array<RedshiftEC2SecurityGroup>;
-    export interface RedshiftElasticIpStatus {
-        ElasticIp?: RedshiftString;
-        Status?: RedshiftString;
-    }
-
-    export interface RedshiftEnableLoggingMessage {
-        ClusterIdentifier: RedshiftString;
-        BucketName: RedshiftString;
-        S3KeyPrefix?: RedshiftString;
-    }
-
-    export interface RedshiftEnableSnapshotCopyMessage {
-        ClusterIdentifier: RedshiftString;
-        DestinationRegion: RedshiftString;
-        RetentionPeriod?: RedshiftIntegerOptional;
-        SnapshotCopyGrantName?: RedshiftString;
-    }
-
-    export interface RedshiftEndpoint {
-        Address?: RedshiftString;
-        Port?: RedshiftInteger;
-    }
-
-    export interface RedshiftEvent {
-        SourceIdentifier?: RedshiftString;
-        SourceType?: RedshiftSourceType;
-        Message?: RedshiftString;
-        EventCategories?: RedshiftEventCategoriesList;
-        Severity?: RedshiftString;
-        Date?: RedshiftTStamp;
-        EventId?: RedshiftString;
-    }
-
-    export type RedshiftEventCategoriesList = Array<RedshiftString>;
-    export interface RedshiftEventCategoriesMap {
-        SourceType?: RedshiftString;
-        Events?: RedshiftEventInfoMapList;
-    }
-
-    export type RedshiftEventCategoriesMapList = Array<RedshiftEventCategoriesMap>;
-    export interface RedshiftEventCategoriesMessage {
-        EventCategoriesMapList?: RedshiftEventCategoriesMapList;
-    }
-
-    export interface RedshiftEventInfoMap {
-        EventId?: RedshiftString;
-        EventCategories?: RedshiftEventCategoriesList;
-        EventDescription?: RedshiftString;
-        Severity?: RedshiftString;
-    }
-
-    export type RedshiftEventInfoMapList = Array<RedshiftEventInfoMap>;
-    export type RedshiftEventList = Array<RedshiftEvent>;
-    export interface RedshiftEventSubscription {
-        CustomerAwsId?: RedshiftString;
-        CustSubscriptionId?: RedshiftString;
-        SnsTopicArn?: RedshiftString;
-        Status?: RedshiftString;
-        SubscriptionCreationTime?: RedshiftTStamp;
-        SourceType?: RedshiftString;
-        SourceIdsList?: RedshiftSourceIdsList;
-        EventCategoriesList?: RedshiftEventCategoriesList;
-        Severity?: RedshiftString;
-        Enabled?: RedshiftBoolean;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftEventSubscriptionQuotaExceededFault {
-    }
-
-    export type RedshiftEventSubscriptionsList = Array<RedshiftEventSubscription>;
-    export interface RedshiftEventSubscriptionsMessage {
-        Marker?: RedshiftString;
-        EventSubscriptionsList?: RedshiftEventSubscriptionsList;
-    }
-
-    export interface RedshiftEventsMessage {
-        Marker?: RedshiftString;
-        Events?: RedshiftEventList;
-    }
-
-    export interface RedshiftHsmClientCertificate {
-        HsmClientCertificateIdentifier?: RedshiftString;
-        HsmClientCertificatePublicKey?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftHsmClientCertificateAlreadyExistsFault {
-    }
-
-    export type RedshiftHsmClientCertificateList = Array<RedshiftHsmClientCertificate>;
-    export interface RedshiftHsmClientCertificateMessage {
-        Marker?: RedshiftString;
-        HsmClientCertificates?: RedshiftHsmClientCertificateList;
-    }
-
-    export interface RedshiftHsmClientCertificateNotFoundFault {
-    }
-
-    export interface RedshiftHsmClientCertificateQuotaExceededFault {
-    }
-
-    export interface RedshiftHsmConfiguration {
-        HsmConfigurationIdentifier?: RedshiftString;
-        Description?: RedshiftString;
-        HsmIpAddress?: RedshiftString;
-        HsmPartitionName?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftHsmConfigurationAlreadyExistsFault {
-    }
-
-    export type RedshiftHsmConfigurationList = Array<RedshiftHsmConfiguration>;
-    export interface RedshiftHsmConfigurationMessage {
-        Marker?: RedshiftString;
-        HsmConfigurations?: RedshiftHsmConfigurationList;
-    }
-
-    export interface RedshiftHsmConfigurationNotFoundFault {
-    }
-
-    export interface RedshiftHsmConfigurationQuotaExceededFault {
-    }
-
-    export interface RedshiftHsmStatus {
-        HsmClientCertificateIdentifier?: RedshiftString;
-        HsmConfigurationIdentifier?: RedshiftString;
-        Status?: RedshiftString;
-    }
-
-    export interface RedshiftIPRange {
-        Status?: RedshiftString;
-        CIDRIP?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export type RedshiftIPRangeList = Array<RedshiftIPRange>;
-    export type RedshiftImportTablesCompleted = Array<RedshiftString>;
-    export type RedshiftImportTablesInProgress = Array<RedshiftString>;
-    export type RedshiftImportTablesNotStarted = Array<RedshiftString>;
-    export interface RedshiftIncompatibleOrderableOptions {
-    }
-
-    export interface RedshiftInsufficientClusterCapacityFault {
-    }
-
-    export interface RedshiftInsufficientS3BucketPolicyFault {
-    }
-
-    export type RedshiftInteger = number;
-    export type RedshiftIntegerOptional = number;
-    export interface RedshiftInvalidClusterParameterGroupStateFault {
-    }
-
-    export interface RedshiftInvalidClusterSecurityGroupStateFault {
-    }
-
-    export interface RedshiftInvalidClusterSnapshotStateFault {
-    }
-
-    export interface RedshiftInvalidClusterStateFault {
-    }
-
-    export interface RedshiftInvalidClusterSubnetGroupStateFault {
-    }
-
-    export interface RedshiftInvalidClusterSubnetStateFault {
-    }
-
-    export interface RedshiftInvalidElasticIpFault {
-    }
-
-    export interface RedshiftInvalidHsmClientCertificateStateFault {
-    }
-
-    export interface RedshiftInvalidHsmConfigurationStateFault {
-    }
-
-    export interface RedshiftInvalidRestoreFault {
-    }
-
-    export interface RedshiftInvalidS3BucketNameFault {
-    }
-
-    export interface RedshiftInvalidS3KeyPrefixFault {
-    }
-
-    export interface RedshiftInvalidSnapshotCopyGrantStateFault {
-    }
-
-    export interface RedshiftInvalidSubnet {
-    }
-
-    export interface RedshiftInvalidSubscriptionStateFault {
-    }
-
-    export interface RedshiftInvalidTagFault {
-    }
-
-    export interface RedshiftInvalidVPCNetworkStateFault {
-    }
-
-    export interface RedshiftLimitExceededFault {
-    }
-
-    export interface RedshiftLoggingStatus {
-        LoggingEnabled?: RedshiftBoolean;
-        BucketName?: RedshiftString;
-        S3KeyPrefix?: RedshiftString;
-        LastSuccessfulDeliveryTime?: RedshiftTStamp;
-        LastFailureTime?: RedshiftTStamp;
-        LastFailureMessage?: RedshiftString;
-    }
-
-    export type RedshiftLong = number;
-    export type RedshiftLongOptional = number;
-    export interface RedshiftModifyClusterMessage {
-        ClusterIdentifier: RedshiftString;
-        ClusterType?: RedshiftString;
-        NodeType?: RedshiftString;
-        NumberOfNodes?: RedshiftIntegerOptional;
-        ClusterSecurityGroups?: RedshiftClusterSecurityGroupNameList;
-        VpcSecurityGroupIds?: RedshiftVpcSecurityGroupIdList;
-        MasterUserPassword?: RedshiftString;
-        ClusterParameterGroupName?: RedshiftString;
-        AutomatedSnapshotRetentionPeriod?: RedshiftIntegerOptional;
-        PreferredMaintenanceWindow?: RedshiftString;
-        ClusterVersion?: RedshiftString;
-        AllowVersionUpgrade?: RedshiftBooleanOptional;
-        HsmClientCertificateIdentifier?: RedshiftString;
-        HsmConfigurationIdentifier?: RedshiftString;
-        NewClusterIdentifier?: RedshiftString;
-    }
-
-    export interface RedshiftModifyClusterParameterGroupMessage {
-        ParameterGroupName: RedshiftString;
-        Parameters: RedshiftParametersList;
-    }
-
-    export interface RedshiftModifyClusterSubnetGroupMessage {
-        ClusterSubnetGroupName: RedshiftString;
-        Description?: RedshiftString;
-        SubnetIds: RedshiftSubnetIdentifierList;
-    }
-
-    export interface RedshiftModifyEventSubscriptionMessage {
-        SubscriptionName: RedshiftString;
-        SnsTopicArn?: RedshiftString;
-        SourceType?: RedshiftString;
-        SourceIds?: RedshiftSourceIdsList;
-        EventCategories?: RedshiftEventCategoriesList;
-        Severity?: RedshiftString;
-        Enabled?: RedshiftBooleanOptional;
-    }
-
-    export interface RedshiftModifySnapshotCopyRetentionPeriodMessage {
-        ClusterIdentifier: RedshiftString;
-        RetentionPeriod: RedshiftInteger;
-    }
-
-    export interface RedshiftNumberOfNodesPerClusterLimitExceededFault {
-    }
-
-    export interface RedshiftNumberOfNodesQuotaExceededFault {
-    }
-
-    export interface RedshiftOrderableClusterOption {
-        ClusterVersion?: RedshiftString;
-        ClusterType?: RedshiftString;
-        NodeType?: RedshiftString;
-        AvailabilityZones?: RedshiftAvailabilityZoneList;
-    }
-
-    export type RedshiftOrderableClusterOptionsList = Array<RedshiftOrderableClusterOption>;
-    export interface RedshiftOrderableClusterOptionsMessage {
-        OrderableClusterOptions?: RedshiftOrderableClusterOptionsList;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftParameter {
-        ParameterName?: RedshiftString;
-        ParameterValue?: RedshiftString;
-        Description?: RedshiftString;
-        Source?: RedshiftString;
-        DataType?: RedshiftString;
-        AllowedValues?: RedshiftString;
-        ApplyType?: RedshiftParameterApplyType;
-        IsModifiable?: RedshiftBoolean;
-        MinimumEngineVersion?: RedshiftString;
-    }
-
-    export type RedshiftParameterApplyType = string;
-    export type RedshiftParameterGroupList = Array<RedshiftClusterParameterGroup>;
-    export type RedshiftParametersList = Array<RedshiftParameter>;
-    export interface RedshiftPendingModifiedValues {
-        MasterUserPassword?: RedshiftString;
-        NodeType?: RedshiftString;
-        NumberOfNodes?: RedshiftIntegerOptional;
-        ClusterType?: RedshiftString;
-        ClusterVersion?: RedshiftString;
-        AutomatedSnapshotRetentionPeriod?: RedshiftIntegerOptional;
-        ClusterIdentifier?: RedshiftString;
-    }
-
-    export interface RedshiftPurchaseReservedNodeOfferingMessage {
-        ReservedNodeOfferingId: RedshiftString;
-        NodeCount?: RedshiftIntegerOptional;
-    }
-
-    export interface RedshiftRebootClusterMessage {
-        ClusterIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftRecurringCharge {
-        RecurringChargeAmount?: RedshiftDouble;
-        RecurringChargeFrequency?: RedshiftString;
-    }
-
-    export type RedshiftRecurringChargeList = Array<RedshiftRecurringCharge>;
-    export interface RedshiftReservedNode {
-        ReservedNodeId?: RedshiftString;
-        ReservedNodeOfferingId?: RedshiftString;
-        NodeType?: RedshiftString;
-        StartTime?: RedshiftTStamp;
-        Duration?: RedshiftInteger;
-        FixedPrice?: RedshiftDouble;
-        UsagePrice?: RedshiftDouble;
-        CurrencyCode?: RedshiftString;
-        NodeCount?: RedshiftInteger;
-        State?: RedshiftString;
-        OfferingType?: RedshiftString;
-        RecurringCharges?: RedshiftRecurringChargeList;
-    }
-
-    export interface RedshiftReservedNodeAlreadyExistsFault {
-    }
-
-    export type RedshiftReservedNodeList = Array<RedshiftReservedNode>;
-    export interface RedshiftReservedNodeNotFoundFault {
-    }
-
-    export interface RedshiftReservedNodeOffering {
-        ReservedNodeOfferingId?: RedshiftString;
-        NodeType?: RedshiftString;
-        Duration?: RedshiftInteger;
-        FixedPrice?: RedshiftDouble;
-        UsagePrice?: RedshiftDouble;
-        CurrencyCode?: RedshiftString;
-        OfferingType?: RedshiftString;
-        RecurringCharges?: RedshiftRecurringChargeList;
-    }
-
-    export type RedshiftReservedNodeOfferingList = Array<RedshiftReservedNodeOffering>;
-    export interface RedshiftReservedNodeOfferingNotFoundFault {
-    }
-
-    export interface RedshiftReservedNodeOfferingsMessage {
-        Marker?: RedshiftString;
-        ReservedNodeOfferings?: RedshiftReservedNodeOfferingList;
-    }
-
-    export interface RedshiftReservedNodeQuotaExceededFault {
-    }
-
-    export interface RedshiftReservedNodesMessage {
-        Marker?: RedshiftString;
-        ReservedNodes?: RedshiftReservedNodeList;
-    }
-
-    export interface RedshiftResetClusterParameterGroupMessage {
-        ParameterGroupName: RedshiftString;
-        ResetAllParameters?: RedshiftBoolean;
-        Parameters?: RedshiftParametersList;
-    }
-
-    export interface RedshiftResizeNotFoundFault {
-    }
-
-    export interface RedshiftResizeProgressMessage {
-        TargetNodeType?: RedshiftString;
-        TargetNumberOfNodes?: RedshiftIntegerOptional;
-        TargetClusterType?: RedshiftString;
-        Status?: RedshiftString;
-        ImportTablesCompleted?: RedshiftImportTablesCompleted;
-        ImportTablesInProgress?: RedshiftImportTablesInProgress;
-        ImportTablesNotStarted?: RedshiftImportTablesNotStarted;
-        AvgResizeRateInMegaBytesPerSecond?: RedshiftDoubleOptional;
-        TotalResizeDataInMegaBytes?: RedshiftLongOptional;
-        ProgressInMegaBytes?: RedshiftLongOptional;
-        ElapsedTimeInSeconds?: RedshiftLongOptional;
-        EstimatedTimeToCompletionInSeconds?: RedshiftLongOptional;
-    }
-
-    export interface RedshiftResourceNotFoundFault {
-    }
-
-    export type RedshiftRestorableNodeTypeList = Array<RedshiftString>;
-    export interface RedshiftRestoreFromClusterSnapshotMessage {
-        ClusterIdentifier: RedshiftString;
-        SnapshotIdentifier: RedshiftString;
-        SnapshotClusterIdentifier?: RedshiftString;
-        Port?: RedshiftIntegerOptional;
-        AvailabilityZone?: RedshiftString;
-        AllowVersionUpgrade?: RedshiftBooleanOptional;
-        ClusterSubnetGroupName?: RedshiftString;
-        PubliclyAccessible?: RedshiftBooleanOptional;
-        OwnerAccount?: RedshiftString;
-        HsmClientCertificateIdentifier?: RedshiftString;
-        HsmConfigurationIdentifier?: RedshiftString;
-        ElasticIp?: RedshiftString;
-        ClusterParameterGroupName?: RedshiftString;
-        ClusterSecurityGroups?: RedshiftClusterSecurityGroupNameList;
-        VpcSecurityGroupIds?: RedshiftVpcSecurityGroupIdList;
-        PreferredMaintenanceWindow?: RedshiftString;
-        AutomatedSnapshotRetentionPeriod?: RedshiftIntegerOptional;
-        KmsKeyId?: RedshiftString;
-        NodeType?: RedshiftString;
-    }
-
-    export interface RedshiftRestoreStatus {
-        Status?: RedshiftString;
-        CurrentRestoreRateInMegaBytesPerSecond?: RedshiftDouble;
-        SnapshotSizeInMegaBytes?: RedshiftLong;
-        ProgressInMegaBytes?: RedshiftLong;
-        ElapsedTimeInSeconds?: RedshiftLong;
-        EstimatedTimeToCompletionInSeconds?: RedshiftLong;
-    }
-
-    export interface RedshiftRevokeClusterSecurityGroupIngressMessage {
-        ClusterSecurityGroupName: RedshiftString;
-        CIDRIP?: RedshiftString;
-        EC2SecurityGroupName?: RedshiftString;
-        EC2SecurityGroupOwnerId?: RedshiftString;
-    }
-
-    export interface RedshiftRevokeSnapshotAccessMessage {
-        SnapshotIdentifier: RedshiftString;
-        SnapshotClusterIdentifier?: RedshiftString;
-        AccountWithRestoreAccess: RedshiftString;
-    }
-
-    export interface RedshiftRotateEncryptionKeyMessage {
-        ClusterIdentifier: RedshiftString;
-    }
-
-    export interface RedshiftSNSInvalidTopicFault {
-    }
+      authorizeClusterSecurityGroupIngress(params: Redshift.AuthorizeClusterSecurityGroupIngressMessage, callback?: (err: Redshift.ClusterSecurityGroupNotFoundFault|Redshift.InvalidClusterSecurityGroupStateFault|Redshift.AuthorizationAlreadyExistsFault|Redshift.AuthorizationQuotaExceededFault|any, data: Redshift.AuthorizeClusterSecurityGroupIngressResult|any) => void): Request;
+      authorizeSnapshotAccess(params: Redshift.AuthorizeSnapshotAccessMessage, callback?: (err: Redshift.ClusterSnapshotNotFoundFault|Redshift.AuthorizationAlreadyExistsFault|Redshift.AuthorizationQuotaExceededFault|any, data: Redshift.AuthorizeSnapshotAccessResult|any) => void): Request;
+      copyClusterSnapshot(params: Redshift.CopyClusterSnapshotMessage, callback?: (err: Redshift.ClusterSnapshotAlreadyExistsFault|Redshift.ClusterSnapshotNotFoundFault|Redshift.InvalidClusterSnapshotStateFault|Redshift.ClusterSnapshotQuotaExceededFault|any, data: Redshift.CopyClusterSnapshotResult|any) => void): Request;
+      createCluster(params: Redshift.CreateClusterMessage, callback?: (err: Redshift.ClusterAlreadyExistsFault|Redshift.InsufficientClusterCapacityFault|Redshift.ClusterParameterGroupNotFoundFault|Redshift.ClusterSecurityGroupNotFoundFault|Redshift.ClusterQuotaExceededFault|Redshift.NumberOfNodesQuotaExceededFault|Redshift.NumberOfNodesPerClusterLimitExceededFault|Redshift.ClusterSubnetGroupNotFoundFault|Redshift.InvalidVPCNetworkStateFault|Redshift.InvalidClusterSubnetGroupStateFault|Redshift.InvalidSubnet|Redshift.UnauthorizedOperation|Redshift.HsmClientCertificateNotFoundFault|Redshift.HsmConfigurationNotFoundFault|Redshift.InvalidElasticIpFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|Redshift.LimitExceededFault|any, data: Redshift.CreateClusterResult|any) => void): Request;
+      createClusterParameterGroup(params: Redshift.CreateClusterParameterGroupMessage, callback?: (err: Redshift.ClusterParameterGroupQuotaExceededFault|Redshift.ClusterParameterGroupAlreadyExistsFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateClusterParameterGroupResult|any) => void): Request;
+      createClusterSecurityGroup(params: Redshift.CreateClusterSecurityGroupMessage, callback?: (err: Redshift.ClusterSecurityGroupAlreadyExistsFault|Redshift.ClusterSecurityGroupQuotaExceededFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateClusterSecurityGroupResult|any) => void): Request;
+      createClusterSnapshot(params: Redshift.CreateClusterSnapshotMessage, callback?: (err: Redshift.ClusterSnapshotAlreadyExistsFault|Redshift.InvalidClusterStateFault|Redshift.ClusterNotFoundFault|Redshift.ClusterSnapshotQuotaExceededFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateClusterSnapshotResult|any) => void): Request;
+      createClusterSubnetGroup(params: Redshift.CreateClusterSubnetGroupMessage, callback?: (err: Redshift.ClusterSubnetGroupAlreadyExistsFault|Redshift.ClusterSubnetGroupQuotaExceededFault|Redshift.ClusterSubnetQuotaExceededFault|Redshift.InvalidSubnet|Redshift.UnauthorizedOperation|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateClusterSubnetGroupResult|any) => void): Request;
+      createEventSubscription(params: Redshift.CreateEventSubscriptionMessage, callback?: (err: Redshift.EventSubscriptionQuotaExceededFault|Redshift.SubscriptionAlreadyExistFault|Redshift.SNSInvalidTopicFault|Redshift.SNSNoAuthorizationFault|Redshift.SNSTopicArnNotFoundFault|Redshift.SubscriptionEventIdNotFoundFault|Redshift.SubscriptionCategoryNotFoundFault|Redshift.SubscriptionSeverityNotFoundFault|Redshift.SourceNotFoundFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateEventSubscriptionResult|any) => void): Request;
+      createHsmClientCertificate(params: Redshift.CreateHsmClientCertificateMessage, callback?: (err: Redshift.HsmClientCertificateAlreadyExistsFault|Redshift.HsmClientCertificateQuotaExceededFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateHsmClientCertificateResult|any) => void): Request;
+      createHsmConfiguration(params: Redshift.CreateHsmConfigurationMessage, callback?: (err: Redshift.HsmConfigurationAlreadyExistsFault|Redshift.HsmConfigurationQuotaExceededFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateHsmConfigurationResult|any) => void): Request;
+      createSnapshotCopyGrant(params: Redshift.CreateSnapshotCopyGrantMessage, callback?: (err: Redshift.SnapshotCopyGrantAlreadyExistsFault|Redshift.SnapshotCopyGrantQuotaExceededFault|Redshift.LimitExceededFault|Redshift.TagLimitExceededFault|Redshift.InvalidTagFault|any, data: Redshift.CreateSnapshotCopyGrantResult|any) => void): Request;
+      createTags(params: Redshift.CreateTagsMessage, callback?: (err: Redshift.TagLimitExceededFault|Redshift.ResourceNotFoundFault|Redshift.InvalidTagFault|any, data: any) => void): Request;
+      deleteCluster(params: Redshift.DeleteClusterMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.InvalidClusterStateFault|Redshift.ClusterSnapshotAlreadyExistsFault|Redshift.ClusterSnapshotQuotaExceededFault|any, data: Redshift.DeleteClusterResult|any) => void): Request;
+      deleteClusterParameterGroup(params: Redshift.DeleteClusterParameterGroupMessage, callback?: (err: Redshift.InvalidClusterParameterGroupStateFault|Redshift.ClusterParameterGroupNotFoundFault|any, data: any) => void): Request;
+      deleteClusterSecurityGroup(params: Redshift.DeleteClusterSecurityGroupMessage, callback?: (err: Redshift.InvalidClusterSecurityGroupStateFault|Redshift.ClusterSecurityGroupNotFoundFault|any, data: any) => void): Request;
+      deleteClusterSnapshot(params: Redshift.DeleteClusterSnapshotMessage, callback?: (err: Redshift.InvalidClusterSnapshotStateFault|Redshift.ClusterSnapshotNotFoundFault|any, data: Redshift.DeleteClusterSnapshotResult|any) => void): Request;
+      deleteClusterSubnetGroup(params: Redshift.DeleteClusterSubnetGroupMessage, callback?: (err: Redshift.InvalidClusterSubnetGroupStateFault|Redshift.InvalidClusterSubnetStateFault|Redshift.ClusterSubnetGroupNotFoundFault|any, data: any) => void): Request;
+      deleteEventSubscription(params: Redshift.DeleteEventSubscriptionMessage, callback?: (err: Redshift.SubscriptionNotFoundFault|Redshift.InvalidSubscriptionStateFault|any, data: any) => void): Request;
+      deleteHsmClientCertificate(params: Redshift.DeleteHsmClientCertificateMessage, callback?: (err: Redshift.InvalidHsmClientCertificateStateFault|Redshift.HsmClientCertificateNotFoundFault|any, data: any) => void): Request;
+      deleteHsmConfiguration(params: Redshift.DeleteHsmConfigurationMessage, callback?: (err: Redshift.InvalidHsmConfigurationStateFault|Redshift.HsmConfigurationNotFoundFault|any, data: any) => void): Request;
+      deleteSnapshotCopyGrant(params: Redshift.DeleteSnapshotCopyGrantMessage, callback?: (err: Redshift.InvalidSnapshotCopyGrantStateFault|Redshift.SnapshotCopyGrantNotFoundFault|any, data: any) => void): Request;
+      deleteTags(params: Redshift.DeleteTagsMessage, callback?: (err: Redshift.ResourceNotFoundFault|Redshift.InvalidTagFault|any, data: any) => void): Request;
+      describeClusterParameterGroups(params: Redshift.DescribeClusterParameterGroupsMessage, callback?: (err: Redshift.ClusterParameterGroupNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.ClusterParameterGroupsMessage|any) => void): Request;
+      describeClusterParameters(params: Redshift.DescribeClusterParametersMessage, callback?: (err: Redshift.ClusterParameterGroupNotFoundFault|any, data: Redshift.ClusterParameterGroupDetails|any) => void): Request;
+      describeClusterSecurityGroups(params: Redshift.DescribeClusterSecurityGroupsMessage, callback?: (err: Redshift.ClusterSecurityGroupNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.ClusterSecurityGroupMessage|any) => void): Request;
+      describeClusterSnapshots(params: Redshift.DescribeClusterSnapshotsMessage, callback?: (err: Redshift.ClusterSnapshotNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.SnapshotMessage|any) => void): Request;
+      describeClusterSubnetGroups(params: Redshift.DescribeClusterSubnetGroupsMessage, callback?: (err: Redshift.ClusterSubnetGroupNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.ClusterSubnetGroupMessage|any) => void): Request;
+      describeClusterVersions(params: Redshift.DescribeClusterVersionsMessage, callback?: (err: any, data: Redshift.ClusterVersionsMessage|any) => void): Request;
+      describeClusters(params: Redshift.DescribeClustersMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.ClustersMessage|any) => void): Request;
+      describeDefaultClusterParameters(params: Redshift.DescribeDefaultClusterParametersMessage, callback?: (err: any, data: Redshift.DescribeDefaultClusterParametersResult|any) => void): Request;
+      describeEventCategories(params: Redshift.DescribeEventCategoriesMessage, callback?: (err: any, data: Redshift.EventCategoriesMessage|any) => void): Request;
+      describeEventSubscriptions(params: Redshift.DescribeEventSubscriptionsMessage, callback?: (err: Redshift.SubscriptionNotFoundFault|any, data: Redshift.EventSubscriptionsMessage|any) => void): Request;
+      describeEvents(params: Redshift.DescribeEventsMessage, callback?: (err: any, data: Redshift.EventsMessage|any) => void): Request;
+      describeHsmClientCertificates(params: Redshift.DescribeHsmClientCertificatesMessage, callback?: (err: Redshift.HsmClientCertificateNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.HsmClientCertificateMessage|any) => void): Request;
+      describeHsmConfigurations(params: Redshift.DescribeHsmConfigurationsMessage, callback?: (err: Redshift.HsmConfigurationNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.HsmConfigurationMessage|any) => void): Request;
+      describeLoggingStatus(params: Redshift.DescribeLoggingStatusMessage, callback?: (err: Redshift.ClusterNotFoundFault|any, data: Redshift.LoggingStatus|any) => void): Request;
+      describeOrderableClusterOptions(params: Redshift.DescribeOrderableClusterOptionsMessage, callback?: (err: any, data: Redshift.OrderableClusterOptionsMessage|any) => void): Request;
+      describeReservedNodeOfferings(params: Redshift.DescribeReservedNodeOfferingsMessage, callback?: (err: Redshift.ReservedNodeOfferingNotFoundFault|Redshift.UnsupportedOperationFault|any, data: Redshift.ReservedNodeOfferingsMessage|any) => void): Request;
+      describeReservedNodes(params: Redshift.DescribeReservedNodesMessage, callback?: (err: Redshift.ReservedNodeNotFoundFault|any, data: Redshift.ReservedNodesMessage|any) => void): Request;
+      describeResize(params: Redshift.DescribeResizeMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.ResizeNotFoundFault|any, data: Redshift.ResizeProgressMessage|any) => void): Request;
+      describeSnapshotCopyGrants(params: Redshift.DescribeSnapshotCopyGrantsMessage, callback?: (err: Redshift.SnapshotCopyGrantNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.SnapshotCopyGrantMessage|any) => void): Request;
+      describeTags(params: Redshift.DescribeTagsMessage, callback?: (err: Redshift.ResourceNotFoundFault|Redshift.InvalidTagFault|any, data: Redshift.TaggedResourceListMessage|any) => void): Request;
+      disableLogging(params: Redshift.DisableLoggingMessage, callback?: (err: Redshift.ClusterNotFoundFault|any, data: Redshift.LoggingStatus|any) => void): Request;
+      disableSnapshotCopy(params: Redshift.DisableSnapshotCopyMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.SnapshotCopyAlreadyDisabledFault|Redshift.InvalidClusterStateFault|Redshift.UnauthorizedOperation|any, data: Redshift.DisableSnapshotCopyResult|any) => void): Request;
+      enableLogging(params: Redshift.EnableLoggingMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.BucketNotFoundFault|Redshift.InsufficientS3BucketPolicyFault|Redshift.InvalidS3KeyPrefixFault|Redshift.InvalidS3BucketNameFault|any, data: Redshift.LoggingStatus|any) => void): Request;
+      enableSnapshotCopy(params: Redshift.EnableSnapshotCopyMessage, callback?: (err: Redshift.IncompatibleOrderableOptions|Redshift.InvalidClusterStateFault|Redshift.ClusterNotFoundFault|Redshift.CopyToRegionDisabledFault|Redshift.SnapshotCopyAlreadyEnabledFault|Redshift.UnknownSnapshotCopyRegionFault|Redshift.UnauthorizedOperation|Redshift.SnapshotCopyGrantNotFoundFault|Redshift.LimitExceededFault|any, data: Redshift.EnableSnapshotCopyResult|any) => void): Request;
+      modifyCluster(params: Redshift.ModifyClusterMessage, callback?: (err: Redshift.InvalidClusterStateFault|Redshift.InvalidClusterSecurityGroupStateFault|Redshift.ClusterNotFoundFault|Redshift.NumberOfNodesQuotaExceededFault|Redshift.ClusterSecurityGroupNotFoundFault|Redshift.ClusterParameterGroupNotFoundFault|Redshift.InsufficientClusterCapacityFault|Redshift.UnsupportedOptionFault|Redshift.UnauthorizedOperation|Redshift.HsmClientCertificateNotFoundFault|Redshift.HsmConfigurationNotFoundFault|Redshift.ClusterAlreadyExistsFault|Redshift.LimitExceededFault|any, data: Redshift.ModifyClusterResult|any) => void): Request;
+      modifyClusterParameterGroup(params: Redshift.ModifyClusterParameterGroupMessage, callback?: (err: Redshift.ClusterParameterGroupNotFoundFault|Redshift.InvalidClusterParameterGroupStateFault|any, data: Redshift.ClusterParameterGroupNameMessage|any) => void): Request;
+      modifyClusterSubnetGroup(params: Redshift.ModifyClusterSubnetGroupMessage, callback?: (err: Redshift.ClusterSubnetGroupNotFoundFault|Redshift.ClusterSubnetQuotaExceededFault|Redshift.SubnetAlreadyInUse|Redshift.InvalidSubnet|Redshift.UnauthorizedOperation|any, data: Redshift.ModifyClusterSubnetGroupResult|any) => void): Request;
+      modifyEventSubscription(params: Redshift.ModifyEventSubscriptionMessage, callback?: (err: Redshift.SubscriptionNotFoundFault|Redshift.SNSInvalidTopicFault|Redshift.SNSNoAuthorizationFault|Redshift.SNSTopicArnNotFoundFault|Redshift.SubscriptionEventIdNotFoundFault|Redshift.SubscriptionCategoryNotFoundFault|Redshift.SubscriptionSeverityNotFoundFault|Redshift.SourceNotFoundFault|Redshift.InvalidSubscriptionStateFault|any, data: Redshift.ModifyEventSubscriptionResult|any) => void): Request;
+      modifySnapshotCopyRetentionPeriod(params: Redshift.ModifySnapshotCopyRetentionPeriodMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.SnapshotCopyDisabledFault|Redshift.UnauthorizedOperation|Redshift.InvalidClusterStateFault|any, data: Redshift.ModifySnapshotCopyRetentionPeriodResult|any) => void): Request;
+      purchaseReservedNodeOffering(params: Redshift.PurchaseReservedNodeOfferingMessage, callback?: (err: Redshift.ReservedNodeOfferingNotFoundFault|Redshift.ReservedNodeAlreadyExistsFault|Redshift.ReservedNodeQuotaExceededFault|Redshift.UnsupportedOperationFault|any, data: Redshift.PurchaseReservedNodeOfferingResult|any) => void): Request;
+      rebootCluster(params: Redshift.RebootClusterMessage, callback?: (err: Redshift.InvalidClusterStateFault|Redshift.ClusterNotFoundFault|any, data: Redshift.RebootClusterResult|any) => void): Request;
+      resetClusterParameterGroup(params: Redshift.ResetClusterParameterGroupMessage, callback?: (err: Redshift.InvalidClusterParameterGroupStateFault|Redshift.ClusterParameterGroupNotFoundFault|any, data: Redshift.ClusterParameterGroupNameMessage|any) => void): Request;
+      restoreFromClusterSnapshot(params: Redshift.RestoreFromClusterSnapshotMessage, callback?: (err: Redshift.AccessToSnapshotDeniedFault|Redshift.ClusterAlreadyExistsFault|Redshift.ClusterSnapshotNotFoundFault|Redshift.ClusterQuotaExceededFault|Redshift.InsufficientClusterCapacityFault|Redshift.InvalidClusterSnapshotStateFault|Redshift.InvalidRestoreFault|Redshift.NumberOfNodesQuotaExceededFault|Redshift.NumberOfNodesPerClusterLimitExceededFault|Redshift.InvalidVPCNetworkStateFault|Redshift.InvalidClusterSubnetGroupStateFault|Redshift.InvalidSubnet|Redshift.ClusterSubnetGroupNotFoundFault|Redshift.UnauthorizedOperation|Redshift.HsmClientCertificateNotFoundFault|Redshift.HsmConfigurationNotFoundFault|Redshift.InvalidElasticIpFault|Redshift.ClusterParameterGroupNotFoundFault|Redshift.ClusterSecurityGroupNotFoundFault|Redshift.LimitExceededFault|any, data: Redshift.RestoreFromClusterSnapshotResult|any) => void): Request;
+      revokeClusterSecurityGroupIngress(params: Redshift.RevokeClusterSecurityGroupIngressMessage, callback?: (err: Redshift.ClusterSecurityGroupNotFoundFault|Redshift.AuthorizationNotFoundFault|Redshift.InvalidClusterSecurityGroupStateFault|any, data: Redshift.RevokeClusterSecurityGroupIngressResult|any) => void): Request;
+      revokeSnapshotAccess(params: Redshift.RevokeSnapshotAccessMessage, callback?: (err: Redshift.AccessToSnapshotDeniedFault|Redshift.AuthorizationNotFoundFault|Redshift.ClusterSnapshotNotFoundFault|any, data: Redshift.RevokeSnapshotAccessResult|any) => void): Request;
+      rotateEncryptionKey(params: Redshift.RotateEncryptionKeyMessage, callback?: (err: Redshift.ClusterNotFoundFault|Redshift.InvalidClusterStateFault|any, data: Redshift.RotateEncryptionKeyResult|any) => void): Request;
+    }
+    
+    export module Redshift {
+        export type AccountsWithRestoreAccessList = AccountWithRestoreAccess[];
+        export type AvailabilityZoneList = AvailabilityZone[];
+        export type Boolean = boolean;
+        export type BooleanOptional = boolean;
+        export type ClusterList = Cluster[];
+        export type ClusterNodesList = ClusterNode[];
+        export type ClusterParameterGroupStatusList = ClusterParameterGroupStatus[];
+        export type ClusterParameterStatusList = ClusterParameterStatus[];
+        export type ClusterSecurityGroupMembershipList = ClusterSecurityGroupMembership[];
+        export type ClusterSecurityGroupNameList = String[];
+        export type ClusterSecurityGroups = ClusterSecurityGroup[];
+        export type ClusterSubnetGroups = ClusterSubnetGroup[];
+        export type ClusterVersionList = ClusterVersion[];
+        export type Double = number;
+        export type DoubleOptional = number;
+        export type EC2SecurityGroupList = EC2SecurityGroup[];
+        export type EventCategoriesList = String[];
+        export type EventCategoriesMapList = EventCategoriesMap[];
+        export type EventInfoMapList = EventInfoMap[];
+        export type EventList = Event[];
+        export type EventSubscriptionsList = EventSubscription[];
+        export type HsmClientCertificateList = HsmClientCertificate[];
+        export type HsmConfigurationList = HsmConfiguration[];
+        export type IPRangeList = IPRange[];
+        export type ImportTablesCompleted = String[];
+        export type ImportTablesInProgress = String[];
+        export type ImportTablesNotStarted = String[];
+        export type Integer = number;
+        export type IntegerOptional = number;
+        export type Long = number;
+        export type LongOptional = number;
+        export type OrderableClusterOptionsList = OrderableClusterOption[];
+        export type ParameterApplyType = string;
+        export type ParameterGroupList = ClusterParameterGroup[];
+        export type ParametersList = Parameter[];
+        export type RecurringChargeList = RecurringCharge[];
+        export type ReservedNodeList = ReservedNode[];
+        export type ReservedNodeOfferingList = ReservedNodeOffering[];
+        export type RestorableNodeTypeList = String[];
+        export type SnapshotCopyGrantList = SnapshotCopyGrant[];
+        export type SnapshotList = Snapshot[];
+        export type SourceIdsList = String[];
+        export type SourceType = string;
+        export type String = string;
+        export type SubnetIdentifierList = String[];
+        export type SubnetList = Subnet[];
+        export type TStamp = number;
+        export type TagKeyList = String[];
+        export type TagList = Tag[];
+        export type TagValueList = String[];
+        export type TaggedResourceList = TaggedResource[];
+        export type VpcSecurityGroupIdList = String[];
+        export type VpcSecurityGroupMembershipList = VpcSecurityGroupMembership[];
+
+        export interface AccessToSnapshotDeniedFault {
+        }
+        export interface AccountWithRestoreAccess {
+            AccountId?: String;            
+        }
+        export interface AuthorizationAlreadyExistsFault {
+        }
+        export interface AuthorizationNotFoundFault {
+        }
+        export interface AuthorizationQuotaExceededFault {
+        }
+        export interface AuthorizeClusterSecurityGroupIngressMessage {
+            ClusterSecurityGroupName: String;            
+            CIDRIP?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+        }
+        export interface AuthorizeSnapshotAccessMessage {
+            SnapshotIdentifier: String;            
+            SnapshotClusterIdentifier?: String;            
+            AccountWithRestoreAccess: String;            
+        }
+        export interface AvailabilityZone {
+            Name?: String;            
+        }
+        export interface BucketNotFoundFault {
+        }
+        export interface Cluster {
+            ClusterIdentifier?: String;            
+            NodeType?: String;            
+            ClusterStatus?: String;            
+            ModifyStatus?: String;            
+            MasterUsername?: String;            
+            DBName?: String;            
+            Endpoint?: Endpoint;            
+            ClusterCreateTime?: TStamp;            
+            AutomatedSnapshotRetentionPeriod?: Integer;            
+            ClusterSecurityGroups?: ClusterSecurityGroupMembershipList;            
+            VpcSecurityGroups?: VpcSecurityGroupMembershipList;            
+            ClusterParameterGroups?: ClusterParameterGroupStatusList;            
+            ClusterSubnetGroupName?: String;            
+            VpcId?: String;            
+            AvailabilityZone?: String;            
+            PreferredMaintenanceWindow?: String;            
+            PendingModifiedValues?: PendingModifiedValues;            
+            ClusterVersion?: String;            
+            AllowVersionUpgrade?: Boolean;            
+            NumberOfNodes?: Integer;            
+            PubliclyAccessible?: Boolean;            
+            Encrypted?: Boolean;            
+            RestoreStatus?: RestoreStatus;            
+            HsmStatus?: HsmStatus;            
+            ClusterSnapshotCopyStatus?: ClusterSnapshotCopyStatus;            
+            ClusterPublicKey?: String;            
+            ClusterNodes?: ClusterNodesList;            
+            ElasticIpStatus?: ElasticIpStatus;            
+            ClusterRevisionNumber?: String;            
+            Tags?: TagList;            
+            KmsKeyId?: String;            
+        }
+        export interface ClusterAlreadyExistsFault {
+        }
+        export interface ClusterNode {
+            NodeRole?: String;            
+            PrivateIPAddress?: String;            
+            PublicIPAddress?: String;            
+        }
+        export interface ClusterNotFoundFault {
+        }
+        export interface ClusterParameterGroup {
+            ParameterGroupName?: String;            
+            ParameterGroupFamily?: String;            
+            Description?: String;            
+            Tags?: TagList;            
+        }
+        export interface ClusterParameterGroupAlreadyExistsFault {
+        }
+        export interface ClusterParameterGroupDetails {
+            Parameters?: ParametersList;            
+            Marker?: String;            
+        }
+        export interface ClusterParameterGroupNameMessage {
+            ParameterGroupName?: String;            
+            ParameterGroupStatus?: String;            
+        }
+        export interface ClusterParameterGroupNotFoundFault {
+        }
+        export interface ClusterParameterGroupQuotaExceededFault {
+        }
+        export interface ClusterParameterGroupStatus {
+            ParameterGroupName?: String;            
+            ParameterApplyStatus?: String;            
+            ClusterParameterStatusList?: ClusterParameterStatusList;            
+        }
+        export interface ClusterParameterGroupsMessage {
+            Marker?: String;            
+            ParameterGroups?: ParameterGroupList;            
+        }
+        export interface ClusterParameterStatus {
+            ParameterName?: String;            
+            ParameterApplyStatus?: String;            
+            ParameterApplyErrorDescription?: String;            
+        }
+        export interface ClusterQuotaExceededFault {
+        }
+        export interface ClusterSecurityGroup {
+            ClusterSecurityGroupName?: String;            
+            Description?: String;            
+            EC2SecurityGroups?: EC2SecurityGroupList;            
+            IPRanges?: IPRangeList;            
+            Tags?: TagList;            
+        }
+        export interface ClusterSecurityGroupAlreadyExistsFault {
+        }
+        export interface ClusterSecurityGroupMembership {
+            ClusterSecurityGroupName?: String;            
+            Status?: String;            
+        }
+        export interface ClusterSecurityGroupMessage {
+            Marker?: String;            
+            ClusterSecurityGroups?: ClusterSecurityGroups;            
+        }
+        export interface ClusterSecurityGroupNotFoundFault {
+        }
+        export interface ClusterSecurityGroupQuotaExceededFault {
+        }
+        export interface ClusterSnapshotAlreadyExistsFault {
+        }
+        export interface ClusterSnapshotCopyStatus {
+            DestinationRegion?: String;            
+            RetentionPeriod?: Long;            
+            SnapshotCopyGrantName?: String;            
+        }
+        export interface ClusterSnapshotNotFoundFault {
+        }
+        export interface ClusterSnapshotQuotaExceededFault {
+        }
+        export interface ClusterSubnetGroup {
+            ClusterSubnetGroupName?: String;            
+            Description?: String;            
+            VpcId?: String;            
+            SubnetGroupStatus?: String;            
+            Subnets?: SubnetList;            
+            Tags?: TagList;            
+        }
+        export interface ClusterSubnetGroupAlreadyExistsFault {
+        }
+        export interface ClusterSubnetGroupMessage {
+            Marker?: String;            
+            ClusterSubnetGroups?: ClusterSubnetGroups;            
+        }
+        export interface ClusterSubnetGroupNotFoundFault {
+        }
+        export interface ClusterSubnetGroupQuotaExceededFault {
+        }
+        export interface ClusterSubnetQuotaExceededFault {
+        }
+        export interface ClusterVersion {
+            ClusterVersion?: String;            
+            ClusterParameterGroupFamily?: String;            
+            Description?: String;            
+        }
+        export interface ClusterVersionsMessage {
+            Marker?: String;            
+            ClusterVersions?: ClusterVersionList;            
+        }
+        export interface ClustersMessage {
+            Marker?: String;            
+            Clusters?: ClusterList;            
+        }
+        export interface CopyClusterSnapshotMessage {
+            SourceSnapshotIdentifier: String;            
+            SourceSnapshotClusterIdentifier?: String;            
+            TargetSnapshotIdentifier: String;            
+        }
+        export interface CopyToRegionDisabledFault {
+        }
+        export interface CreateClusterMessage {
+            DBName?: String;            
+            ClusterIdentifier: String;            
+            ClusterType?: String;            
+            NodeType: String;            
+            MasterUsername: String;            
+            MasterUserPassword: String;            
+            ClusterSecurityGroups?: ClusterSecurityGroupNameList;            
+            VpcSecurityGroupIds?: VpcSecurityGroupIdList;            
+            ClusterSubnetGroupName?: String;            
+            AvailabilityZone?: String;            
+            PreferredMaintenanceWindow?: String;            
+            ClusterParameterGroupName?: String;            
+            AutomatedSnapshotRetentionPeriod?: IntegerOptional;            
+            Port?: IntegerOptional;            
+            ClusterVersion?: String;            
+            AllowVersionUpgrade?: BooleanOptional;            
+            NumberOfNodes?: IntegerOptional;            
+            PubliclyAccessible?: BooleanOptional;            
+            Encrypted?: BooleanOptional;            
+            HsmClientCertificateIdentifier?: String;            
+            HsmConfigurationIdentifier?: String;            
+            ElasticIp?: String;            
+            Tags?: TagList;            
+            KmsKeyId?: String;            
+        }
+        export interface CreateClusterParameterGroupMessage {
+            ParameterGroupName: String;            
+            ParameterGroupFamily: String;            
+            Description: String;            
+            Tags?: TagList;            
+        }
+        export interface CreateClusterSecurityGroupMessage {
+            ClusterSecurityGroupName: String;            
+            Description: String;            
+            Tags?: TagList;            
+        }
+        export interface CreateClusterSnapshotMessage {
+            SnapshotIdentifier: String;            
+            ClusterIdentifier: String;            
+            Tags?: TagList;            
+        }
+        export interface CreateClusterSubnetGroupMessage {
+            ClusterSubnetGroupName: String;            
+            Description: String;            
+            SubnetIds: SubnetIdentifierList;            
+            Tags?: TagList;            
+        }
+        export interface CreateEventSubscriptionMessage {
+            SubscriptionName: String;            
+            SnsTopicArn: String;            
+            SourceType?: String;            
+            SourceIds?: SourceIdsList;            
+            EventCategories?: EventCategoriesList;            
+            Severity?: String;            
+            Enabled?: BooleanOptional;            
+            Tags?: TagList;            
+        }
+        export interface CreateHsmClientCertificateMessage {
+            HsmClientCertificateIdentifier: String;            
+            Tags?: TagList;            
+        }
+        export interface CreateHsmConfigurationMessage {
+            HsmConfigurationIdentifier: String;            
+            Description: String;            
+            HsmIpAddress: String;            
+            HsmPartitionName: String;            
+            HsmPartitionPassword: String;            
+            HsmServerPublicCertificate: String;            
+            Tags?: TagList;            
+        }
+        export interface CreateSnapshotCopyGrantMessage {
+            SnapshotCopyGrantName: String;            
+            KmsKeyId?: String;            
+            Tags?: TagList;            
+        }
+        export interface CreateTagsMessage {
+            ResourceName: String;            
+            Tags: TagList;            
+        }
+        export interface DefaultClusterParameters {
+            ParameterGroupFamily?: String;            
+            Marker?: String;            
+            Parameters?: ParametersList;            
+        }
+        export interface DeleteClusterMessage {
+            ClusterIdentifier: String;            
+            SkipFinalClusterSnapshot?: Boolean;            
+            FinalClusterSnapshotIdentifier?: String;            
+        }
+        export interface DeleteClusterParameterGroupMessage {
+            ParameterGroupName: String;            
+        }
+        export interface DeleteClusterSecurityGroupMessage {
+            ClusterSecurityGroupName: String;            
+        }
+        export interface DeleteClusterSnapshotMessage {
+            SnapshotIdentifier: String;            
+            SnapshotClusterIdentifier?: String;            
+        }
+        export interface DeleteClusterSubnetGroupMessage {
+            ClusterSubnetGroupName: String;            
+        }
+        export interface DeleteEventSubscriptionMessage {
+            SubscriptionName: String;            
+        }
+        export interface DeleteHsmClientCertificateMessage {
+            HsmClientCertificateIdentifier: String;            
+        }
+        export interface DeleteHsmConfigurationMessage {
+            HsmConfigurationIdentifier: String;            
+        }
+        export interface DeleteSnapshotCopyGrantMessage {
+            SnapshotCopyGrantName: String;            
+        }
+        export interface DeleteTagsMessage {
+            ResourceName: String;            
+            TagKeys: TagKeyList;            
+        }
+        export interface DescribeClusterParameterGroupsMessage {
+            ParameterGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeClusterParametersMessage {
+            ParameterGroupName: String;            
+            Source?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeClusterSecurityGroupsMessage {
+            ClusterSecurityGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeClusterSnapshotsMessage {
+            ClusterIdentifier?: String;            
+            SnapshotIdentifier?: String;            
+            SnapshotType?: String;            
+            StartTime?: TStamp;            
+            EndTime?: TStamp;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            OwnerAccount?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeClusterSubnetGroupsMessage {
+            ClusterSubnetGroupName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeClusterVersionsMessage {
+            ClusterVersion?: String;            
+            ClusterParameterGroupFamily?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeClustersMessage {
+            ClusterIdentifier?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeDefaultClusterParametersMessage {
+            ParameterGroupFamily: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEventCategoriesMessage {
+            SourceType?: String;            
+        }
+        export interface DescribeEventSubscriptionsMessage {
+            SubscriptionName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeEventsMessage {
+            SourceIdentifier?: String;            
+            SourceType?: SourceType;            
+            StartTime?: TStamp;            
+            EndTime?: TStamp;            
+            Duration?: IntegerOptional;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeHsmClientCertificatesMessage {
+            HsmClientCertificateIdentifier?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeHsmConfigurationsMessage {
+            HsmConfigurationIdentifier?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeLoggingStatusMessage {
+            ClusterIdentifier: String;            
+        }
+        export interface DescribeOrderableClusterOptionsMessage {
+            ClusterVersion?: String;            
+            NodeType?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReservedNodeOfferingsMessage {
+            ReservedNodeOfferingId?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeReservedNodesMessage {
+            ReservedNodeId?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+        }
+        export interface DescribeResizeMessage {
+            ClusterIdentifier: String;            
+        }
+        export interface DescribeSnapshotCopyGrantsMessage {
+            SnapshotCopyGrantName?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DescribeTagsMessage {
+            ResourceName?: String;            
+            ResourceType?: String;            
+            MaxRecords?: IntegerOptional;            
+            Marker?: String;            
+            TagKeys?: TagKeyList;            
+            TagValues?: TagValueList;            
+        }
+        export interface DisableLoggingMessage {
+            ClusterIdentifier: String;            
+        }
+        export interface DisableSnapshotCopyMessage {
+            ClusterIdentifier: String;            
+        }
+        export interface EC2SecurityGroup {
+            Status?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+            Tags?: TagList;            
+        }
+        export interface ElasticIpStatus {
+            ElasticIp?: String;            
+            Status?: String;            
+        }
+        export interface EnableLoggingMessage {
+            ClusterIdentifier: String;            
+            BucketName: String;            
+            S3KeyPrefix?: String;            
+        }
+        export interface EnableSnapshotCopyMessage {
+            ClusterIdentifier: String;            
+            DestinationRegion: String;            
+            RetentionPeriod?: IntegerOptional;            
+            SnapshotCopyGrantName?: String;            
+        }
+        export interface Endpoint {
+            Address?: String;            
+            Port?: Integer;            
+        }
+        export interface Event {
+            SourceIdentifier?: String;            
+            SourceType?: SourceType;            
+            Message?: String;            
+            EventCategories?: EventCategoriesList;            
+            Severity?: String;            
+            Date?: TStamp;            
+            EventId?: String;            
+        }
+        export interface EventCategoriesMap {
+            SourceType?: String;            
+            Events?: EventInfoMapList;            
+        }
+        export interface EventCategoriesMessage {
+            EventCategoriesMapList?: EventCategoriesMapList;            
+        }
+        export interface EventInfoMap {
+            EventId?: String;            
+            EventCategories?: EventCategoriesList;            
+            EventDescription?: String;            
+            Severity?: String;            
+        }
+        export interface EventSubscription {
+            CustomerAwsId?: String;            
+            CustSubscriptionId?: String;            
+            SnsTopicArn?: String;            
+            Status?: String;            
+            SubscriptionCreationTime?: TStamp;            
+            SourceType?: String;            
+            SourceIdsList?: SourceIdsList;            
+            EventCategoriesList?: EventCategoriesList;            
+            Severity?: String;            
+            Enabled?: Boolean;            
+            Tags?: TagList;            
+        }
+        export interface EventSubscriptionQuotaExceededFault {
+        }
+        export interface EventSubscriptionsMessage {
+            Marker?: String;            
+            EventSubscriptionsList?: EventSubscriptionsList;            
+        }
+        export interface EventsMessage {
+            Marker?: String;            
+            Events?: EventList;            
+        }
+        export interface HsmClientCertificate {
+            HsmClientCertificateIdentifier?: String;            
+            HsmClientCertificatePublicKey?: String;            
+            Tags?: TagList;            
+        }
+        export interface HsmClientCertificateAlreadyExistsFault {
+        }
+        export interface HsmClientCertificateMessage {
+            Marker?: String;            
+            HsmClientCertificates?: HsmClientCertificateList;            
+        }
+        export interface HsmClientCertificateNotFoundFault {
+        }
+        export interface HsmClientCertificateQuotaExceededFault {
+        }
+        export interface HsmConfiguration {
+            HsmConfigurationIdentifier?: String;            
+            Description?: String;            
+            HsmIpAddress?: String;            
+            HsmPartitionName?: String;            
+            Tags?: TagList;            
+        }
+        export interface HsmConfigurationAlreadyExistsFault {
+        }
+        export interface HsmConfigurationMessage {
+            Marker?: String;            
+            HsmConfigurations?: HsmConfigurationList;            
+        }
+        export interface HsmConfigurationNotFoundFault {
+        }
+        export interface HsmConfigurationQuotaExceededFault {
+        }
+        export interface HsmStatus {
+            HsmClientCertificateIdentifier?: String;            
+            HsmConfigurationIdentifier?: String;            
+            Status?: String;            
+        }
+        export interface IPRange {
+            Status?: String;            
+            CIDRIP?: String;            
+            Tags?: TagList;            
+        }
+        export interface IncompatibleOrderableOptions {
+        }
+        export interface InsufficientClusterCapacityFault {
+        }
+        export interface InsufficientS3BucketPolicyFault {
+        }
+        export interface InvalidClusterParameterGroupStateFault {
+        }
+        export interface InvalidClusterSecurityGroupStateFault {
+        }
+        export interface InvalidClusterSnapshotStateFault {
+        }
+        export interface InvalidClusterStateFault {
+        }
+        export interface InvalidClusterSubnetGroupStateFault {
+        }
+        export interface InvalidClusterSubnetStateFault {
+        }
+        export interface InvalidElasticIpFault {
+        }
+        export interface InvalidHsmClientCertificateStateFault {
+        }
+        export interface InvalidHsmConfigurationStateFault {
+        }
+        export interface InvalidRestoreFault {
+        }
+        export interface InvalidS3BucketNameFault {
+        }
+        export interface InvalidS3KeyPrefixFault {
+        }
+        export interface InvalidSnapshotCopyGrantStateFault {
+        }
+        export interface InvalidSubnet {
+        }
+        export interface InvalidSubscriptionStateFault {
+        }
+        export interface InvalidTagFault {
+        }
+        export interface InvalidVPCNetworkStateFault {
+        }
+        export interface LimitExceededFault {
+        }
+        export interface LoggingStatus {
+            LoggingEnabled?: Boolean;            
+            BucketName?: String;            
+            S3KeyPrefix?: String;            
+            LastSuccessfulDeliveryTime?: TStamp;            
+            LastFailureTime?: TStamp;            
+            LastFailureMessage?: String;            
+        }
+        export interface ModifyClusterMessage {
+            ClusterIdentifier: String;            
+            ClusterType?: String;            
+            NodeType?: String;            
+            NumberOfNodes?: IntegerOptional;            
+            ClusterSecurityGroups?: ClusterSecurityGroupNameList;            
+            VpcSecurityGroupIds?: VpcSecurityGroupIdList;            
+            MasterUserPassword?: String;            
+            ClusterParameterGroupName?: String;            
+            AutomatedSnapshotRetentionPeriod?: IntegerOptional;            
+            PreferredMaintenanceWindow?: String;            
+            ClusterVersion?: String;            
+            AllowVersionUpgrade?: BooleanOptional;            
+            HsmClientCertificateIdentifier?: String;            
+            HsmConfigurationIdentifier?: String;            
+            NewClusterIdentifier?: String;            
+        }
+        export interface ModifyClusterParameterGroupMessage {
+            ParameterGroupName: String;            
+            Parameters: ParametersList;            
+        }
+        export interface ModifyClusterSubnetGroupMessage {
+            ClusterSubnetGroupName: String;            
+            Description?: String;            
+            SubnetIds: SubnetIdentifierList;            
+        }
+        export interface ModifyEventSubscriptionMessage {
+            SubscriptionName: String;            
+            SnsTopicArn?: String;            
+            SourceType?: String;            
+            SourceIds?: SourceIdsList;            
+            EventCategories?: EventCategoriesList;            
+            Severity?: String;            
+            Enabled?: BooleanOptional;            
+        }
+        export interface ModifySnapshotCopyRetentionPeriodMessage {
+            ClusterIdentifier: String;            
+            RetentionPeriod: Integer;            
+        }
+        export interface NumberOfNodesPerClusterLimitExceededFault {
+        }
+        export interface NumberOfNodesQuotaExceededFault {
+        }
+        export interface OrderableClusterOption {
+            ClusterVersion?: String;            
+            ClusterType?: String;            
+            NodeType?: String;            
+            AvailabilityZones?: AvailabilityZoneList;            
+        }
+        export interface OrderableClusterOptionsMessage {
+            OrderableClusterOptions?: OrderableClusterOptionsList;            
+            Marker?: String;            
+        }
+        export interface Parameter {
+            ParameterName?: String;            
+            ParameterValue?: String;            
+            Description?: String;            
+            Source?: String;            
+            DataType?: String;            
+            AllowedValues?: String;            
+            ApplyType?: ParameterApplyType;            
+            IsModifiable?: Boolean;            
+            MinimumEngineVersion?: String;            
+        }
+        export interface PendingModifiedValues {
+            MasterUserPassword?: String;            
+            NodeType?: String;            
+            NumberOfNodes?: IntegerOptional;            
+            ClusterType?: String;            
+            ClusterVersion?: String;            
+            AutomatedSnapshotRetentionPeriod?: IntegerOptional;            
+            ClusterIdentifier?: String;            
+        }
+        export interface PurchaseReservedNodeOfferingMessage {
+            ReservedNodeOfferingId: String;            
+            NodeCount?: IntegerOptional;            
+        }
+        export interface RebootClusterMessage {
+            ClusterIdentifier: String;            
+        }
+        export interface RecurringCharge {
+            RecurringChargeAmount?: Double;            
+            RecurringChargeFrequency?: String;            
+        }
+        export interface ReservedNode {
+            ReservedNodeId?: String;            
+            ReservedNodeOfferingId?: String;            
+            NodeType?: String;            
+            StartTime?: TStamp;            
+            Duration?: Integer;            
+            FixedPrice?: Double;            
+            UsagePrice?: Double;            
+            CurrencyCode?: String;            
+            NodeCount?: Integer;            
+            State?: String;            
+            OfferingType?: String;            
+            RecurringCharges?: RecurringChargeList;            
+        }
+        export interface ReservedNodeAlreadyExistsFault {
+        }
+        export interface ReservedNodeNotFoundFault {
+        }
+        export interface ReservedNodeOffering {
+            ReservedNodeOfferingId?: String;            
+            NodeType?: String;            
+            Duration?: Integer;            
+            FixedPrice?: Double;            
+            UsagePrice?: Double;            
+            CurrencyCode?: String;            
+            OfferingType?: String;            
+            RecurringCharges?: RecurringChargeList;            
+        }
+        export interface ReservedNodeOfferingNotFoundFault {
+        }
+        export interface ReservedNodeOfferingsMessage {
+            Marker?: String;            
+            ReservedNodeOfferings?: ReservedNodeOfferingList;            
+        }
+        export interface ReservedNodeQuotaExceededFault {
+        }
+        export interface ReservedNodesMessage {
+            Marker?: String;            
+            ReservedNodes?: ReservedNodeList;            
+        }
+        export interface ResetClusterParameterGroupMessage {
+            ParameterGroupName: String;            
+            ResetAllParameters?: Boolean;            
+            Parameters?: ParametersList;            
+        }
+        export interface ResizeNotFoundFault {
+        }
+        export interface ResizeProgressMessage {
+            TargetNodeType?: String;            
+            TargetNumberOfNodes?: IntegerOptional;            
+            TargetClusterType?: String;            
+            Status?: String;            
+            ImportTablesCompleted?: ImportTablesCompleted;            
+            ImportTablesInProgress?: ImportTablesInProgress;            
+            ImportTablesNotStarted?: ImportTablesNotStarted;            
+            AvgResizeRateInMegaBytesPerSecond?: DoubleOptional;            
+            TotalResizeDataInMegaBytes?: LongOptional;            
+            ProgressInMegaBytes?: LongOptional;            
+            ElapsedTimeInSeconds?: LongOptional;            
+            EstimatedTimeToCompletionInSeconds?: LongOptional;            
+        }
+        export interface ResourceNotFoundFault {
+        }
+        export interface RestoreFromClusterSnapshotMessage {
+            ClusterIdentifier: String;            
+            SnapshotIdentifier: String;            
+            SnapshotClusterIdentifier?: String;            
+            Port?: IntegerOptional;            
+            AvailabilityZone?: String;            
+            AllowVersionUpgrade?: BooleanOptional;            
+            ClusterSubnetGroupName?: String;            
+            PubliclyAccessible?: BooleanOptional;            
+            OwnerAccount?: String;            
+            HsmClientCertificateIdentifier?: String;            
+            HsmConfigurationIdentifier?: String;            
+            ElasticIp?: String;            
+            ClusterParameterGroupName?: String;            
+            ClusterSecurityGroups?: ClusterSecurityGroupNameList;            
+            VpcSecurityGroupIds?: VpcSecurityGroupIdList;            
+            PreferredMaintenanceWindow?: String;            
+            AutomatedSnapshotRetentionPeriod?: IntegerOptional;            
+            KmsKeyId?: String;            
+            NodeType?: String;            
+        }
+        export interface RestoreStatus {
+            Status?: String;            
+            CurrentRestoreRateInMegaBytesPerSecond?: Double;            
+            SnapshotSizeInMegaBytes?: Long;            
+            ProgressInMegaBytes?: Long;            
+            ElapsedTimeInSeconds?: Long;            
+            EstimatedTimeToCompletionInSeconds?: Long;            
+        }
+        export interface RevokeClusterSecurityGroupIngressMessage {
+            ClusterSecurityGroupName: String;            
+            CIDRIP?: String;            
+            EC2SecurityGroupName?: String;            
+            EC2SecurityGroupOwnerId?: String;            
+        }
+        export interface RevokeSnapshotAccessMessage {
+            SnapshotIdentifier: String;            
+            SnapshotClusterIdentifier?: String;            
+            AccountWithRestoreAccess: String;            
+        }
+        export interface RotateEncryptionKeyMessage {
+            ClusterIdentifier: String;            
+        }
+        export interface SNSInvalidTopicFault {
+        }
+        export interface SNSNoAuthorizationFault {
+        }
+        export interface SNSTopicArnNotFoundFault {
+        }
+        export interface Snapshot {
+            SnapshotIdentifier?: String;            
+            ClusterIdentifier?: String;            
+            SnapshotCreateTime?: TStamp;            
+            Status?: String;            
+            Port?: Integer;            
+            AvailabilityZone?: String;            
+            ClusterCreateTime?: TStamp;            
+            MasterUsername?: String;            
+            ClusterVersion?: String;            
+            SnapshotType?: String;            
+            NodeType?: String;            
+            NumberOfNodes?: Integer;            
+            DBName?: String;            
+            VpcId?: String;            
+            Encrypted?: Boolean;            
+            KmsKeyId?: String;            
+            EncryptedWithHSM?: Boolean;            
+            AccountsWithRestoreAccess?: AccountsWithRestoreAccessList;            
+            OwnerAccount?: String;            
+            TotalBackupSizeInMegaBytes?: Double;            
+            ActualIncrementalBackupSizeInMegaBytes?: Double;            
+            BackupProgressInMegaBytes?: Double;            
+            CurrentBackupRateInMegaBytesPerSecond?: Double;            
+            EstimatedSecondsToCompletion?: Long;            
+            ElapsedTimeInSeconds?: Long;            
+            SourceRegion?: String;            
+            Tags?: TagList;            
+            RestorableNodeTypes?: RestorableNodeTypeList;            
+        }
+        export interface SnapshotCopyAlreadyDisabledFault {
+        }
+        export interface SnapshotCopyAlreadyEnabledFault {
+        }
+        export interface SnapshotCopyDisabledFault {
+        }
+        export interface SnapshotCopyGrant {
+            SnapshotCopyGrantName?: String;            
+            KmsKeyId?: String;            
+            Tags?: TagList;            
+        }
+        export interface SnapshotCopyGrantAlreadyExistsFault {
+        }
+        export interface SnapshotCopyGrantMessage {
+            Marker?: String;            
+            SnapshotCopyGrants?: SnapshotCopyGrantList;            
+        }
+        export interface SnapshotCopyGrantNotFoundFault {
+        }
+        export interface SnapshotCopyGrantQuotaExceededFault {
+        }
+        export interface SnapshotMessage {
+            Marker?: String;            
+            Snapshots?: SnapshotList;            
+        }
+        export interface SourceNotFoundFault {
+        }
+        export interface Subnet {
+            SubnetIdentifier?: String;            
+            SubnetAvailabilityZone?: AvailabilityZone;            
+            SubnetStatus?: String;            
+        }
+        export interface SubnetAlreadyInUse {
+        }
+        export interface SubscriptionAlreadyExistFault {
+        }
+        export interface SubscriptionCategoryNotFoundFault {
+        }
+        export interface SubscriptionEventIdNotFoundFault {
+        }
+        export interface SubscriptionNotFoundFault {
+        }
+        export interface SubscriptionSeverityNotFoundFault {
+        }
+        export interface Tag {
+            Key?: String;            
+            Value?: String;            
+        }
+        export interface TagLimitExceededFault {
+        }
+        export interface TaggedResource {
+            Tag?: Tag;            
+            ResourceName?: String;            
+            ResourceType?: String;            
+        }
+        export interface TaggedResourceListMessage {
+            TaggedResources?: TaggedResourceList;            
+            Marker?: String;            
+        }
+        export interface UnauthorizedOperation {
+        }
+        export interface UnknownSnapshotCopyRegionFault {
+        }
+        export interface UnsupportedOperationFault {
+        }
+        export interface UnsupportedOptionFault {
+        }
+        export interface VpcSecurityGroupMembership {
+            VpcSecurityGroupId?: String;            
+            Status?: String;            
+        }
+        export interface AuthorizeClusterSecurityGroupIngressResult {
+            ClusterSecurityGroup?: ClusterSecurityGroup;            
+        }
+        export interface AuthorizeSnapshotAccessResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface CopyClusterSnapshotResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface CreateClusterResult {
+            Cluster?: Cluster;            
+        }
+        export interface CreateClusterParameterGroupResult {
+            ClusterParameterGroup?: ClusterParameterGroup;            
+        }
+        export interface CreateClusterSecurityGroupResult {
+            ClusterSecurityGroup?: ClusterSecurityGroup;            
+        }
+        export interface CreateClusterSnapshotResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface CreateClusterSubnetGroupResult {
+            ClusterSubnetGroup?: ClusterSubnetGroup;            
+        }
+        export interface CreateEventSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface CreateHsmClientCertificateResult {
+            HsmClientCertificate?: HsmClientCertificate;            
+        }
+        export interface CreateHsmConfigurationResult {
+            HsmConfiguration?: HsmConfiguration;            
+        }
+        export interface CreateSnapshotCopyGrantResult {
+            SnapshotCopyGrant?: SnapshotCopyGrant;            
+        }
+        export interface DeleteClusterResult {
+            Cluster?: Cluster;            
+        }
+        export interface DeleteClusterSnapshotResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface DescribeDefaultClusterParametersResult {
+            DefaultClusterParameters?: DefaultClusterParameters;            
+        }
+        export interface DisableSnapshotCopyResult {
+            Cluster?: Cluster;            
+        }
+        export interface EnableSnapshotCopyResult {
+            Cluster?: Cluster;            
+        }
+        export interface ModifyClusterResult {
+            Cluster?: Cluster;            
+        }
+        export interface ModifyClusterSubnetGroupResult {
+            ClusterSubnetGroup?: ClusterSubnetGroup;            
+        }
+        export interface ModifyEventSubscriptionResult {
+            EventSubscription?: EventSubscription;            
+        }
+        export interface ModifySnapshotCopyRetentionPeriodResult {
+            Cluster?: Cluster;            
+        }
+        export interface PurchaseReservedNodeOfferingResult {
+            ReservedNode?: ReservedNode;            
+        }
+        export interface RebootClusterResult {
+            Cluster?: Cluster;            
+        }
+        export interface RestoreFromClusterSnapshotResult {
+            Cluster?: Cluster;            
+        }
+        export interface RevokeClusterSecurityGroupIngressResult {
+            ClusterSecurityGroup?: ClusterSecurityGroup;            
+        }
+        export interface RevokeSnapshotAccessResult {
+            Snapshot?: Snapshot;            
+        }
+        export interface RotateEncryptionKeyResult {
+            Cluster?: Cluster;            
+        }
 
-    export interface RedshiftSNSNoAuthorizationFault {
     }
-
-    export interface RedshiftSNSTopicArnNotFoundFault {
-    }
-
-    export interface RedshiftSnapshot {
-        SnapshotIdentifier?: RedshiftString;
-        ClusterIdentifier?: RedshiftString;
-        SnapshotCreateTime?: RedshiftTStamp;
-        Status?: RedshiftString;
-        Port?: RedshiftInteger;
-        AvailabilityZone?: RedshiftString;
-        ClusterCreateTime?: RedshiftTStamp;
-        MasterUsername?: RedshiftString;
-        ClusterVersion?: RedshiftString;
-        SnapshotType?: RedshiftString;
-        NodeType?: RedshiftString;
-        NumberOfNodes?: RedshiftInteger;
-        DBName?: RedshiftString;
-        VpcId?: RedshiftString;
-        Encrypted?: RedshiftBoolean;
-        KmsKeyId?: RedshiftString;
-        EncryptedWithHSM?: RedshiftBoolean;
-        AccountsWithRestoreAccess?: RedshiftAccountsWithRestoreAccessList;
-        OwnerAccount?: RedshiftString;
-        TotalBackupSizeInMegaBytes?: RedshiftDouble;
-        ActualIncrementalBackupSizeInMegaBytes?: RedshiftDouble;
-        BackupProgressInMegaBytes?: RedshiftDouble;
-        CurrentBackupRateInMegaBytesPerSecond?: RedshiftDouble;
-        EstimatedSecondsToCompletion?: RedshiftLong;
-        ElapsedTimeInSeconds?: RedshiftLong;
-        SourceRegion?: RedshiftString;
-        Tags?: RedshiftTagList;
-        RestorableNodeTypes?: RedshiftRestorableNodeTypeList;
-    }
-
-    export interface RedshiftSnapshotCopyAlreadyDisabledFault {
-    }
-
-    export interface RedshiftSnapshotCopyAlreadyEnabledFault {
-    }
-
-    export interface RedshiftSnapshotCopyDisabledFault {
-    }
-
-    export interface RedshiftSnapshotCopyGrant {
-        SnapshotCopyGrantName?: RedshiftString;
-        KmsKeyId?: RedshiftString;
-        Tags?: RedshiftTagList;
-    }
-
-    export interface RedshiftSnapshotCopyGrantAlreadyExistsFault {
-    }
-
-    export type RedshiftSnapshotCopyGrantList = Array<RedshiftSnapshotCopyGrant>;
-    export interface RedshiftSnapshotCopyGrantMessage {
-        Marker?: RedshiftString;
-        SnapshotCopyGrants?: RedshiftSnapshotCopyGrantList;
-    }
-
-    export interface RedshiftSnapshotCopyGrantNotFoundFault {
-    }
-
-    export interface RedshiftSnapshotCopyGrantQuotaExceededFault {
-    }
-
-    export type RedshiftSnapshotList = Array<RedshiftSnapshot>;
-    export interface RedshiftSnapshotMessage {
-        Marker?: RedshiftString;
-        Snapshots?: RedshiftSnapshotList;
-    }
-
-    export type RedshiftSourceIdsList = Array<RedshiftString>;
-    export interface RedshiftSourceNotFoundFault {
-    }
-
-    export type RedshiftSourceType = string;
-    export type RedshiftString = string;
-    export interface RedshiftSubnet {
-        SubnetIdentifier?: RedshiftString;
-        SubnetAvailabilityZone?: RedshiftAvailabilityZone;
-        SubnetStatus?: RedshiftString;
-    }
-
-    export interface RedshiftSubnetAlreadyInUse {
-    }
-
-    export type RedshiftSubnetIdentifierList = Array<RedshiftString>;
-    export type RedshiftSubnetList = Array<RedshiftSubnet>;
-    export interface RedshiftSubscriptionAlreadyExistFault {
-    }
-
-    export interface RedshiftSubscriptionCategoryNotFoundFault {
-    }
-
-    export interface RedshiftSubscriptionEventIdNotFoundFault {
-    }
-
-    export interface RedshiftSubscriptionNotFoundFault {
-    }
-
-    export interface RedshiftSubscriptionSeverityNotFoundFault {
-    }
-
-    export type RedshiftTStamp = number;
-    export interface RedshiftTag {
-        Key?: RedshiftString;
-        Value?: RedshiftString;
-    }
-
-    export type RedshiftTagKeyList = Array<RedshiftString>;
-    export interface RedshiftTagLimitExceededFault {
-    }
-
-    export type RedshiftTagList = Array<RedshiftTag>;
-    export type RedshiftTagValueList = Array<RedshiftString>;
-    export interface RedshiftTaggedResource {
-        Tag?: RedshiftTag;
-        ResourceName?: RedshiftString;
-        ResourceType?: RedshiftString;
-    }
-
-    export type RedshiftTaggedResourceList = Array<RedshiftTaggedResource>;
-    export interface RedshiftTaggedResourceListMessage {
-        TaggedResources?: RedshiftTaggedResourceList;
-        Marker?: RedshiftString;
-    }
-
-    export interface RedshiftUnauthorizedOperation {
-    }
-
-    export interface RedshiftUnknownSnapshotCopyRegionFault {
-    }
-
-    export interface RedshiftUnsupportedOperationFault {
-    }
-
-    export interface RedshiftUnsupportedOptionFault {
-    }
-
-    export type RedshiftVpcSecurityGroupIdList = Array<RedshiftString>;
-    export interface RedshiftVpcSecurityGroupMembership {
-        VpcSecurityGroupId?: RedshiftString;
-        Status?: RedshiftString;
-    }
-
-    export type RedshiftVpcSecurityGroupMembershipList = Array<RedshiftVpcSecurityGroupMembership>;
-    export interface RedshiftAuthorizeClusterSecurityGroupIngressResult {
-        ClusterSecurityGroup?: RedshiftClusterSecurityGroup;
-    }
-
-    export interface RedshiftAuthorizeSnapshotAccessResult {
-        Snapshot?: RedshiftSnapshot;
-    }
-
-    export interface RedshiftCopyClusterSnapshotResult {
-        Snapshot?: RedshiftSnapshot;
-    }
-
-    export interface RedshiftCreateClusterResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftCreateClusterParameterGroupResult {
-        ClusterParameterGroup?: RedshiftClusterParameterGroup;
-    }
-
-    export interface RedshiftCreateClusterSecurityGroupResult {
-        ClusterSecurityGroup?: RedshiftClusterSecurityGroup;
-    }
-
-    export interface RedshiftCreateClusterSnapshotResult {
-        Snapshot?: RedshiftSnapshot;
-    }
-
-    export interface RedshiftCreateClusterSubnetGroupResult {
-        ClusterSubnetGroup?: RedshiftClusterSubnetGroup;
-    }
-
-    export interface RedshiftCreateEventSubscriptionResult {
-        EventSubscription?: RedshiftEventSubscription;
-    }
-
-    export interface RedshiftCreateHsmClientCertificateResult {
-        HsmClientCertificate?: RedshiftHsmClientCertificate;
-    }
-
-    export interface RedshiftCreateHsmConfigurationResult {
-        HsmConfiguration?: RedshiftHsmConfiguration;
-    }
-
-    export interface RedshiftCreateSnapshotCopyGrantResult {
-        SnapshotCopyGrant?: RedshiftSnapshotCopyGrant;
-    }
-
-    export interface RedshiftDeleteClusterResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftDeleteClusterSnapshotResult {
-        Snapshot?: RedshiftSnapshot;
-    }
-
-    export interface RedshiftDescribeDefaultClusterParametersResult {
-        DefaultClusterParameters?: RedshiftDefaultClusterParameters;
-    }
-
-    export interface RedshiftDisableSnapshotCopyResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftEnableSnapshotCopyResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftModifyClusterResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftModifyClusterSubnetGroupResult {
-        ClusterSubnetGroup?: RedshiftClusterSubnetGroup;
-    }
-
-    export interface RedshiftModifyEventSubscriptionResult {
-        EventSubscription?: RedshiftEventSubscription;
-    }
-
-    export interface RedshiftModifySnapshotCopyRetentionPeriodResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftPurchaseReservedNodeOfferingResult {
-        ReservedNode?: RedshiftReservedNode;
-    }
-
-    export interface RedshiftRebootClusterResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftRestoreFromClusterSnapshotResult {
-        Cluster?: RedshiftCluster;
-    }
-
-    export interface RedshiftRevokeClusterSecurityGroupIngressResult {
-        ClusterSecurityGroup?: RedshiftClusterSecurityGroup;
-    }
-
-    export interface RedshiftRevokeSnapshotAccessResult {
-        Snapshot?: RedshiftSnapshot;
-    }
-
-    export interface RedshiftRotateEncryptionKeyResult {
-        Cluster?: RedshiftCluster;
-    }
-
 }

--- a/output/aws-route53.d.ts
+++ b/output/aws-route53.d.ts
@@ -6,666 +6,561 @@ declare module "aws-sdk" {
 
     export class Route53 extends Service {
       constructor(options?: any);
-      associateVPCWithHostedZone(params: Route53AssociateVPCWithHostedZoneRequest, callback?: (err: Route53NoSuchHostedZone|Route53InvalidVPCId|Route53InvalidInput|Route53PublicZoneVPCAssociation|Route53ConflictingDomainExists|any, data: Route53AssociateVPCWithHostedZoneResponse|any) => void): Request;
-      changeResourceRecordSets(params: Route53ChangeResourceRecordSetsRequest, callback?: (err: Route53NoSuchHostedZone|Route53NoSuchHealthCheck|Route53InvalidChangeBatch|Route53InvalidInput|Route53PriorRequestNotComplete|any, data: Route53ChangeResourceRecordSetsResponse|any) => void): Request;
-      changeTagsForResource(params: Route53ChangeTagsForResourceRequest, callback?: (err: Route53InvalidInput|Route53NoSuchHealthCheck|Route53NoSuchHostedZone|Route53PriorRequestNotComplete|Route53ThrottlingException|any, data: Route53ChangeTagsForResourceResponse|any) => void): Request;
-      createHealthCheck(params: Route53CreateHealthCheckRequest, callback?: (err: Route53TooManyHealthChecks|Route53HealthCheckAlreadyExists|Route53InvalidInput|any, data: Route53CreateHealthCheckResponse|any) => void): Request;
-      createHostedZone(params: Route53CreateHostedZoneRequest, callback?: (err: Route53InvalidDomainName|Route53HostedZoneAlreadyExists|Route53TooManyHostedZones|Route53InvalidVPCId|Route53InvalidInput|Route53DelegationSetNotAvailable|Route53ConflictingDomainExists|Route53NoSuchDelegationSet|Route53DelegationSetNotReusable|any, data: Route53CreateHostedZoneResponse|any) => void): Request;
-      createReusableDelegationSet(params: Route53CreateReusableDelegationSetRequest, callback?: (err: Route53DelegationSetAlreadyCreated|Route53LimitsExceeded|Route53HostedZoneNotFound|Route53InvalidArgument|Route53InvalidInput|Route53DelegationSetNotAvailable|Route53DelegationSetAlreadyReusable|any, data: Route53CreateReusableDelegationSetResponse|any) => void): Request;
-      deleteHealthCheck(params: Route53DeleteHealthCheckRequest, callback?: (err: Route53NoSuchHealthCheck|Route53HealthCheckInUse|Route53InvalidInput|any, data: Route53DeleteHealthCheckResponse|any) => void): Request;
-      deleteHostedZone(params: Route53DeleteHostedZoneRequest, callback?: (err: Route53NoSuchHostedZone|Route53HostedZoneNotEmpty|Route53PriorRequestNotComplete|Route53InvalidInput|any, data: Route53DeleteHostedZoneResponse|any) => void): Request;
-      deleteReusableDelegationSet(params: Route53DeleteReusableDelegationSetRequest, callback?: (err: Route53NoSuchDelegationSet|Route53DelegationSetInUse|Route53DelegationSetNotReusable|Route53InvalidInput|any, data: Route53DeleteReusableDelegationSetResponse|any) => void): Request;
-      disassociateVPCFromHostedZone(params: Route53DisassociateVPCFromHostedZoneRequest, callback?: (err: Route53NoSuchHostedZone|Route53InvalidVPCId|Route53VPCAssociationNotFound|Route53LastVPCAssociation|Route53InvalidInput|any, data: Route53DisassociateVPCFromHostedZoneResponse|any) => void): Request;
-      getChange(params: Route53GetChangeRequest, callback?: (err: Route53NoSuchChange|Route53InvalidInput|any, data: Route53GetChangeResponse|any) => void): Request;
-      getCheckerIpRanges(params: Route53GetCheckerIpRangesRequest, callback?: (err: any, data: Route53GetCheckerIpRangesResponse|any) => void): Request;
-      getGeoLocation(params: Route53GetGeoLocationRequest, callback?: (err: Route53NoSuchGeoLocation|Route53InvalidInput|any, data: Route53GetGeoLocationResponse|any) => void): Request;
-      getHealthCheck(params: Route53GetHealthCheckRequest, callback?: (err: Route53NoSuchHealthCheck|Route53InvalidInput|Route53IncompatibleVersion|any, data: Route53GetHealthCheckResponse|any) => void): Request;
-      getHealthCheckCount(params: Route53GetHealthCheckCountRequest, callback?: (err: any, data: Route53GetHealthCheckCountResponse|any) => void): Request;
-      getHealthCheckLastFailureReason(params: Route53GetHealthCheckLastFailureReasonRequest, callback?: (err: Route53NoSuchHealthCheck|any, data: Route53GetHealthCheckLastFailureReasonResponse|any) => void): Request;
-      getHealthCheckStatus(params: Route53GetHealthCheckStatusRequest, callback?: (err: Route53NoSuchHealthCheck|any, data: Route53GetHealthCheckStatusResponse|any) => void): Request;
-      getHostedZone(params: Route53GetHostedZoneRequest, callback?: (err: Route53NoSuchHostedZone|Route53InvalidInput|any, data: Route53GetHostedZoneResponse|any) => void): Request;
-      getHostedZoneCount(params: Route53GetHostedZoneCountRequest, callback?: (err: Route53InvalidInput|any, data: Route53GetHostedZoneCountResponse|any) => void): Request;
-      getReusableDelegationSet(params: Route53GetReusableDelegationSetRequest, callback?: (err: Route53NoSuchDelegationSet|Route53DelegationSetNotReusable|Route53InvalidInput|any, data: Route53GetReusableDelegationSetResponse|any) => void): Request;
-      listGeoLocations(params: Route53ListGeoLocationsRequest, callback?: (err: Route53InvalidInput|any, data: Route53ListGeoLocationsResponse|any) => void): Request;
-      listHealthChecks(params: Route53ListHealthChecksRequest, callback?: (err: Route53InvalidInput|Route53IncompatibleVersion|any, data: Route53ListHealthChecksResponse|any) => void): Request;
-      listHostedZones(params: Route53ListHostedZonesRequest, callback?: (err: Route53InvalidInput|Route53NoSuchDelegationSet|Route53DelegationSetNotReusable|any, data: Route53ListHostedZonesResponse|any) => void): Request;
-      listHostedZonesByName(params: Route53ListHostedZonesByNameRequest, callback?: (err: Route53InvalidInput|Route53InvalidDomainName|any, data: Route53ListHostedZonesByNameResponse|any) => void): Request;
-      listResourceRecordSets(params: Route53ListResourceRecordSetsRequest, callback?: (err: Route53NoSuchHostedZone|Route53InvalidInput|any, data: Route53ListResourceRecordSetsResponse|any) => void): Request;
-      listReusableDelegationSets(params: Route53ListReusableDelegationSetsRequest, callback?: (err: Route53InvalidInput|any, data: Route53ListReusableDelegationSetsResponse|any) => void): Request;
-      listTagsForResource(params: Route53ListTagsForResourceRequest, callback?: (err: Route53InvalidInput|Route53NoSuchHealthCheck|Route53NoSuchHostedZone|Route53PriorRequestNotComplete|Route53ThrottlingException|any, data: Route53ListTagsForResourceResponse|any) => void): Request;
-      listTagsForResources(params: Route53ListTagsForResourcesRequest, callback?: (err: Route53InvalidInput|Route53NoSuchHealthCheck|Route53NoSuchHostedZone|Route53PriorRequestNotComplete|Route53ThrottlingException|any, data: Route53ListTagsForResourcesResponse|any) => void): Request;
-      updateHealthCheck(params: Route53UpdateHealthCheckRequest, callback?: (err: Route53NoSuchHealthCheck|Route53InvalidInput|Route53HealthCheckVersionMismatch|any, data: Route53UpdateHealthCheckResponse|any) => void): Request;
-      updateHostedZoneComment(params: Route53UpdateHostedZoneCommentRequest, callback?: (err: Route53NoSuchHostedZone|Route53InvalidInput|any, data: Route53UpdateHostedZoneCommentResponse|any) => void): Request;
-    }
-
-    export type Route53AliasHealthEnabled = boolean;
-    export interface Route53AliasTarget {
-        HostedZoneId: Route53ResourceId;
-        DNSName: Route53DNSName;
-        EvaluateTargetHealth: Route53AliasHealthEnabled;
-    }
-
-    export type Route53AssociateVPCComment = string;
-    export interface Route53AssociateVPCWithHostedZoneRequest {
-        HostedZoneId: Route53ResourceId;
-        VPC: Route53VPC;
-        Comment?: Route53AssociateVPCComment;
-    }
-
-    export interface Route53AssociateVPCWithHostedZoneResponse {
-        ChangeInfo: Route53ChangeInfo;
-    }
-
-    export interface Route53Change {
-        Action: Route53ChangeAction;
-        ResourceRecordSet: Route53ResourceRecordSet;
-    }
-
-    export type Route53ChangeAction = string;
-    export interface Route53ChangeBatch {
-        Comment?: Route53ResourceDescription;
-        Changes: Route53Changes;
-    }
-
-    export interface Route53ChangeInfo {
-        Id: Route53ResourceId;
-        Status: Route53ChangeStatus;
-        SubmittedAt: Route53TimeStamp;
-        Comment?: Route53ResourceDescription;
-    }
-
-    export interface Route53ChangeResourceRecordSetsRequest {
-        HostedZoneId: Route53ResourceId;
-        ChangeBatch: Route53ChangeBatch;
-    }
-
-    export interface Route53ChangeResourceRecordSetsResponse {
-        ChangeInfo: Route53ChangeInfo;
-    }
-
-    export type Route53ChangeStatus = string;
-    export interface Route53ChangeTagsForResourceRequest {
-        ResourceType: Route53TagResourceType;
-        ResourceId: Route53TagResourceId;
-        AddTags?: Route53TagList;
-        RemoveTagKeys?: Route53TagKeyList;
-    }
-
-    export interface Route53ChangeTagsForResourceResponse {
-    }
-
-    export type Route53Changes = Array<Route53Change>;
-    export type Route53CheckerIpRanges = Array<Route53IPAddressCidr>;
-    export type Route53ChildHealthCheckList = Array<Route53HealthCheckId>; // max: 256
-    export interface Route53ConflictingDomainExists {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53CreateHealthCheckRequest {
-        CallerReference: Route53HealthCheckNonce;
-        HealthCheckConfig: Route53HealthCheckConfig;
-    }
-
-    export interface Route53CreateHealthCheckResponse {
-        HealthCheck: Route53HealthCheck;
-        Location: Route53ResourceURI;
-    }
-
-    export interface Route53CreateHostedZoneRequest {
-        Name: Route53DNSName;
-        VPC?: Route53VPC;
-        CallerReference: Route53Nonce;
-        HostedZoneConfig?: Route53HostedZoneConfig;
-        DelegationSetId?: Route53ResourceId;
-    }
-
-    export interface Route53CreateHostedZoneResponse {
-        HostedZone: Route53HostedZone;
-        ChangeInfo: Route53ChangeInfo;
-        DelegationSet: Route53DelegationSet;
-        VPC?: Route53VPC;
-        Location: Route53ResourceURI;
-    }
-
-    export interface Route53CreateReusableDelegationSetRequest {
-        CallerReference: Route53Nonce;
-        HostedZoneId?: Route53ResourceId;
-    }
-
-    export interface Route53CreateReusableDelegationSetResponse {
-        DelegationSet: Route53DelegationSet;
-        Location: Route53ResourceURI;
-    }
-
-    export type Route53DNSName = string;
-    export interface Route53DelegationSet {
-        Id?: Route53ResourceId;
-        CallerReference?: Route53Nonce;
-        NameServers: Route53DelegationSetNameServers;
-    }
-
-    export interface Route53DelegationSetAlreadyCreated {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53DelegationSetAlreadyReusable {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53DelegationSetInUse {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53DelegationSetNameServers = Array<Route53DNSName>;
-    export interface Route53DelegationSetNotAvailable {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53DelegationSetNotReusable {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53DelegationSets = Array<Route53DelegationSet>;
-    export interface Route53DeleteHealthCheckRequest {
-        HealthCheckId: Route53HealthCheckId;
-    }
-
-    export interface Route53DeleteHealthCheckResponse {
-    }
-
-    export interface Route53DeleteHostedZoneRequest {
-        Id: Route53ResourceId;
-    }
-
-    export interface Route53DeleteHostedZoneResponse {
-        ChangeInfo: Route53ChangeInfo;
-    }
-
-    export interface Route53DeleteReusableDelegationSetRequest {
-        Id: Route53ResourceId;
-    }
-
-    export interface Route53DeleteReusableDelegationSetResponse {
-    }
-
-    export type Route53DisassociateVPCComment = string;
-    export interface Route53DisassociateVPCFromHostedZoneRequest {
-        HostedZoneId: Route53ResourceId;
-        VPC: Route53VPC;
-        Comment?: Route53DisassociateVPCComment;
-    }
-
-    export interface Route53DisassociateVPCFromHostedZoneResponse {
-        ChangeInfo: Route53ChangeInfo;
-    }
-
-    export type Route53ErrorMessage = string;
-    export type Route53ErrorMessages = Array<Route53ErrorMessage>;
-    export type Route53FailureThreshold = number;
-    export type Route53FullyQualifiedDomainName = string;
-    export interface Route53GeoLocation {
-        ContinentCode?: Route53GeoLocationContinentCode;
-        CountryCode?: Route53GeoLocationCountryCode;
-        SubdivisionCode?: Route53GeoLocationSubdivisionCode;
-    }
-
-    export type Route53GeoLocationContinentCode = string;
-    export type Route53GeoLocationContinentName = string;
-    export type Route53GeoLocationCountryCode = string;
-    export type Route53GeoLocationCountryName = string;
-    export interface Route53GeoLocationDetails {
-        ContinentCode?: Route53GeoLocationContinentCode;
-        ContinentName?: Route53GeoLocationContinentName;
-        CountryCode?: Route53GeoLocationCountryCode;
-        CountryName?: Route53GeoLocationCountryName;
-        SubdivisionCode?: Route53GeoLocationSubdivisionCode;
-        SubdivisionName?: Route53GeoLocationSubdivisionName;
-    }
-
-    export type Route53GeoLocationDetailsList = Array<Route53GeoLocationDetails>;
-    export type Route53GeoLocationSubdivisionCode = string;
-    export type Route53GeoLocationSubdivisionName = string;
-    export interface Route53GetChangeRequest {
-        Id: Route53ResourceId;
-    }
-
-    export interface Route53GetChangeResponse {
-        ChangeInfo: Route53ChangeInfo;
-    }
-
-    export interface Route53GetCheckerIpRangesRequest {
-    }
-
-    export interface Route53GetCheckerIpRangesResponse {
-        CheckerIpRanges: Route53CheckerIpRanges;
-    }
-
-    export interface Route53GetGeoLocationRequest {
-        ContinentCode?: Route53GeoLocationContinentCode;
-        CountryCode?: Route53GeoLocationCountryCode;
-        SubdivisionCode?: Route53GeoLocationSubdivisionCode;
-    }
-
-    export interface Route53GetGeoLocationResponse {
-        GeoLocationDetails: Route53GeoLocationDetails;
-    }
-
-    export interface Route53GetHealthCheckCountRequest {
-    }
-
-    export interface Route53GetHealthCheckCountResponse {
-        HealthCheckCount: Route53HealthCheckCount;
-    }
-
-    export interface Route53GetHealthCheckLastFailureReasonRequest {
-        HealthCheckId: Route53HealthCheckId;
-    }
-
-    export interface Route53GetHealthCheckLastFailureReasonResponse {
-        HealthCheckObservations: Route53HealthCheckObservations;
-    }
-
-    export interface Route53GetHealthCheckRequest {
-        HealthCheckId: Route53HealthCheckId;
-    }
-
-    export interface Route53GetHealthCheckResponse {
-        HealthCheck: Route53HealthCheck;
-    }
-
-    export interface Route53GetHealthCheckStatusRequest {
-        HealthCheckId: Route53HealthCheckId;
-    }
-
-    export interface Route53GetHealthCheckStatusResponse {
-        HealthCheckObservations: Route53HealthCheckObservations;
-    }
-
-    export interface Route53GetHostedZoneCountRequest {
-    }
-
-    export interface Route53GetHostedZoneCountResponse {
-        HostedZoneCount: Route53HostedZoneCount;
-    }
-
-    export interface Route53GetHostedZoneRequest {
-        Id: Route53ResourceId;
-    }
-
-    export interface Route53GetHostedZoneResponse {
-        HostedZone: Route53HostedZone;
-        DelegationSet?: Route53DelegationSet;
-        VPCs?: Route53VPCs;
-    }
-
-    export interface Route53GetReusableDelegationSetRequest {
-        Id: Route53ResourceId;
-    }
-
-    export interface Route53GetReusableDelegationSetResponse {
-        DelegationSet: Route53DelegationSet;
-    }
-
-    export interface Route53HealthCheck {
-        Id: Route53HealthCheckId;
-        CallerReference: Route53HealthCheckNonce;
-        HealthCheckConfig: Route53HealthCheckConfig;
-        HealthCheckVersion: Route53HealthCheckVersion;
-    }
+      associateVPCWithHostedZone(params: Route53.AssociateVPCWithHostedZoneRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.InvalidVPCId|Route53.InvalidInput|Route53.PublicZoneVPCAssociation|Route53.ConflictingDomainExists|any, data: Route53.AssociateVPCWithHostedZoneResponse|any) => void): Request;
+      changeResourceRecordSets(params: Route53.ChangeResourceRecordSetsRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.NoSuchHealthCheck|Route53.InvalidChangeBatch|Route53.InvalidInput|Route53.PriorRequestNotComplete|any, data: Route53.ChangeResourceRecordSetsResponse|any) => void): Request;
+      changeTagsForResource(params: Route53.ChangeTagsForResourceRequest, callback?: (err: Route53.InvalidInput|Route53.NoSuchHealthCheck|Route53.NoSuchHostedZone|Route53.PriorRequestNotComplete|Route53.ThrottlingException|any, data: Route53.ChangeTagsForResourceResponse|any) => void): Request;
+      createHealthCheck(params: Route53.CreateHealthCheckRequest, callback?: (err: Route53.TooManyHealthChecks|Route53.HealthCheckAlreadyExists|Route53.InvalidInput|any, data: Route53.CreateHealthCheckResponse|any) => void): Request;
+      createHostedZone(params: Route53.CreateHostedZoneRequest, callback?: (err: Route53.InvalidDomainName|Route53.HostedZoneAlreadyExists|Route53.TooManyHostedZones|Route53.InvalidVPCId|Route53.InvalidInput|Route53.DelegationSetNotAvailable|Route53.ConflictingDomainExists|Route53.NoSuchDelegationSet|Route53.DelegationSetNotReusable|any, data: Route53.CreateHostedZoneResponse|any) => void): Request;
+      createReusableDelegationSet(params: Route53.CreateReusableDelegationSetRequest, callback?: (err: Route53.DelegationSetAlreadyCreated|Route53.LimitsExceeded|Route53.HostedZoneNotFound|Route53.InvalidArgument|Route53.InvalidInput|Route53.DelegationSetNotAvailable|Route53.DelegationSetAlreadyReusable|any, data: Route53.CreateReusableDelegationSetResponse|any) => void): Request;
+      deleteHealthCheck(params: Route53.DeleteHealthCheckRequest, callback?: (err: Route53.NoSuchHealthCheck|Route53.HealthCheckInUse|Route53.InvalidInput|any, data: Route53.DeleteHealthCheckResponse|any) => void): Request;
+      deleteHostedZone(params: Route53.DeleteHostedZoneRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.HostedZoneNotEmpty|Route53.PriorRequestNotComplete|Route53.InvalidInput|any, data: Route53.DeleteHostedZoneResponse|any) => void): Request;
+      deleteReusableDelegationSet(params: Route53.DeleteReusableDelegationSetRequest, callback?: (err: Route53.NoSuchDelegationSet|Route53.DelegationSetInUse|Route53.DelegationSetNotReusable|Route53.InvalidInput|any, data: Route53.DeleteReusableDelegationSetResponse|any) => void): Request;
+      disassociateVPCFromHostedZone(params: Route53.DisassociateVPCFromHostedZoneRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.InvalidVPCId|Route53.VPCAssociationNotFound|Route53.LastVPCAssociation|Route53.InvalidInput|any, data: Route53.DisassociateVPCFromHostedZoneResponse|any) => void): Request;
+      getChange(params: Route53.GetChangeRequest, callback?: (err: Route53.NoSuchChange|Route53.InvalidInput|any, data: Route53.GetChangeResponse|any) => void): Request;
+      getCheckerIpRanges(params: Route53.GetCheckerIpRangesRequest, callback?: (err: any, data: Route53.GetCheckerIpRangesResponse|any) => void): Request;
+      getGeoLocation(params: Route53.GetGeoLocationRequest, callback?: (err: Route53.NoSuchGeoLocation|Route53.InvalidInput|any, data: Route53.GetGeoLocationResponse|any) => void): Request;
+      getHealthCheck(params: Route53.GetHealthCheckRequest, callback?: (err: Route53.NoSuchHealthCheck|Route53.InvalidInput|Route53.IncompatibleVersion|any, data: Route53.GetHealthCheckResponse|any) => void): Request;
+      getHealthCheckCount(params: Route53.GetHealthCheckCountRequest, callback?: (err: any, data: Route53.GetHealthCheckCountResponse|any) => void): Request;
+      getHealthCheckLastFailureReason(params: Route53.GetHealthCheckLastFailureReasonRequest, callback?: (err: Route53.NoSuchHealthCheck|any, data: Route53.GetHealthCheckLastFailureReasonResponse|any) => void): Request;
+      getHealthCheckStatus(params: Route53.GetHealthCheckStatusRequest, callback?: (err: Route53.NoSuchHealthCheck|any, data: Route53.GetHealthCheckStatusResponse|any) => void): Request;
+      getHostedZone(params: Route53.GetHostedZoneRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.InvalidInput|any, data: Route53.GetHostedZoneResponse|any) => void): Request;
+      getHostedZoneCount(params: Route53.GetHostedZoneCountRequest, callback?: (err: Route53.InvalidInput|any, data: Route53.GetHostedZoneCountResponse|any) => void): Request;
+      getReusableDelegationSet(params: Route53.GetReusableDelegationSetRequest, callback?: (err: Route53.NoSuchDelegationSet|Route53.DelegationSetNotReusable|Route53.InvalidInput|any, data: Route53.GetReusableDelegationSetResponse|any) => void): Request;
+      listGeoLocations(params: Route53.ListGeoLocationsRequest, callback?: (err: Route53.InvalidInput|any, data: Route53.ListGeoLocationsResponse|any) => void): Request;
+      listHealthChecks(params: Route53.ListHealthChecksRequest, callback?: (err: Route53.InvalidInput|Route53.IncompatibleVersion|any, data: Route53.ListHealthChecksResponse|any) => void): Request;
+      listHostedZones(params: Route53.ListHostedZonesRequest, callback?: (err: Route53.InvalidInput|Route53.NoSuchDelegationSet|Route53.DelegationSetNotReusable|any, data: Route53.ListHostedZonesResponse|any) => void): Request;
+      listHostedZonesByName(params: Route53.ListHostedZonesByNameRequest, callback?: (err: Route53.InvalidInput|Route53.InvalidDomainName|any, data: Route53.ListHostedZonesByNameResponse|any) => void): Request;
+      listResourceRecordSets(params: Route53.ListResourceRecordSetsRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.InvalidInput|any, data: Route53.ListResourceRecordSetsResponse|any) => void): Request;
+      listReusableDelegationSets(params: Route53.ListReusableDelegationSetsRequest, callback?: (err: Route53.InvalidInput|any, data: Route53.ListReusableDelegationSetsResponse|any) => void): Request;
+      listTagsForResource(params: Route53.ListTagsForResourceRequest, callback?: (err: Route53.InvalidInput|Route53.NoSuchHealthCheck|Route53.NoSuchHostedZone|Route53.PriorRequestNotComplete|Route53.ThrottlingException|any, data: Route53.ListTagsForResourceResponse|any) => void): Request;
+      listTagsForResources(params: Route53.ListTagsForResourcesRequest, callback?: (err: Route53.InvalidInput|Route53.NoSuchHealthCheck|Route53.NoSuchHostedZone|Route53.PriorRequestNotComplete|Route53.ThrottlingException|any, data: Route53.ListTagsForResourcesResponse|any) => void): Request;
+      updateHealthCheck(params: Route53.UpdateHealthCheckRequest, callback?: (err: Route53.NoSuchHealthCheck|Route53.InvalidInput|Route53.HealthCheckVersionMismatch|any, data: Route53.UpdateHealthCheckResponse|any) => void): Request;
+      updateHostedZoneComment(params: Route53.UpdateHostedZoneCommentRequest, callback?: (err: Route53.NoSuchHostedZone|Route53.InvalidInput|any, data: Route53.UpdateHostedZoneCommentResponse|any) => void): Request;
+    }
+    
+    export module Route53 {
+        export type AliasHealthEnabled = boolean;
+        export type AssociateVPCComment = string;
+        export type ChangeAction = string;
+        export type ChangeStatus = string;
+        export type Changes = Change[];    // min: 1
+        export type CheckerIpRanges = IPAddressCidr[];
+        export type ChildHealthCheckList = HealthCheckId[];    // max: 256
+        export type DNSName = string;    // max: 1024
+        export type DelegationSetNameServers = DNSName[];    // min: 1
+        export type DelegationSets = DelegationSet[];
+        export type DisassociateVPCComment = string;
+        export type ErrorMessage = string;
+        export type ErrorMessages = ErrorMessage[];
+        export type FailureThreshold = number;    // max: 10, min: 1
+        export type FullyQualifiedDomainName = string;    // max: 255
+        export type GeoLocationContinentCode = string;    // max: 2, min: 2
+        export type GeoLocationContinentName = string;    // max: 32, min: 1
+        export type GeoLocationCountryCode = string;    // max: 2, min: 1
+        export type GeoLocationCountryName = string;    // max: 64, min: 1
+        export type GeoLocationDetailsList = GeoLocationDetails[];
+        export type GeoLocationSubdivisionCode = string;    // max: 3, min: 1
+        export type GeoLocationSubdivisionName = string;    // max: 64, min: 1
+        export type HealthCheckCount = number;
+        export type HealthCheckId = string;    // max: 64
+        export type HealthCheckNonce = string;    // max: 64, min: 1
+        export type HealthCheckObservations = HealthCheckObservation[];
+        export type HealthCheckType = string;
+        export type HealthCheckVersion = number;    // min: 1
+        export type HealthChecks = HealthCheck[];
+        export type HealthThreshold = number;    // max: 256
+        export type HostedZoneCount = number;
+        export type HostedZoneRRSetCount = number;
+        export type HostedZones = HostedZone[];
+        export type IPAddress = string;    // pattern: &quot;^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$&quot;, max: 15
+        export type IPAddressCidr = string;
+        export type Inverted = boolean;
+        export type IsPrivateZone = boolean;
+        export type MeasureLatency = boolean;
+        export type Nonce = string;    // max: 128, min: 1
+        export type PageMarker = string;    // max: 64
+        export type PageMaxItems = string;
+        export type PageTruncated = boolean;
+        export type Port = number;    // max: 65535, min: 1
+        export type RData = string;    // max: 4000
+        export type RRType = string;
+        export type RequestInterval = number;    // max: 30, min: 10
+        export type ResourceDescription = string;    // max: 256
+        export type ResourceId = string;    // max: 32
+        export type ResourcePath = string;    // max: 255
+        export type ResourceRecordSetFailover = string;
+        export type ResourceRecordSetIdentifier = string;    // max: 128, min: 1
+        export type ResourceRecordSetRegion = string;    // max: 64, min: 1
+        export type ResourceRecordSetWeight = number;    // max: 255
+        export type ResourceRecordSets = ResourceRecordSet[];
+        export type ResourceRecords = ResourceRecord[];    // min: 1
+        export type ResourceTagSetList = ResourceTagSet[];
+        export type ResourceURI = string;    // max: 1024
+        export type SearchString = string;    // max: 255
+        export type Status = string;
+        export type TTL = number;    // max: 2147483647
+        export type TagKey = string;    // max: 128
+        export type TagKeyList = TagKey[];    // max: 10, min: 1
+        export type TagList = Tag[];    // max: 10, min: 1
+        export type TagResourceId = string;    // max: 64
+        export type TagResourceIdList = TagResourceId[];    // max: 10, min: 1
+        export type TagResourceType = string;
+        export type TagValue = string;    // max: 256
+        export type TimeStamp = number;
+        export type VPCId = string;    // max: 1024
+        export type VPCRegion = string;    // max: 64, min: 1
+        export type VPCs = VPC[];    // min: 1
+
+        export interface AliasTarget {
+            HostedZoneId: ResourceId;            
+            DNSName: DNSName;            
+            EvaluateTargetHealth: AliasHealthEnabled;            
+        }
+        export interface AssociateVPCWithHostedZoneRequest {
+            HostedZoneId: ResourceId;            
+            VPC: VPC;            
+            Comment?: AssociateVPCComment;            
+        }
+        export interface AssociateVPCWithHostedZoneResponse {
+            ChangeInfo: ChangeInfo;            
+        }
+        export interface Change {
+            Action: ChangeAction;            
+            ResourceRecordSet: ResourceRecordSet;            
+        }
+        export interface ChangeBatch {
+            Comment?: ResourceDescription;            
+            Changes: Changes;            
+        }
+        export interface ChangeInfo {
+            Id: ResourceId;            
+            Status: ChangeStatus;            
+            SubmittedAt: TimeStamp;            
+            Comment?: ResourceDescription;            
+        }
+        export interface ChangeResourceRecordSetsRequest {
+            HostedZoneId: ResourceId;            
+            ChangeBatch: ChangeBatch;            
+        }
+        export interface ChangeResourceRecordSetsResponse {
+            ChangeInfo: ChangeInfo;            
+        }
+        export interface ChangeTagsForResourceRequest {
+            ResourceType: TagResourceType;            
+            ResourceId: TagResourceId;            
+            AddTags?: TagList;            
+            RemoveTagKeys?: TagKeyList;            
+        }
+        export interface ChangeTagsForResourceResponse {
+        }
+        export interface ConflictingDomainExists {
+            message?: ErrorMessage;            
+        }
+        export interface CreateHealthCheckRequest {
+            CallerReference: HealthCheckNonce;            
+            HealthCheckConfig: HealthCheckConfig;            
+        }
+        export interface CreateHealthCheckResponse {
+            HealthCheck: HealthCheck;            
+            Location: ResourceURI;            
+        }
+        export interface CreateHostedZoneRequest {
+            Name: DNSName;            
+            VPC?: VPC;            
+            CallerReference: Nonce;            
+            HostedZoneConfig?: HostedZoneConfig;            
+            DelegationSetId?: ResourceId;            
+        }
+        export interface CreateHostedZoneResponse {
+            HostedZone: HostedZone;            
+            ChangeInfo: ChangeInfo;            
+            DelegationSet: DelegationSet;            
+            VPC?: VPC;            
+            Location: ResourceURI;            
+        }
+        export interface CreateReusableDelegationSetRequest {
+            CallerReference: Nonce;            
+            HostedZoneId?: ResourceId;            
+        }
+        export interface CreateReusableDelegationSetResponse {
+            DelegationSet: DelegationSet;            
+            Location: ResourceURI;            
+        }
+        export interface DelegationSet {
+            Id?: ResourceId;            
+            CallerReference?: Nonce;            
+            NameServers: DelegationSetNameServers;            
+        }
+        export interface DelegationSetAlreadyCreated {
+            message?: ErrorMessage;            
+        }
+        export interface DelegationSetAlreadyReusable {
+            message?: ErrorMessage;            
+        }
+        export interface DelegationSetInUse {
+            message?: ErrorMessage;            
+        }
+        export interface DelegationSetNotAvailable {
+            message?: ErrorMessage;            
+        }
+        export interface DelegationSetNotReusable {
+            message?: ErrorMessage;            
+        }
+        export interface DeleteHealthCheckRequest {
+            HealthCheckId: HealthCheckId;            
+        }
+        export interface DeleteHealthCheckResponse {
+        }
+        export interface DeleteHostedZoneRequest {
+            Id: ResourceId;            
+        }
+        export interface DeleteHostedZoneResponse {
+            ChangeInfo: ChangeInfo;            
+        }
+        export interface DeleteReusableDelegationSetRequest {
+            Id: ResourceId;            
+        }
+        export interface DeleteReusableDelegationSetResponse {
+        }
+        export interface DisassociateVPCFromHostedZoneRequest {
+            HostedZoneId: ResourceId;            
+            VPC: VPC;            
+            Comment?: DisassociateVPCComment;            
+        }
+        export interface DisassociateVPCFromHostedZoneResponse {
+            ChangeInfo: ChangeInfo;            
+        }
+        export interface GeoLocation {
+            ContinentCode?: GeoLocationContinentCode;            
+            CountryCode?: GeoLocationCountryCode;            
+            SubdivisionCode?: GeoLocationSubdivisionCode;            
+        }
+        export interface GeoLocationDetails {
+            ContinentCode?: GeoLocationContinentCode;            
+            ContinentName?: GeoLocationContinentName;            
+            CountryCode?: GeoLocationCountryCode;            
+            CountryName?: GeoLocationCountryName;            
+            SubdivisionCode?: GeoLocationSubdivisionCode;            
+            SubdivisionName?: GeoLocationSubdivisionName;            
+        }
+        export interface GetChangeRequest {
+            Id: ResourceId;            
+        }
+        export interface GetChangeResponse {
+            ChangeInfo: ChangeInfo;            
+        }
+        export interface GetCheckerIpRangesRequest {
+        }
+        export interface GetCheckerIpRangesResponse {
+            CheckerIpRanges: CheckerIpRanges;            
+        }
+        export interface GetGeoLocationRequest {
+            ContinentCode?: GeoLocationContinentCode;            
+            CountryCode?: GeoLocationCountryCode;            
+            SubdivisionCode?: GeoLocationSubdivisionCode;            
+        }
+        export interface GetGeoLocationResponse {
+            GeoLocationDetails: GeoLocationDetails;            
+        }
+        export interface GetHealthCheckCountRequest {
+        }
+        export interface GetHealthCheckCountResponse {
+            HealthCheckCount: HealthCheckCount;            
+        }
+        export interface GetHealthCheckLastFailureReasonRequest {
+            HealthCheckId: HealthCheckId;            
+        }
+        export interface GetHealthCheckLastFailureReasonResponse {
+            HealthCheckObservations: HealthCheckObservations;            
+        }
+        export interface GetHealthCheckRequest {
+            HealthCheckId: HealthCheckId;            
+        }
+        export interface GetHealthCheckResponse {
+            HealthCheck: HealthCheck;            
+        }
+        export interface GetHealthCheckStatusRequest {
+            HealthCheckId: HealthCheckId;            
+        }
+        export interface GetHealthCheckStatusResponse {
+            HealthCheckObservations: HealthCheckObservations;            
+        }
+        export interface GetHostedZoneCountRequest {
+        }
+        export interface GetHostedZoneCountResponse {
+            HostedZoneCount: HostedZoneCount;            
+        }
+        export interface GetHostedZoneRequest {
+            Id: ResourceId;            
+        }
+        export interface GetHostedZoneResponse {
+            HostedZone: HostedZone;            
+            DelegationSet?: DelegationSet;            
+            VPCs?: VPCs;            
+        }
+        export interface GetReusableDelegationSetRequest {
+            Id: ResourceId;            
+        }
+        export interface GetReusableDelegationSetResponse {
+            DelegationSet: DelegationSet;            
+        }
+        export interface HealthCheck {
+            Id: HealthCheckId;            
+            CallerReference: HealthCheckNonce;            
+            HealthCheckConfig: HealthCheckConfig;            
+            HealthCheckVersion: HealthCheckVersion;            
+        }
+        export interface HealthCheckAlreadyExists {
+            message?: ErrorMessage;            
+        }
+        export interface HealthCheckConfig {
+            IPAddress?: IPAddress;            
+            Port?: Port;            
+            Type: HealthCheckType;            
+            ResourcePath?: ResourcePath;            
+            FullyQualifiedDomainName?: FullyQualifiedDomainName;            
+            SearchString?: SearchString;            
+            RequestInterval?: RequestInterval;            
+            FailureThreshold?: FailureThreshold;            
+            MeasureLatency?: MeasureLatency;            
+            Inverted?: Inverted;            
+            HealthThreshold?: HealthThreshold;            
+            ChildHealthChecks?: ChildHealthCheckList;            
+        }
+        export interface HealthCheckInUse {
+            message?: ErrorMessage;            
+        }
+        export interface HealthCheckObservation {
+            IPAddress?: IPAddress;            
+            StatusReport?: StatusReport;            
+        }
+        export interface HealthCheckVersionMismatch {
+            message?: ErrorMessage;            
+        }
+        export interface HostedZone {
+            Id: ResourceId;            
+            Name: DNSName;            
+            CallerReference: Nonce;            
+            Config?: HostedZoneConfig;            
+            ResourceRecordSetCount?: HostedZoneRRSetCount;            
+        }
+        export interface HostedZoneAlreadyExists {
+            message?: ErrorMessage;            
+        }
+        export interface HostedZoneConfig {
+            Comment?: ResourceDescription;            
+            PrivateZone?: IsPrivateZone;            
+        }
+        export interface HostedZoneNotEmpty {
+            message?: ErrorMessage;            
+        }
+        export interface HostedZoneNotFound {
+            message?: ErrorMessage;            
+        }
+        export interface IncompatibleVersion {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidArgument {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidChangeBatch {
+            messages?: ErrorMessages;            
+        }
+        export interface InvalidDomainName {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidInput {
+            message?: ErrorMessage;            
+        }
+        export interface InvalidVPCId {
+            message?: ErrorMessage;            
+        }
+        export interface LastVPCAssociation {
+            message?: ErrorMessage;            
+        }
+        export interface LimitsExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface ListGeoLocationsRequest {
+            StartContinentCode?: GeoLocationContinentCode;            
+            StartCountryCode?: GeoLocationCountryCode;            
+            StartSubdivisionCode?: GeoLocationSubdivisionCode;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListGeoLocationsResponse {
+            GeoLocationDetailsList: GeoLocationDetailsList;            
+            IsTruncated: PageTruncated;            
+            NextContinentCode?: GeoLocationContinentCode;            
+            NextCountryCode?: GeoLocationCountryCode;            
+            NextSubdivisionCode?: GeoLocationSubdivisionCode;            
+            MaxItems: PageMaxItems;            
+        }
+        export interface ListHealthChecksRequest {
+            Marker?: PageMarker;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListHealthChecksResponse {
+            HealthChecks: HealthChecks;            
+            Marker: PageMarker;            
+            IsTruncated: PageTruncated;            
+            NextMarker?: PageMarker;            
+            MaxItems: PageMaxItems;            
+        }
+        export interface ListHostedZonesByNameRequest {
+            DNSName?: DNSName;            
+            HostedZoneId?: ResourceId;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListHostedZonesByNameResponse {
+            HostedZones: HostedZones;            
+            DNSName?: DNSName;            
+            HostedZoneId?: ResourceId;            
+            IsTruncated: PageTruncated;            
+            NextDNSName?: DNSName;            
+            NextHostedZoneId?: ResourceId;            
+            MaxItems: PageMaxItems;            
+        }
+        export interface ListHostedZonesRequest {
+            Marker?: PageMarker;            
+            MaxItems?: PageMaxItems;            
+            DelegationSetId?: ResourceId;            
+        }
+        export interface ListHostedZonesResponse {
+            HostedZones: HostedZones;            
+            Marker: PageMarker;            
+            IsTruncated: PageTruncated;            
+            NextMarker?: PageMarker;            
+            MaxItems: PageMaxItems;            
+        }
+        export interface ListResourceRecordSetsRequest {
+            HostedZoneId: ResourceId;            
+            StartRecordName?: DNSName;            
+            StartRecordType?: RRType;            
+            StartRecordIdentifier?: ResourceRecordSetIdentifier;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListResourceRecordSetsResponse {
+            ResourceRecordSets: ResourceRecordSets;            
+            IsTruncated: PageTruncated;            
+            NextRecordName?: DNSName;            
+            NextRecordType?: RRType;            
+            NextRecordIdentifier?: ResourceRecordSetIdentifier;            
+            MaxItems: PageMaxItems;            
+        }
+        export interface ListReusableDelegationSetsRequest {
+            Marker?: PageMarker;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListReusableDelegationSetsResponse {
+            DelegationSets: DelegationSets;            
+            Marker: PageMarker;            
+            IsTruncated: PageTruncated;            
+            NextMarker?: PageMarker;            
+            MaxItems: PageMaxItems;            
+        }
+        export interface ListTagsForResourceRequest {
+            ResourceType: TagResourceType;            
+            ResourceId: TagResourceId;            
+        }
+        export interface ListTagsForResourceResponse {
+            ResourceTagSet: ResourceTagSet;            
+        }
+        export interface ListTagsForResourcesRequest {
+            ResourceType: TagResourceType;            
+            ResourceIds: TagResourceIdList;            
+        }
+        export interface ListTagsForResourcesResponse {
+            ResourceTagSets: ResourceTagSetList;            
+        }
+        export interface NoSuchChange {
+            message?: ErrorMessage;            
+        }
+        export interface NoSuchDelegationSet {
+            message?: ErrorMessage;            
+        }
+        export interface NoSuchGeoLocation {
+            message?: ErrorMessage;            
+        }
+        export interface NoSuchHealthCheck {
+            message?: ErrorMessage;            
+        }
+        export interface NoSuchHostedZone {
+            message?: ErrorMessage;            
+        }
+        export interface PriorRequestNotComplete {
+            message?: ErrorMessage;            
+        }
+        export interface PublicZoneVPCAssociation {
+            message?: ErrorMessage;            
+        }
+        export interface ResourceRecord {
+            Value: RData;            
+        }
+        export interface ResourceRecordSet {
+            Name: DNSName;            
+            Type: RRType;            
+            SetIdentifier?: ResourceRecordSetIdentifier;            
+            Weight?: ResourceRecordSetWeight;            
+            Region?: ResourceRecordSetRegion;            
+            GeoLocation?: GeoLocation;            
+            Failover?: ResourceRecordSetFailover;            
+            TTL?: TTL;            
+            ResourceRecords?: ResourceRecords;            
+            AliasTarget?: AliasTarget;            
+            HealthCheckId?: HealthCheckId;            
+        }
+        export interface ResourceTagSet {
+            ResourceType?: TagResourceType;            
+            ResourceId?: TagResourceId;            
+            Tags?: TagList;            
+        }
+        export interface StatusReport {
+            Status?: Status;            
+            CheckedTime?: TimeStamp;            
+        }
+        export interface Tag {
+            Key?: TagKey;            
+            Value?: TagValue;            
+        }
+        export interface ThrottlingException {
+            message?: ErrorMessage;            
+        }
+        export interface TooManyHealthChecks {
+            message?: ErrorMessage;            
+        }
+        export interface TooManyHostedZones {
+            message?: ErrorMessage;            
+        }
+        export interface UpdateHealthCheckRequest {
+            HealthCheckId: HealthCheckId;            
+            HealthCheckVersion?: HealthCheckVersion;            
+            IPAddress?: IPAddress;            
+            Port?: Port;            
+            ResourcePath?: ResourcePath;            
+            FullyQualifiedDomainName?: FullyQualifiedDomainName;            
+            SearchString?: SearchString;            
+            FailureThreshold?: FailureThreshold;            
+            Inverted?: Inverted;            
+            HealthThreshold?: HealthThreshold;            
+            ChildHealthChecks?: ChildHealthCheckList;            
+        }
+        export interface UpdateHealthCheckResponse {
+            HealthCheck: HealthCheck;            
+        }
+        export interface UpdateHostedZoneCommentRequest {
+            Id: ResourceId;            
+            Comment?: ResourceDescription;            
+        }
+        export interface UpdateHostedZoneCommentResponse {
+            HostedZone: HostedZone;            
+        }
+        export interface VPC {
+            VPCRegion?: VPCRegion;            
+            VPCId?: VPCId;            
+        }
+        export interface VPCAssociationNotFound {
+            message?: ErrorMessage;            
+        }
 
-    export interface Route53HealthCheckAlreadyExists {
-        message?: Route53ErrorMessage;
     }
-
-    export interface Route53HealthCheckConfig {
-        IPAddress?: Route53IPAddress;
-        Port?: Route53Port;
-        Type: Route53HealthCheckType;
-        ResourcePath?: Route53ResourcePath;
-        FullyQualifiedDomainName?: Route53FullyQualifiedDomainName;
-        SearchString?: Route53SearchString;
-        RequestInterval?: Route53RequestInterval;
-        FailureThreshold?: Route53FailureThreshold;
-        MeasureLatency?: Route53MeasureLatency;
-        Inverted?: Route53Inverted;
-        HealthThreshold?: Route53HealthThreshold;
-        ChildHealthChecks?: Route53ChildHealthCheckList;
-    }
-
-    export type Route53HealthCheckCount = number;
-    export type Route53HealthCheckId = string;
-    export interface Route53HealthCheckInUse {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53HealthCheckNonce = string;
-    export interface Route53HealthCheckObservation {
-        IPAddress?: Route53IPAddress;
-        StatusReport?: Route53StatusReport;
-    }
-
-    export type Route53HealthCheckObservations = Array<Route53HealthCheckObservation>;
-    export type Route53HealthCheckType = string;
-    export type Route53HealthCheckVersion = number;
-    export interface Route53HealthCheckVersionMismatch {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53HealthChecks = Array<Route53HealthCheck>;
-    export type Route53HealthThreshold = number;
-    export interface Route53HostedZone {
-        Id: Route53ResourceId;
-        Name: Route53DNSName;
-        CallerReference: Route53Nonce;
-        Config?: Route53HostedZoneConfig;
-        ResourceRecordSetCount?: Route53HostedZoneRRSetCount;
-    }
-
-    export interface Route53HostedZoneAlreadyExists {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53HostedZoneConfig {
-        Comment?: Route53ResourceDescription;
-        PrivateZone?: Route53IsPrivateZone;
-    }
-
-    export type Route53HostedZoneCount = number;
-    export interface Route53HostedZoneNotEmpty {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53HostedZoneNotFound {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53HostedZoneRRSetCount = number;
-    export type Route53HostedZones = Array<Route53HostedZone>;
-    export type Route53IPAddress = string; // pattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
-    export type Route53IPAddressCidr = string;
-    export interface Route53IncompatibleVersion {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53InvalidArgument {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53InvalidChangeBatch {
-        messages?: Route53ErrorMessages;
-    }
-
-    export interface Route53InvalidDomainName {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53InvalidInput {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53InvalidVPCId {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53Inverted = boolean;
-    export type Route53IsPrivateZone = boolean;
-    export interface Route53LastVPCAssociation {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53LimitsExceeded {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53ListGeoLocationsRequest {
-        StartContinentCode?: Route53GeoLocationContinentCode;
-        StartCountryCode?: Route53GeoLocationCountryCode;
-        StartSubdivisionCode?: Route53GeoLocationSubdivisionCode;
-        MaxItems?: Route53PageMaxItems;
-    }
-
-    export interface Route53ListGeoLocationsResponse {
-        GeoLocationDetailsList: Route53GeoLocationDetailsList;
-        IsTruncated: Route53PageTruncated;
-        NextContinentCode?: Route53GeoLocationContinentCode;
-        NextCountryCode?: Route53GeoLocationCountryCode;
-        NextSubdivisionCode?: Route53GeoLocationSubdivisionCode;
-        MaxItems: Route53PageMaxItems;
-    }
-
-    export interface Route53ListHealthChecksRequest {
-        Marker?: Route53PageMarker;
-        MaxItems?: Route53PageMaxItems;
-    }
-
-    export interface Route53ListHealthChecksResponse {
-        HealthChecks: Route53HealthChecks;
-        Marker: Route53PageMarker;
-        IsTruncated: Route53PageTruncated;
-        NextMarker?: Route53PageMarker;
-        MaxItems: Route53PageMaxItems;
-    }
-
-    export interface Route53ListHostedZonesByNameRequest {
-        DNSName?: Route53DNSName;
-        HostedZoneId?: Route53ResourceId;
-        MaxItems?: Route53PageMaxItems;
-    }
-
-    export interface Route53ListHostedZonesByNameResponse {
-        HostedZones: Route53HostedZones;
-        DNSName?: Route53DNSName;
-        HostedZoneId?: Route53ResourceId;
-        IsTruncated: Route53PageTruncated;
-        NextDNSName?: Route53DNSName;
-        NextHostedZoneId?: Route53ResourceId;
-        MaxItems: Route53PageMaxItems;
-    }
-
-    export interface Route53ListHostedZonesRequest {
-        Marker?: Route53PageMarker;
-        MaxItems?: Route53PageMaxItems;
-        DelegationSetId?: Route53ResourceId;
-    }
-
-    export interface Route53ListHostedZonesResponse {
-        HostedZones: Route53HostedZones;
-        Marker: Route53PageMarker;
-        IsTruncated: Route53PageTruncated;
-        NextMarker?: Route53PageMarker;
-        MaxItems: Route53PageMaxItems;
-    }
-
-    export interface Route53ListResourceRecordSetsRequest {
-        HostedZoneId: Route53ResourceId;
-        StartRecordName?: Route53DNSName;
-        StartRecordType?: Route53RRType;
-        StartRecordIdentifier?: Route53ResourceRecordSetIdentifier;
-        MaxItems?: Route53PageMaxItems;
-    }
-
-    export interface Route53ListResourceRecordSetsResponse {
-        ResourceRecordSets: Route53ResourceRecordSets;
-        IsTruncated: Route53PageTruncated;
-        NextRecordName?: Route53DNSName;
-        NextRecordType?: Route53RRType;
-        NextRecordIdentifier?: Route53ResourceRecordSetIdentifier;
-        MaxItems: Route53PageMaxItems;
-    }
-
-    export interface Route53ListReusableDelegationSetsRequest {
-        Marker?: Route53PageMarker;
-        MaxItems?: Route53PageMaxItems;
-    }
-
-    export interface Route53ListReusableDelegationSetsResponse {
-        DelegationSets: Route53DelegationSets;
-        Marker: Route53PageMarker;
-        IsTruncated: Route53PageTruncated;
-        NextMarker?: Route53PageMarker;
-        MaxItems: Route53PageMaxItems;
-    }
-
-    export interface Route53ListTagsForResourceRequest {
-        ResourceType: Route53TagResourceType;
-        ResourceId: Route53TagResourceId;
-    }
-
-    export interface Route53ListTagsForResourceResponse {
-        ResourceTagSet: Route53ResourceTagSet;
-    }
-
-    export interface Route53ListTagsForResourcesRequest {
-        ResourceType: Route53TagResourceType;
-        ResourceIds: Route53TagResourceIdList;
-    }
-
-    export interface Route53ListTagsForResourcesResponse {
-        ResourceTagSets: Route53ResourceTagSetList;
-    }
-
-    export type Route53MeasureLatency = boolean;
-    export interface Route53NoSuchChange {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53NoSuchDelegationSet {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53NoSuchGeoLocation {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53NoSuchHealthCheck {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53NoSuchHostedZone {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53Nonce = string;
-    export type Route53PageMarker = string;
-    export type Route53PageMaxItems = string;
-    export type Route53PageTruncated = boolean;
-    export type Route53Port = number;
-    export interface Route53PriorRequestNotComplete {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53PublicZoneVPCAssociation {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53RData = string;
-    export type Route53RRType = string;
-    export type Route53RequestInterval = number;
-    export type Route53ResourceDescription = string;
-    export type Route53ResourceId = string;
-    export type Route53ResourcePath = string;
-    export interface Route53ResourceRecord {
-        Value: Route53RData;
-    }
-
-    export interface Route53ResourceRecordSet {
-        Name: Route53DNSName;
-        Type: Route53RRType;
-        SetIdentifier?: Route53ResourceRecordSetIdentifier;
-        Weight?: Route53ResourceRecordSetWeight;
-        Region?: Route53ResourceRecordSetRegion;
-        GeoLocation?: Route53GeoLocation;
-        Failover?: Route53ResourceRecordSetFailover;
-        TTL?: Route53TTL;
-        ResourceRecords?: Route53ResourceRecords;
-        AliasTarget?: Route53AliasTarget;
-        HealthCheckId?: Route53HealthCheckId;
-    }
-
-    export type Route53ResourceRecordSetFailover = string;
-    export type Route53ResourceRecordSetIdentifier = string;
-    export type Route53ResourceRecordSetRegion = string;
-    export type Route53ResourceRecordSetWeight = number;
-    export type Route53ResourceRecordSets = Array<Route53ResourceRecordSet>;
-    export type Route53ResourceRecords = Array<Route53ResourceRecord>;
-    export interface Route53ResourceTagSet {
-        ResourceType?: Route53TagResourceType;
-        ResourceId?: Route53TagResourceId;
-        Tags?: Route53TagList;
-    }
-
-    export type Route53ResourceTagSetList = Array<Route53ResourceTagSet>;
-    export type Route53ResourceURI = string;
-    export type Route53SearchString = string;
-    export type Route53Status = string;
-    export interface Route53StatusReport {
-        Status?: Route53Status;
-        CheckedTime?: Route53TimeStamp;
-    }
-
-    export type Route53TTL = number;
-    export interface Route53Tag {
-        Key?: Route53TagKey;
-        Value?: Route53TagValue;
-    }
-
-    export type Route53TagKey = string;
-    export type Route53TagKeyList = Array<Route53TagKey>; // max: 10
-    export type Route53TagList = Array<Route53Tag>; // max: 10
-    export type Route53TagResourceId = string;
-    export type Route53TagResourceIdList = Array<Route53TagResourceId>; // max: 10
-    export type Route53TagResourceType = string;
-    export type Route53TagValue = string;
-    export interface Route53ThrottlingException {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53TimeStamp = number;
-    export interface Route53TooManyHealthChecks {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53TooManyHostedZones {
-        message?: Route53ErrorMessage;
-    }
-
-    export interface Route53UpdateHealthCheckRequest {
-        HealthCheckId: Route53HealthCheckId;
-        HealthCheckVersion?: Route53HealthCheckVersion;
-        IPAddress?: Route53IPAddress;
-        Port?: Route53Port;
-        ResourcePath?: Route53ResourcePath;
-        FullyQualifiedDomainName?: Route53FullyQualifiedDomainName;
-        SearchString?: Route53SearchString;
-        FailureThreshold?: Route53FailureThreshold;
-        Inverted?: Route53Inverted;
-        HealthThreshold?: Route53HealthThreshold;
-        ChildHealthChecks?: Route53ChildHealthCheckList;
-    }
-
-    export interface Route53UpdateHealthCheckResponse {
-        HealthCheck: Route53HealthCheck;
-    }
-
-    export interface Route53UpdateHostedZoneCommentRequest {
-        Id: Route53ResourceId;
-        Comment?: Route53ResourceDescription;
-    }
-
-    export interface Route53UpdateHostedZoneCommentResponse {
-        HostedZone: Route53HostedZone;
-    }
-
-    export interface Route53VPC {
-        VPCRegion?: Route53VPCRegion;
-        VPCId?: Route53VPCId;
-    }
-
-    export interface Route53VPCAssociationNotFound {
-        message?: Route53ErrorMessage;
-    }
-
-    export type Route53VPCId = string;
-    export type Route53VPCRegion = string;
-    export type Route53VPCs = Array<Route53VPC>;
 }

--- a/output/aws-route53domains.d.ts
+++ b/output/aws-route53domains.d.ts
@@ -6,338 +6,294 @@ declare module "aws-sdk" {
 
     export class Route53Domains extends Service {
       constructor(options?: any);
-      checkDomainAvailability(params: Route53DomainsCheckDomainAvailabilityRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|any, data: Route53DomainsCheckDomainAvailabilityResponse|any) => void): Request;
-      deleteTagsForDomain(params: Route53DomainsDeleteTagsForDomainRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsDeleteTagsForDomainResponse|any) => void): Request;
-      disableDomainAutoRenew(params: Route53DomainsDisableDomainAutoRenewRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|any, data: Route53DomainsDisableDomainAutoRenewResponse|any) => void): Request;
-      disableDomainTransferLock(params: Route53DomainsDisableDomainTransferLockRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsDisableDomainTransferLockResponse|any) => void): Request;
-      enableDomainAutoRenew(params: Route53DomainsEnableDomainAutoRenewRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|any, data: Route53DomainsEnableDomainAutoRenewResponse|any) => void): Request;
-      enableDomainTransferLock(params: Route53DomainsEnableDomainTransferLockRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsEnableDomainTransferLockResponse|any) => void): Request;
-      getDomainDetail(params: Route53DomainsGetDomainDetailRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|any, data: Route53DomainsGetDomainDetailResponse|any) => void): Request;
-      getOperationDetail(params: Route53DomainsGetOperationDetailRequest, callback?: (err: Route53DomainsInvalidInput|any, data: Route53DomainsGetOperationDetailResponse|any) => void): Request;
-      listDomains(params: Route53DomainsListDomainsRequest, callback?: (err: Route53DomainsInvalidInput|any, data: Route53DomainsListDomainsResponse|any) => void): Request;
-      listOperations(params: Route53DomainsListOperationsRequest, callback?: (err: Route53DomainsInvalidInput|any, data: Route53DomainsListOperationsResponse|any) => void): Request;
-      listTagsForDomain(params: Route53DomainsListTagsForDomainRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsListTagsForDomainResponse|any) => void): Request;
-      registerDomain(params: Route53DomainsRegisterDomainRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsDomainLimitExceeded|Route53DomainsOperationLimitExceeded|any, data: Route53DomainsRegisterDomainResponse|any) => void): Request;
-      retrieveDomainAuthCode(params: Route53DomainsRetrieveDomainAuthCodeRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|any, data: Route53DomainsRetrieveDomainAuthCodeResponse|any) => void): Request;
-      transferDomain(params: Route53DomainsTransferDomainRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsUnsupportedTLD|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsDomainLimitExceeded|Route53DomainsOperationLimitExceeded|any, data: Route53DomainsTransferDomainResponse|any) => void): Request;
-      updateDomainContact(params: Route53DomainsUpdateDomainContactRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsUpdateDomainContactResponse|any) => void): Request;
-      updateDomainContactPrivacy(params: Route53DomainsUpdateDomainContactPrivacyRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsUpdateDomainContactPrivacyResponse|any) => void): Request;
-      updateDomainNameservers(params: Route53DomainsUpdateDomainNameserversRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsDuplicateRequest|Route53DomainsTLDRulesViolation|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsUpdateDomainNameserversResponse|any) => void): Request;
-      updateTagsForDomain(params: Route53DomainsUpdateTagsForDomainRequest, callback?: (err: Route53DomainsInvalidInput|Route53DomainsOperationLimitExceeded|Route53DomainsUnsupportedTLD|any, data: Route53DomainsUpdateTagsForDomainResponse|any) => void): Request;
+      checkDomainAvailability(params: Route53Domains.CheckDomainAvailabilityRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|any, data: Route53Domains.CheckDomainAvailabilityResponse|any) => void): Request;
+      deleteTagsForDomain(params: Route53Domains.DeleteTagsForDomainRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.DeleteTagsForDomainResponse|any) => void): Request;
+      disableDomainAutoRenew(params: Route53Domains.DisableDomainAutoRenewRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|any, data: Route53Domains.DisableDomainAutoRenewResponse|any) => void): Request;
+      disableDomainTransferLock(params: Route53Domains.DisableDomainTransferLockRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.DisableDomainTransferLockResponse|any) => void): Request;
+      enableDomainAutoRenew(params: Route53Domains.EnableDomainAutoRenewRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|any, data: Route53Domains.EnableDomainAutoRenewResponse|any) => void): Request;
+      enableDomainTransferLock(params: Route53Domains.EnableDomainTransferLockRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.EnableDomainTransferLockResponse|any) => void): Request;
+      getDomainDetail(params: Route53Domains.GetDomainDetailRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|any, data: Route53Domains.GetDomainDetailResponse|any) => void): Request;
+      getOperationDetail(params: Route53Domains.GetOperationDetailRequest, callback?: (err: Route53Domains.InvalidInput|any, data: Route53Domains.GetOperationDetailResponse|any) => void): Request;
+      listDomains(params: Route53Domains.ListDomainsRequest, callback?: (err: Route53Domains.InvalidInput|any, data: Route53Domains.ListDomainsResponse|any) => void): Request;
+      listOperations(params: Route53Domains.ListOperationsRequest, callback?: (err: Route53Domains.InvalidInput|any, data: Route53Domains.ListOperationsResponse|any) => void): Request;
+      listTagsForDomain(params: Route53Domains.ListTagsForDomainRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.ListTagsForDomainResponse|any) => void): Request;
+      registerDomain(params: Route53Domains.RegisterDomainRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.DomainLimitExceeded|Route53Domains.OperationLimitExceeded|any, data: Route53Domains.RegisterDomainResponse|any) => void): Request;
+      retrieveDomainAuthCode(params: Route53Domains.RetrieveDomainAuthCodeRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|any, data: Route53Domains.RetrieveDomainAuthCodeResponse|any) => void): Request;
+      transferDomain(params: Route53Domains.TransferDomainRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.UnsupportedTLD|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.DomainLimitExceeded|Route53Domains.OperationLimitExceeded|any, data: Route53Domains.TransferDomainResponse|any) => void): Request;
+      updateDomainContact(params: Route53Domains.UpdateDomainContactRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.UpdateDomainContactResponse|any) => void): Request;
+      updateDomainContactPrivacy(params: Route53Domains.UpdateDomainContactPrivacyRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.UpdateDomainContactPrivacyResponse|any) => void): Request;
+      updateDomainNameservers(params: Route53Domains.UpdateDomainNameserversRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.DuplicateRequest|Route53Domains.TLDRulesViolation|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.UpdateDomainNameserversResponse|any) => void): Request;
+      updateTagsForDomain(params: Route53Domains.UpdateTagsForDomainRequest, callback?: (err: Route53Domains.InvalidInput|Route53Domains.OperationLimitExceeded|Route53Domains.UnsupportedTLD|any, data: Route53Domains.UpdateTagsForDomainResponse|any) => void): Request;
     }
+    
+    export module Route53Domains {
+        export type AddressLine = string;    // max: 255
+        export type Boolean = boolean;
+        export type City = string;    // max: 255
+        export type ContactName = string;    // max: 255
+        export type ContactNumber = string;    // max: 30
+        export type ContactType = string;
+        export type CountryCode = string;
+        export type DNSSec = string;
+        export type DomainAuthCode = string;    // max: 1024
+        export type DomainAvailability = string;
+        export type DomainName = string;    // pattern: &quot;[a-zA-Z0-9_\-.]*&quot;, max: 255
+        export type DomainStatus = string;
+        export type DomainStatusList = DomainStatus[];
+        export type DomainSummaryList = DomainSummary[];
+        export type DurationInYears = number;    // max: 10, min: 1
+        export type Email = string;    // max: 254
+        export type ErrorMessage = string;
+        export type ExtraParamList = ExtraParam[];
+        export type ExtraParamName = string;
+        export type ExtraParamValue = string;    // max: 2048
+        export type FIAuthKey = string;
+        export type GlueIp = string;    // max: 45
+        export type GlueIpList = GlueIp[];
+        export type HostName = string;    // pattern: &quot;[a-zA-Z0-9_\-.]*&quot;, max: 255
+        export type LangCode = string;    // max: 3
+        export type NameserverList = Nameserver[];
+        export type OperationId = string;    // max: 255
+        export type OperationStatus = string;
+        export type OperationSummaryList = OperationSummary[];
+        export type OperationType = string;
+        export type PageMarker = string;    // max: 4096
+        export type PageMaxItems = number;    // max: 100
+        export type RegistrarName = string;
+        export type RegistrarUrl = string;
+        export type RegistrarWhoIsServer = string;
+        export type RegistryDomainId = string;
+        export type Reseller = string;
+        export type State = string;    // max: 255
+        export type TagKey = string;
+        export type TagKeyList = TagKey[];
+        export type TagList = Tag[];
+        export type TagValue = string;
+        export type Timestamp = number;
+        export type ZipCode = string;    // max: 255
 
-    export type Route53DomainsAddressLine = string;
-    export type Route53DomainsBoolean = boolean;
-    export interface Route53DomainsCheckDomainAvailabilityRequest {
-        DomainName: Route53DomainsDomainName;
-        IdnLangCode?: Route53DomainsLangCode;
+        export interface CheckDomainAvailabilityRequest {
+            DomainName: DomainName;            
+            IdnLangCode?: LangCode;            
+        }
+        export interface CheckDomainAvailabilityResponse {
+            Availability: DomainAvailability;            
+        }
+        export interface ContactDetail {
+            FirstName?: ContactName;            
+            LastName?: ContactName;            
+            ContactType?: ContactType;            
+            OrganizationName?: ContactName;            
+            AddressLine1?: AddressLine;            
+            AddressLine2?: AddressLine;            
+            City?: City;            
+            State?: State;            
+            CountryCode?: CountryCode;            
+            ZipCode?: ZipCode;            
+            PhoneNumber?: ContactNumber;            
+            Email?: Email;            
+            Fax?: ContactNumber;            
+            ExtraParams?: ExtraParamList;            
+        }
+        export interface DeleteTagsForDomainRequest {
+            DomainName: DomainName;            
+            TagsToDelete: TagKeyList;            
+        }
+        export interface DeleteTagsForDomainResponse {
+        }
+        export interface DisableDomainAutoRenewRequest {
+            DomainName: DomainName;            
+        }
+        export interface DisableDomainAutoRenewResponse {
+        }
+        export interface DisableDomainTransferLockRequest {
+            DomainName: DomainName;            
+        }
+        export interface DisableDomainTransferLockResponse {
+            OperationId: OperationId;            
+        }
+        export interface DomainLimitExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface DomainSummary {
+            DomainName: DomainName;            
+            AutoRenew?: Boolean;            
+            TransferLock?: Boolean;            
+            Expiry?: Timestamp;            
+        }
+        export interface DuplicateRequest {
+            message?: ErrorMessage;            
+        }
+        export interface EnableDomainAutoRenewRequest {
+            DomainName: DomainName;            
+        }
+        export interface EnableDomainAutoRenewResponse {
+        }
+        export interface EnableDomainTransferLockRequest {
+            DomainName: DomainName;            
+        }
+        export interface EnableDomainTransferLockResponse {
+            OperationId: OperationId;            
+        }
+        export interface ExtraParam {
+            Name: ExtraParamName;            
+            Value: ExtraParamValue;            
+        }
+        export interface GetDomainDetailRequest {
+            DomainName: DomainName;            
+        }
+        export interface GetDomainDetailResponse {
+            DomainName: DomainName;            
+            Nameservers: NameserverList;            
+            AutoRenew?: Boolean;            
+            AdminContact: ContactDetail;            
+            RegistrantContact: ContactDetail;            
+            TechContact: ContactDetail;            
+            AdminPrivacy?: Boolean;            
+            RegistrantPrivacy?: Boolean;            
+            TechPrivacy?: Boolean;            
+            RegistrarName?: RegistrarName;            
+            WhoIsServer?: RegistrarWhoIsServer;            
+            RegistrarUrl?: RegistrarUrl;            
+            AbuseContactEmail?: Email;            
+            AbuseContactPhone?: ContactNumber;            
+            RegistryDomainId?: RegistryDomainId;            
+            CreationDate?: Timestamp;            
+            UpdatedDate?: Timestamp;            
+            ExpirationDate?: Timestamp;            
+            Reseller?: Reseller;            
+            DnsSec?: DNSSec;            
+            StatusList?: DomainStatusList;            
+        }
+        export interface GetOperationDetailRequest {
+            OperationId: OperationId;            
+        }
+        export interface GetOperationDetailResponse {
+            OperationId?: OperationId;            
+            Status?: OperationStatus;            
+            Message?: ErrorMessage;            
+            DomainName?: DomainName;            
+            Type?: OperationType;            
+            SubmittedDate?: Timestamp;            
+        }
+        export interface InvalidInput {
+            message?: ErrorMessage;            
+        }
+        export interface ListDomainsRequest {
+            Marker?: PageMarker;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListDomainsResponse {
+            Domains: DomainSummaryList;            
+            NextPageMarker?: PageMarker;            
+        }
+        export interface ListOperationsRequest {
+            Marker?: PageMarker;            
+            MaxItems?: PageMaxItems;            
+        }
+        export interface ListOperationsResponse {
+            Operations: OperationSummaryList;            
+            NextPageMarker?: PageMarker;            
+        }
+        export interface ListTagsForDomainRequest {
+            DomainName: DomainName;            
+        }
+        export interface ListTagsForDomainResponse {
+            TagList: TagList;            
+        }
+        export interface Nameserver {
+            Name: HostName;            
+            GlueIps?: GlueIpList;            
+        }
+        export interface OperationLimitExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface OperationSummary {
+            OperationId: OperationId;            
+            Status: OperationStatus;            
+            Type: OperationType;            
+            SubmittedDate: Timestamp;            
+        }
+        export interface RegisterDomainRequest {
+            DomainName: DomainName;            
+            IdnLangCode?: LangCode;            
+            DurationInYears: DurationInYears;            
+            AutoRenew?: Boolean;            
+            AdminContact: ContactDetail;            
+            RegistrantContact: ContactDetail;            
+            TechContact: ContactDetail;            
+            PrivacyProtectAdminContact?: Boolean;            
+            PrivacyProtectRegistrantContact?: Boolean;            
+            PrivacyProtectTechContact?: Boolean;            
+        }
+        export interface RegisterDomainResponse {
+            OperationId: OperationId;            
+        }
+        export interface RetrieveDomainAuthCodeRequest {
+            DomainName: DomainName;            
+        }
+        export interface RetrieveDomainAuthCodeResponse {
+            AuthCode: DomainAuthCode;            
+        }
+        export interface TLDRulesViolation {
+            message?: ErrorMessage;            
+        }
+        export interface Tag {
+            Key?: TagKey;            
+            Value?: TagValue;            
+        }
+        export interface TransferDomainRequest {
+            DomainName: DomainName;            
+            IdnLangCode?: LangCode;            
+            DurationInYears: DurationInYears;            
+            Nameservers?: NameserverList;            
+            AuthCode?: DomainAuthCode;            
+            AutoRenew?: Boolean;            
+            AdminContact: ContactDetail;            
+            RegistrantContact: ContactDetail;            
+            TechContact: ContactDetail;            
+            PrivacyProtectAdminContact?: Boolean;            
+            PrivacyProtectRegistrantContact?: Boolean;            
+            PrivacyProtectTechContact?: Boolean;            
+        }
+        export interface TransferDomainResponse {
+            OperationId: OperationId;            
+        }
+        export interface UnsupportedTLD {
+            message?: ErrorMessage;            
+        }
+        export interface UpdateDomainContactPrivacyRequest {
+            DomainName: DomainName;            
+            AdminPrivacy?: Boolean;            
+            RegistrantPrivacy?: Boolean;            
+            TechPrivacy?: Boolean;            
+        }
+        export interface UpdateDomainContactPrivacyResponse {
+            OperationId: OperationId;            
+        }
+        export interface UpdateDomainContactRequest {
+            DomainName: DomainName;            
+            AdminContact?: ContactDetail;            
+            RegistrantContact?: ContactDetail;            
+            TechContact?: ContactDetail;            
+        }
+        export interface UpdateDomainContactResponse {
+            OperationId: OperationId;            
+        }
+        export interface UpdateDomainNameserversRequest {
+            DomainName: DomainName;            
+            FIAuthKey?: FIAuthKey;            
+            Nameservers: NameserverList;            
+        }
+        export interface UpdateDomainNameserversResponse {
+            OperationId: OperationId;            
+        }
+        export interface UpdateTagsForDomainRequest {
+            DomainName: DomainName;            
+            TagsToUpdate?: TagList;            
+        }
+        export interface UpdateTagsForDomainResponse {
+        }
+
     }
-
-    export interface Route53DomainsCheckDomainAvailabilityResponse {
-        Availability: Route53DomainsDomainAvailability;
-    }
-
-    export type Route53DomainsCity = string;
-    export interface Route53DomainsContactDetail {
-        FirstName?: Route53DomainsContactName;
-        LastName?: Route53DomainsContactName;
-        ContactType?: Route53DomainsContactType;
-        OrganizationName?: Route53DomainsContactName;
-        AddressLine1?: Route53DomainsAddressLine;
-        AddressLine2?: Route53DomainsAddressLine;
-        City?: Route53DomainsCity;
-        State?: Route53DomainsState;
-        CountryCode?: Route53DomainsCountryCode;
-        ZipCode?: Route53DomainsZipCode;
-        PhoneNumber?: Route53DomainsContactNumber;
-        Email?: Route53DomainsEmail;
-        Fax?: Route53DomainsContactNumber;
-        ExtraParams?: Route53DomainsExtraParamList;
-    }
-
-    export type Route53DomainsContactName = string;
-    export type Route53DomainsContactNumber = string;
-    export type Route53DomainsContactType = string;
-    export type Route53DomainsCountryCode = string;
-    export type Route53DomainsDNSSec = string;
-    export interface Route53DomainsDeleteTagsForDomainRequest {
-        DomainName: Route53DomainsDomainName;
-        TagsToDelete: Route53DomainsTagKeyList;
-    }
-
-    export interface Route53DomainsDeleteTagsForDomainResponse {
-    }
-
-    export interface Route53DomainsDisableDomainAutoRenewRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsDisableDomainAutoRenewResponse {
-    }
-
-    export interface Route53DomainsDisableDomainTransferLockRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsDisableDomainTransferLockResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export type Route53DomainsDomainAuthCode = string;
-    export type Route53DomainsDomainAvailability = string;
-    export interface Route53DomainsDomainLimitExceeded {
-        message?: Route53DomainsErrorMessage;
-    }
-
-    export type Route53DomainsDomainName = string; // pattern: "[a-zA-Z0-9_\-.]*"
-    export type Route53DomainsDomainStatus = string;
-    export type Route53DomainsDomainStatusList = Array<Route53DomainsDomainStatus>;
-    export interface Route53DomainsDomainSummary {
-        DomainName: Route53DomainsDomainName;
-        AutoRenew?: Route53DomainsBoolean;
-        TransferLock?: Route53DomainsBoolean;
-        Expiry?: Route53DomainsTimestamp;
-    }
-
-    export type Route53DomainsDomainSummaryList = Array<Route53DomainsDomainSummary>;
-    export interface Route53DomainsDuplicateRequest {
-        message?: Route53DomainsErrorMessage;
-    }
-
-    export type Route53DomainsDurationInYears = number;
-    export type Route53DomainsEmail = string;
-    export interface Route53DomainsEnableDomainAutoRenewRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsEnableDomainAutoRenewResponse {
-    }
-
-    export interface Route53DomainsEnableDomainTransferLockRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsEnableDomainTransferLockResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export type Route53DomainsErrorMessage = string;
-    export interface Route53DomainsExtraParam {
-        Name: Route53DomainsExtraParamName;
-        Value: Route53DomainsExtraParamValue;
-    }
-
-    export type Route53DomainsExtraParamList = Array<Route53DomainsExtraParam>;
-    export type Route53DomainsExtraParamName = string;
-    export type Route53DomainsExtraParamValue = string;
-    export type Route53DomainsFIAuthKey = string;
-    export interface Route53DomainsGetDomainDetailRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsGetDomainDetailResponse {
-        DomainName: Route53DomainsDomainName;
-        Nameservers: Route53DomainsNameserverList;
-        AutoRenew?: Route53DomainsBoolean;
-        AdminContact: Route53DomainsContactDetail;
-        RegistrantContact: Route53DomainsContactDetail;
-        TechContact: Route53DomainsContactDetail;
-        AdminPrivacy?: Route53DomainsBoolean;
-        RegistrantPrivacy?: Route53DomainsBoolean;
-        TechPrivacy?: Route53DomainsBoolean;
-        RegistrarName?: Route53DomainsRegistrarName;
-        WhoIsServer?: Route53DomainsRegistrarWhoIsServer;
-        RegistrarUrl?: Route53DomainsRegistrarUrl;
-        AbuseContactEmail?: Route53DomainsEmail;
-        AbuseContactPhone?: Route53DomainsContactNumber;
-        RegistryDomainId?: Route53DomainsRegistryDomainId;
-        CreationDate?: Route53DomainsTimestamp;
-        UpdatedDate?: Route53DomainsTimestamp;
-        ExpirationDate?: Route53DomainsTimestamp;
-        Reseller?: Route53DomainsReseller;
-        DnsSec?: Route53DomainsDNSSec;
-        StatusList?: Route53DomainsDomainStatusList;
-    }
-
-    export interface Route53DomainsGetOperationDetailRequest {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export interface Route53DomainsGetOperationDetailResponse {
-        OperationId?: Route53DomainsOperationId;
-        Status?: Route53DomainsOperationStatus;
-        Message?: Route53DomainsErrorMessage;
-        DomainName?: Route53DomainsDomainName;
-        Type?: Route53DomainsOperationType;
-        SubmittedDate?: Route53DomainsTimestamp;
-    }
-
-    export type Route53DomainsGlueIp = string;
-    export type Route53DomainsGlueIpList = Array<Route53DomainsGlueIp>;
-    export type Route53DomainsHostName = string; // pattern: "[a-zA-Z0-9_\-.]*"
-    export interface Route53DomainsInvalidInput {
-        message?: Route53DomainsErrorMessage;
-    }
-
-    export type Route53DomainsLangCode = string;
-    export interface Route53DomainsListDomainsRequest {
-        Marker?: Route53DomainsPageMarker;
-        MaxItems?: Route53DomainsPageMaxItems;
-    }
-
-    export interface Route53DomainsListDomainsResponse {
-        Domains: Route53DomainsDomainSummaryList;
-        NextPageMarker?: Route53DomainsPageMarker;
-    }
-
-    export interface Route53DomainsListOperationsRequest {
-        Marker?: Route53DomainsPageMarker;
-        MaxItems?: Route53DomainsPageMaxItems;
-    }
-
-    export interface Route53DomainsListOperationsResponse {
-        Operations: Route53DomainsOperationSummaryList;
-        NextPageMarker?: Route53DomainsPageMarker;
-    }
-
-    export interface Route53DomainsListTagsForDomainRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsListTagsForDomainResponse {
-        TagList: Route53DomainsTagList;
-    }
-
-    export interface Route53DomainsNameserver {
-        Name: Route53DomainsHostName;
-        GlueIps?: Route53DomainsGlueIpList;
-    }
-
-    export type Route53DomainsNameserverList = Array<Route53DomainsNameserver>;
-    export type Route53DomainsOperationId = string;
-    export interface Route53DomainsOperationLimitExceeded {
-        message?: Route53DomainsErrorMessage;
-    }
-
-    export type Route53DomainsOperationStatus = string;
-    export interface Route53DomainsOperationSummary {
-        OperationId: Route53DomainsOperationId;
-        Status: Route53DomainsOperationStatus;
-        Type: Route53DomainsOperationType;
-        SubmittedDate: Route53DomainsTimestamp;
-    }
-
-    export type Route53DomainsOperationSummaryList = Array<Route53DomainsOperationSummary>;
-    export type Route53DomainsOperationType = string;
-    export type Route53DomainsPageMarker = string;
-    export type Route53DomainsPageMaxItems = number;
-    export interface Route53DomainsRegisterDomainRequest {
-        DomainName: Route53DomainsDomainName;
-        IdnLangCode?: Route53DomainsLangCode;
-        DurationInYears: Route53DomainsDurationInYears;
-        AutoRenew?: Route53DomainsBoolean;
-        AdminContact: Route53DomainsContactDetail;
-        RegistrantContact: Route53DomainsContactDetail;
-        TechContact: Route53DomainsContactDetail;
-        PrivacyProtectAdminContact?: Route53DomainsBoolean;
-        PrivacyProtectRegistrantContact?: Route53DomainsBoolean;
-        PrivacyProtectTechContact?: Route53DomainsBoolean;
-    }
-
-    export interface Route53DomainsRegisterDomainResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export type Route53DomainsRegistrarName = string;
-    export type Route53DomainsRegistrarUrl = string;
-    export type Route53DomainsRegistrarWhoIsServer = string;
-    export type Route53DomainsRegistryDomainId = string;
-    export type Route53DomainsReseller = string;
-    export interface Route53DomainsRetrieveDomainAuthCodeRequest {
-        DomainName: Route53DomainsDomainName;
-    }
-
-    export interface Route53DomainsRetrieveDomainAuthCodeResponse {
-        AuthCode: Route53DomainsDomainAuthCode;
-    }
-
-    export type Route53DomainsState = string;
-    export interface Route53DomainsTLDRulesViolation {
-        message?: Route53DomainsErrorMessage;
-    }
-
-    export interface Route53DomainsTag {
-        Key?: Route53DomainsTagKey;
-        Value?: Route53DomainsTagValue;
-    }
-
-    export type Route53DomainsTagKey = string;
-    export type Route53DomainsTagKeyList = Array<Route53DomainsTagKey>;
-    export type Route53DomainsTagList = Array<Route53DomainsTag>;
-    export type Route53DomainsTagValue = string;
-    export type Route53DomainsTimestamp = number;
-    export interface Route53DomainsTransferDomainRequest {
-        DomainName: Route53DomainsDomainName;
-        IdnLangCode?: Route53DomainsLangCode;
-        DurationInYears: Route53DomainsDurationInYears;
-        Nameservers?: Route53DomainsNameserverList;
-        AuthCode?: Route53DomainsDomainAuthCode;
-        AutoRenew?: Route53DomainsBoolean;
-        AdminContact: Route53DomainsContactDetail;
-        RegistrantContact: Route53DomainsContactDetail;
-        TechContact: Route53DomainsContactDetail;
-        PrivacyProtectAdminContact?: Route53DomainsBoolean;
-        PrivacyProtectRegistrantContact?: Route53DomainsBoolean;
-        PrivacyProtectTechContact?: Route53DomainsBoolean;
-    }
-
-    export interface Route53DomainsTransferDomainResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export interface Route53DomainsUnsupportedTLD {
-        message?: Route53DomainsErrorMessage;
-    }
-
-    export interface Route53DomainsUpdateDomainContactPrivacyRequest {
-        DomainName: Route53DomainsDomainName;
-        AdminPrivacy?: Route53DomainsBoolean;
-        RegistrantPrivacy?: Route53DomainsBoolean;
-        TechPrivacy?: Route53DomainsBoolean;
-    }
-
-    export interface Route53DomainsUpdateDomainContactPrivacyResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export interface Route53DomainsUpdateDomainContactRequest {
-        DomainName: Route53DomainsDomainName;
-        AdminContact?: Route53DomainsContactDetail;
-        RegistrantContact?: Route53DomainsContactDetail;
-        TechContact?: Route53DomainsContactDetail;
-    }
-
-    export interface Route53DomainsUpdateDomainContactResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export interface Route53DomainsUpdateDomainNameserversRequest {
-        DomainName: Route53DomainsDomainName;
-        FIAuthKey?: Route53DomainsFIAuthKey;
-        Nameservers: Route53DomainsNameserverList;
-    }
-
-    export interface Route53DomainsUpdateDomainNameserversResponse {
-        OperationId: Route53DomainsOperationId;
-    }
-
-    export interface Route53DomainsUpdateTagsForDomainRequest {
-        DomainName: Route53DomainsDomainName;
-        TagsToUpdate?: Route53DomainsTagList;
-    }
-
-    export interface Route53DomainsUpdateTagsForDomainResponse {
-    }
-
-    export type Route53DomainsZipCode = string;
 }

--- a/output/aws-s3.d.ts
+++ b/output/aws-s3.d.ts
@@ -6,1310 +6,1161 @@ declare module "aws-sdk" {
 
     export class S3 extends Service {
       constructor(options?: any);
-      abortMultipartUpload(params: S3AbortMultipartUploadRequest, callback?: (err: S3NoSuchUpload|any, data: S3AbortMultipartUploadOutput|any) => void): Request;
-      completeMultipartUpload(params: S3CompleteMultipartUploadRequest, callback?: (err: any, data: S3CompleteMultipartUploadOutput|any) => void): Request;
-      copyObject(params: S3CopyObjectRequest, callback?: (err: S3ObjectNotInActiveTierError|any, data: S3CopyObjectOutput|any) => void): Request;
-      createBucket(params: S3CreateBucketRequest, callback?: (err: S3BucketAlreadyExists|any, data: S3CreateBucketOutput|any) => void): Request;
-      createMultipartUpload(params: S3CreateMultipartUploadRequest, callback?: (err: any, data: S3CreateMultipartUploadOutput|any) => void): Request;
-      deleteBucket(params: S3DeleteBucketRequest, callback?: (err: any, data: any) => void): Request;
-      deleteBucketCors(params: S3DeleteBucketCorsRequest, callback?: (err: any, data: any) => void): Request;
-      deleteBucketLifecycle(params: S3DeleteBucketLifecycleRequest, callback?: (err: any, data: any) => void): Request;
-      deleteBucketPolicy(params: S3DeleteBucketPolicyRequest, callback?: (err: any, data: any) => void): Request;
-      deleteBucketReplication(params: S3DeleteBucketReplicationRequest, callback?: (err: any, data: any) => void): Request;
-      deleteBucketTagging(params: S3DeleteBucketTaggingRequest, callback?: (err: any, data: any) => void): Request;
-      deleteBucketWebsite(params: S3DeleteBucketWebsiteRequest, callback?: (err: any, data: any) => void): Request;
-      deleteObject(params: S3DeleteObjectRequest, callback?: (err: any, data: S3DeleteObjectOutput|any) => void): Request;
-      deleteObjects(params: S3DeleteObjectsRequest, callback?: (err: any, data: S3DeleteObjectsOutput|any) => void): Request;
-      getBucketAcl(params: S3GetBucketAclRequest, callback?: (err: any, data: S3GetBucketAclOutput|any) => void): Request;
-      getBucketCors(params: S3GetBucketCorsRequest, callback?: (err: any, data: S3GetBucketCorsOutput|any) => void): Request;
-      getBucketLifecycle(params: S3GetBucketLifecycleRequest, callback?: (err: any, data: S3GetBucketLifecycleOutput|any) => void): Request;
-      getBucketLifecycleConfiguration(params: S3GetBucketLifecycleConfigurationRequest, callback?: (err: any, data: S3GetBucketLifecycleConfigurationOutput|any) => void): Request;
-      getBucketLocation(params: S3GetBucketLocationRequest, callback?: (err: any, data: S3GetBucketLocationOutput|any) => void): Request;
-      getBucketLogging(params: S3GetBucketLoggingRequest, callback?: (err: any, data: S3GetBucketLoggingOutput|any) => void): Request;
-      getBucketNotification(params: S3GetBucketNotificationConfigurationRequest, callback?: (err: any, data: S3NotificationConfigurationDeprecated|any) => void): Request;
-      getBucketNotificationConfiguration(params: S3GetBucketNotificationConfigurationRequest, callback?: (err: any, data: S3NotificationConfiguration|any) => void): Request;
-      getBucketPolicy(params: S3GetBucketPolicyRequest, callback?: (err: any, data: S3GetBucketPolicyOutput|any) => void): Request;
-      getBucketReplication(params: S3GetBucketReplicationRequest, callback?: (err: any, data: S3GetBucketReplicationOutput|any) => void): Request;
-      getBucketRequestPayment(params: S3GetBucketRequestPaymentRequest, callback?: (err: any, data: S3GetBucketRequestPaymentOutput|any) => void): Request;
-      getBucketTagging(params: S3GetBucketTaggingRequest, callback?: (err: any, data: S3GetBucketTaggingOutput|any) => void): Request;
-      getBucketVersioning(params: S3GetBucketVersioningRequest, callback?: (err: any, data: S3GetBucketVersioningOutput|any) => void): Request;
-      getBucketWebsite(params: S3GetBucketWebsiteRequest, callback?: (err: any, data: S3GetBucketWebsiteOutput|any) => void): Request;
-      getObject(params: S3GetObjectRequest, callback?: (err: S3NoSuchKey|any, data: S3GetObjectOutput|any) => void): Request;
-      getObjectAcl(params: S3GetObjectAclRequest, callback?: (err: S3NoSuchKey|any, data: S3GetObjectAclOutput|any) => void): Request;
-      getObjectTorrent(params: S3GetObjectTorrentRequest, callback?: (err: any, data: S3GetObjectTorrentOutput|any) => void): Request;
-      headBucket(params: S3HeadBucketRequest, callback?: (err: S3NoSuchBucket|any, data: any) => void): Request;
-      headObject(params: S3HeadObjectRequest, callback?: (err: S3NoSuchKey|any, data: S3HeadObjectOutput|any) => void): Request;
-      listBuckets(callback?: (err: any, data: S3ListBucketsOutput|any) => void): Request;
-      listMultipartUploads(params: S3ListMultipartUploadsRequest, callback?: (err: any, data: S3ListMultipartUploadsOutput|any) => void): Request;
-      listObjectVersions(params: S3ListObjectVersionsRequest, callback?: (err: any, data: S3ListObjectVersionsOutput|any) => void): Request;
-      listObjects(params: S3ListObjectsRequest, callback?: (err: S3NoSuchBucket|any, data: S3ListObjectsOutput|any) => void): Request;
-      listParts(params: S3ListPartsRequest, callback?: (err: any, data: S3ListPartsOutput|any) => void): Request;
-      putBucketAcl(params: S3PutBucketAclRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketCors(params: S3PutBucketCorsRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketLifecycle(params: S3PutBucketLifecycleRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketLifecycleConfiguration(params: S3PutBucketLifecycleConfigurationRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketLogging(params: S3PutBucketLoggingRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketNotification(params: S3PutBucketNotificationRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketNotificationConfiguration(params: S3PutBucketNotificationConfigurationRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketPolicy(params: S3PutBucketPolicyRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketReplication(params: S3PutBucketReplicationRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketRequestPayment(params: S3PutBucketRequestPaymentRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketTagging(params: S3PutBucketTaggingRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketVersioning(params: S3PutBucketVersioningRequest, callback?: (err: any, data: any) => void): Request;
-      putBucketWebsite(params: S3PutBucketWebsiteRequest, callback?: (err: any, data: any) => void): Request;
-      putObject(params: S3PutObjectRequest, callback?: (err: any, data: S3PutObjectOutput|any) => void): Request;
-      putObjectAcl(params: S3PutObjectAclRequest, callback?: (err: S3NoSuchKey|any, data: S3PutObjectAclOutput|any) => void): Request;
-      restoreObject(params: S3RestoreObjectRequest, callback?: (err: S3ObjectAlreadyInActiveTierError|any, data: S3RestoreObjectOutput|any) => void): Request;
-      uploadPart(params: S3UploadPartRequest, callback?: (err: any, data: S3UploadPartOutput|any) => void): Request;
-      uploadPartCopy(params: S3UploadPartCopyRequest, callback?: (err: any, data: S3UploadPartCopyOutput|any) => void): Request;
-    }
-
-    export interface S3AbortMultipartUploadOutput {
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3AbortMultipartUploadRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        UploadId: S3MultipartUploadId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export type S3AcceptRanges = string;
-    export interface S3AccessControlPolicy {
-        Grants?: S3Grants;
-        Owner?: S3Owner;
-    }
-
-    export type S3AllowedHeader = string;
-    export type S3AllowedHeaders = Array<S3AllowedHeader>;
-    export type S3AllowedMethod = string;
-    export type S3AllowedMethods = Array<S3AllowedMethod>;
-    export type S3AllowedOrigin = string;
-    export type S3AllowedOrigins = Array<S3AllowedOrigin>;
-    export type S3Body = any; // not really - it was 'blob' instead - must fix this one
-    export interface S3Bucket {
-        Name?: S3BucketName;
-        CreationDate?: S3CreationDate;
-    }
-
-    export interface S3BucketAlreadyExists {
-    }
-
-    export type S3BucketCannedACL = string;
-    export interface S3BucketLifecycleConfiguration {
-        Rules: S3LifecycleRules;
-    }
-
-    export type S3BucketLocationConstraint = string;
-    export interface S3BucketLoggingStatus {
-        LoggingEnabled?: S3LoggingEnabled;
-    }
-
-    export type S3BucketLogsPermission = string;
-    export type S3BucketName = string;
-    export type S3BucketVersioningStatus = string;
-    export type S3Buckets = Array<S3Bucket>;
-    export interface S3CORSConfiguration {
-        CORSRules: S3CORSRules;
-    }
-
-    export interface S3CORSRule {
-        AllowedHeaders?: S3AllowedHeaders;
-        AllowedMethods: S3AllowedMethods;
-        AllowedOrigins: S3AllowedOrigins;
-        ExposeHeaders?: S3ExposeHeaders;
-        MaxAgeSeconds?: S3MaxAgeSeconds;
-    }
-
-    export type S3CORSRules = Array<S3CORSRule>;
-    export type S3CacheControl = string;
-    export type S3CloudFunction = string;
-    export interface S3CloudFunctionConfiguration {
-        Id?: S3NotificationId;
-        Event?: S3Event;
-        Events?: S3EventList;
-        CloudFunction?: S3CloudFunction;
-        InvocationRole?: S3CloudFunctionInvocationRole;
-    }
-
-    export type S3CloudFunctionInvocationRole = string;
-    export type S3Code = string;
-    export interface S3CommonPrefix {
-        Prefix?: S3Prefix;
-    }
-
-    export type S3CommonPrefixList = Array<S3CommonPrefix>;
-    export interface S3CompleteMultipartUploadOutput {
-        Location?: S3Location;
-        Bucket?: S3BucketName;
-        Key?: S3ObjectKey;
-        Expiration?: S3Expiration;
-        ETag?: S3ETag;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        VersionId?: S3ObjectVersionId;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3CompleteMultipartUploadRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        MultipartUpload?: S3CompletedMultipartUpload;
-        UploadId: S3MultipartUploadId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3CompletedMultipartUpload {
-        Parts?: S3CompletedPartList;
-    }
-
-    export interface S3CompletedPart {
-        ETag?: S3ETag;
-        PartNumber?: S3PartNumber;
-    }
-
-    export type S3CompletedPartList = Array<S3CompletedPart>;
-    export interface S3Condition {
-        HttpErrorCodeReturnedEquals?: S3HttpErrorCodeReturnedEquals;
-        KeyPrefixEquals?: S3KeyPrefixEquals;
-    }
-
-    export type S3ContentDisposition = string;
-    export type S3ContentEncoding = string;
-    export type S3ContentLanguage = string;
-    export type S3ContentLength = number;
-    export type S3ContentMD5 = string;
-    export type S3ContentRange = string;
-    export type S3ContentType = string;
-    export interface S3CopyObjectOutput {
-        CopyObjectResult?: S3CopyObjectResult;
-        Expiration?: S3Expiration;
-        CopySourceVersionId?: S3CopySourceVersionId;
-        VersionId?: S3ObjectVersionId;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3CopyObjectRequest {
-        ACL?: S3ObjectCannedACL;
-        Bucket: S3BucketName;
-        CacheControl?: S3CacheControl;
-        ContentDisposition?: S3ContentDisposition;
-        ContentEncoding?: S3ContentEncoding;
-        ContentLanguage?: S3ContentLanguage;
-        ContentType?: S3ContentType;
-        CopySource: S3CopySource;
-        CopySourceIfMatch?: S3CopySourceIfMatch;
-        CopySourceIfModifiedSince?: S3CopySourceIfModifiedSince;
-        CopySourceIfNoneMatch?: S3CopySourceIfNoneMatch;
-        CopySourceIfUnmodifiedSince?: S3CopySourceIfUnmodifiedSince;
-        Expires?: S3Expires;
-        GrantFullControl?: S3GrantFullControl;
-        GrantRead?: S3GrantRead;
-        GrantReadACP?: S3GrantReadACP;
-        GrantWriteACP?: S3GrantWriteACP;
-        Key: S3ObjectKey;
-        Metadata?: S3Metadata;
-        MetadataDirective?: S3MetadataDirective;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        StorageClass?: S3StorageClass;
-        WebsiteRedirectLocation?: S3WebsiteRedirectLocation;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        CopySourceSSECustomerAlgorithm?: S3CopySourceSSECustomerAlgorithm;
-        CopySourceSSECustomerKey?: S3CopySourceSSECustomerKey;
-        CopySourceSSECustomerKeyMD5?: S3CopySourceSSECustomerKeyMD5;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3CopyObjectResult {
-        ETag?: S3ETag;
-        LastModified?: S3LastModified;
-    }
-
-    export interface S3CopyPartResult {
-        ETag?: S3ETag;
-        LastModified?: S3LastModified;
-    }
-
-    export type S3CopySource = string; // pattern: "\/.+\/.+"
-    export type S3CopySourceIfMatch = string;
-    export type S3CopySourceIfModifiedSince = number;
-    export type S3CopySourceIfNoneMatch = string;
-    export type S3CopySourceIfUnmodifiedSince = number;
-    export type S3CopySourceRange = string;
-    export type S3CopySourceSSECustomerAlgorithm = string;
-    export type S3CopySourceSSECustomerKey = any; // not really - it was 'blob' instead - must fix this one
-    export type S3CopySourceSSECustomerKeyMD5 = string;
-    export type S3CopySourceVersionId = string;
-    export interface S3CreateBucketConfiguration {
-        LocationConstraint?: S3BucketLocationConstraint;
-    }
-
-    export interface S3CreateBucketOutput {
-        Location?: S3Location;
-    }
-
-    export interface S3CreateBucketRequest {
-        ACL?: S3BucketCannedACL;
-        Bucket: S3BucketName;
-        CreateBucketConfiguration?: S3CreateBucketConfiguration;
-        GrantFullControl?: S3GrantFullControl;
-        GrantRead?: S3GrantRead;
-        GrantReadACP?: S3GrantReadACP;
-        GrantWrite?: S3GrantWrite;
-        GrantWriteACP?: S3GrantWriteACP;
-    }
-
-    export interface S3CreateMultipartUploadOutput {
-        Bucket?: S3BucketName;
-        Key?: S3ObjectKey;
-        UploadId?: S3MultipartUploadId;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3CreateMultipartUploadRequest {
-        ACL?: S3ObjectCannedACL;
-        Bucket: S3BucketName;
-        CacheControl?: S3CacheControl;
-        ContentDisposition?: S3ContentDisposition;
-        ContentEncoding?: S3ContentEncoding;
-        ContentLanguage?: S3ContentLanguage;
-        ContentType?: S3ContentType;
-        Expires?: S3Expires;
-        GrantFullControl?: S3GrantFullControl;
-        GrantRead?: S3GrantRead;
-        GrantReadACP?: S3GrantReadACP;
-        GrantWriteACP?: S3GrantWriteACP;
-        Key: S3ObjectKey;
-        Metadata?: S3Metadata;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        StorageClass?: S3StorageClass;
-        WebsiteRedirectLocation?: S3WebsiteRedirectLocation;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export type S3CreationDate = number;
-    export type S3Date = number;
-    export type S3Days = number;
-    export interface S3Delete {
-        Objects: S3ObjectIdentifierList;
-        Quiet?: S3Quiet;
-    }
-
-    export interface S3DeleteBucketCorsRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3DeleteBucketLifecycleRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3DeleteBucketPolicyRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3DeleteBucketReplicationRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3DeleteBucketRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3DeleteBucketTaggingRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3DeleteBucketWebsiteRequest {
-        Bucket: S3BucketName;
-    }
-
-    export type S3DeleteMarker = boolean;
-    export interface S3DeleteMarkerEntry {
-        Owner?: S3Owner;
-        Key?: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-        IsLatest?: S3IsLatest;
-        LastModified?: S3LastModified;
-    }
-
-    export type S3DeleteMarkerVersionId = string;
-    export type S3DeleteMarkers = Array<S3DeleteMarkerEntry>;
-    export interface S3DeleteObjectOutput {
-        DeleteMarker?: S3DeleteMarker;
-        VersionId?: S3ObjectVersionId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3DeleteObjectRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        MFA?: S3MFA;
-        VersionId?: S3ObjectVersionId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3DeleteObjectsOutput {
-        Deleted?: S3DeletedObjects;
-        RequestCharged?: S3RequestCharged;
-        Errors?: S3Errors;
-    }
-
-    export interface S3DeleteObjectsRequest {
-        Bucket: S3BucketName;
-        Delete: S3Delete;
-        MFA?: S3MFA;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3DeletedObject {
-        Key?: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-        DeleteMarker?: S3DeleteMarker;
-        DeleteMarkerVersionId?: S3DeleteMarkerVersionId;
-    }
-
-    export type S3DeletedObjects = Array<S3DeletedObject>;
-    export type S3Delimiter = string;
-    export interface S3Destination {
-        Bucket: S3BucketName;
-        StorageClass?: S3StorageClass;
-    }
-
-    export type S3DisplayName = string;
-    export type S3ETag = string;
-    export type S3EmailAddress = string;
-    export type S3EncodingType = string;
-    export interface S3Error {
-        Key?: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-        Code?: S3Code;
-        Message?: S3Message;
-    }
-
-    export interface S3ErrorDocument {
-        Key: S3ObjectKey;
-    }
-
-    export type S3Errors = Array<S3Error>;
-    export type S3Event = string;
-    export type S3EventList = Array<S3Event>;
-    export type S3Expiration = string;
-    export type S3ExpirationStatus = string;
-    export type S3Expires = number;
-    export type S3ExposeHeader = string;
-    export type S3ExposeHeaders = Array<S3ExposeHeader>;
-    export interface S3FilterRule {
-        Name?: S3FilterRuleName;
-        Value?: S3FilterRuleValue;
-    }
-
-    export type S3FilterRuleList = Array<S3FilterRule>;
-    export type S3FilterRuleName = string;
-    export type S3FilterRuleValue = string;
-    export interface S3GetBucketAclOutput {
-        Owner?: S3Owner;
-        Grants?: S3Grants;
-    }
-
-    export interface S3GetBucketAclRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketCorsOutput {
-        CORSRules?: S3CORSRules;
-    }
-
-    export interface S3GetBucketCorsRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketLifecycleConfigurationOutput {
-        Rules?: S3LifecycleRules;
-    }
-
-    export interface S3GetBucketLifecycleConfigurationRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketLifecycleOutput {
-        Rules?: S3Rules;
-    }
-
-    export interface S3GetBucketLifecycleRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketLocationOutput {
-        LocationConstraint?: S3BucketLocationConstraint;
-    }
-
-    export interface S3GetBucketLocationRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketLoggingOutput {
-        LoggingEnabled?: S3LoggingEnabled;
-    }
-
-    export interface S3GetBucketLoggingRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketNotificationConfigurationRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketPolicyOutput {
-        Policy?: S3Policy;
-    }
-
-    export interface S3GetBucketPolicyRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketReplicationOutput {
-        ReplicationConfiguration?: S3ReplicationConfiguration;
-    }
-
-    export interface S3GetBucketReplicationRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketRequestPaymentOutput {
-        Payer?: S3Payer;
-    }
-
-    export interface S3GetBucketRequestPaymentRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketTaggingOutput {
-        TagSet: S3TagSet;
-    }
-
-    export interface S3GetBucketTaggingRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketVersioningOutput {
-        Status?: S3BucketVersioningStatus;
-        MFADelete?: S3MFADeleteStatus;
-    }
-
-    export interface S3GetBucketVersioningRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetBucketWebsiteOutput {
-        RedirectAllRequestsTo?: S3RedirectAllRequestsTo;
-        IndexDocument?: S3IndexDocument;
-        ErrorDocument?: S3ErrorDocument;
-        RoutingRules?: S3RoutingRules;
-    }
-
-    export interface S3GetBucketWebsiteRequest {
-        Bucket: S3BucketName;
-    }
-
-    export interface S3GetObjectAclOutput {
-        Owner?: S3Owner;
-        Grants?: S3Grants;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3GetObjectAclRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3GetObjectOutput {
-        Body?: S3Body;
-        DeleteMarker?: S3DeleteMarker;
-        AcceptRanges?: S3AcceptRanges;
-        Expiration?: S3Expiration;
-        Restore?: S3Restore;
-        LastModified?: S3LastModified;
-        ContentLength?: S3ContentLength;
-        ETag?: S3ETag;
-        MissingMeta?: S3MissingMeta;
-        VersionId?: S3ObjectVersionId;
-        CacheControl?: S3CacheControl;
-        ContentDisposition?: S3ContentDisposition;
-        ContentEncoding?: S3ContentEncoding;
-        ContentLanguage?: S3ContentLanguage;
-        ContentRange?: S3ContentRange;
-        ContentType?: S3ContentType;
-        Expires?: S3Expires;
-        WebsiteRedirectLocation?: S3WebsiteRedirectLocation;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        Metadata?: S3Metadata;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        StorageClass?: S3StorageClass;
-        RequestCharged?: S3RequestCharged;
-        ReplicationStatus?: S3ReplicationStatus;
-    }
-
-    export interface S3GetObjectRequest {
-        Bucket: S3BucketName;
-        IfMatch?: S3IfMatch;
-        IfModifiedSince?: S3IfModifiedSince;
-        IfNoneMatch?: S3IfNoneMatch;
-        IfUnmodifiedSince?: S3IfUnmodifiedSince;
-        Key: S3ObjectKey;
-        Range?: S3Range;
-        ResponseCacheControl?: S3ResponseCacheControl;
-        ResponseContentDisposition?: S3ResponseContentDisposition;
-        ResponseContentEncoding?: S3ResponseContentEncoding;
-        ResponseContentLanguage?: S3ResponseContentLanguage;
-        ResponseContentType?: S3ResponseContentType;
-        ResponseExpires?: S3ResponseExpires;
-        VersionId?: S3ObjectVersionId;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3GetObjectTorrentOutput {
-        Body?: S3Body;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3GetObjectTorrentRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3Grant {
-        Grantee?: S3Grantee;
-        Permission?: S3Permission;
-    }
-
-    export type S3GrantFullControl = string;
-    export type S3GrantRead = string;
-    export type S3GrantReadACP = string;
-    export type S3GrantWrite = string;
-    export type S3GrantWriteACP = string;
-    export interface S3Grantee {
-        DisplayName?: S3DisplayName;
-        EmailAddress?: S3EmailAddress;
-        ID?: S3ID;
-        Type: S3Type;
-        URI?: S3URI;
-    }
+      abortMultipartUpload(params: S3.AbortMultipartUploadRequest, callback?: (err: S3.NoSuchUpload|any, data: S3.AbortMultipartUploadOutput|any) => void): Request;
+      completeMultipartUpload(params: S3.CompleteMultipartUploadRequest, callback?: (err: any, data: S3.CompleteMultipartUploadOutput|any) => void): Request;
+      copyObject(params: S3.CopyObjectRequest, callback?: (err: S3.ObjectNotInActiveTierError|any, data: S3.CopyObjectOutput|any) => void): Request;
+      createBucket(params: S3.CreateBucketRequest, callback?: (err: S3.BucketAlreadyExists|any, data: S3.CreateBucketOutput|any) => void): Request;
+      createMultipartUpload(params: S3.CreateMultipartUploadRequest, callback?: (err: any, data: S3.CreateMultipartUploadOutput|any) => void): Request;
+      deleteBucket(params: S3.DeleteBucketRequest, callback?: (err: any, data: any) => void): Request;
+      deleteBucketCors(params: S3.DeleteBucketCorsRequest, callback?: (err: any, data: any) => void): Request;
+      deleteBucketLifecycle(params: S3.DeleteBucketLifecycleRequest, callback?: (err: any, data: any) => void): Request;
+      deleteBucketPolicy(params: S3.DeleteBucketPolicyRequest, callback?: (err: any, data: any) => void): Request;
+      deleteBucketReplication(params: S3.DeleteBucketReplicationRequest, callback?: (err: any, data: any) => void): Request;
+      deleteBucketTagging(params: S3.DeleteBucketTaggingRequest, callback?: (err: any, data: any) => void): Request;
+      deleteBucketWebsite(params: S3.DeleteBucketWebsiteRequest, callback?: (err: any, data: any) => void): Request;
+      deleteObject(params: S3.DeleteObjectRequest, callback?: (err: any, data: S3.DeleteObjectOutput|any) => void): Request;
+      deleteObjects(params: S3.DeleteObjectsRequest, callback?: (err: any, data: S3.DeleteObjectsOutput|any) => void): Request;
+      getBucketAcl(params: S3.GetBucketAclRequest, callback?: (err: any, data: S3.GetBucketAclOutput|any) => void): Request;
+      getBucketCors(params: S3.GetBucketCorsRequest, callback?: (err: any, data: S3.GetBucketCorsOutput|any) => void): Request;
+      getBucketLifecycle(params: S3.GetBucketLifecycleRequest, callback?: (err: any, data: S3.GetBucketLifecycleOutput|any) => void): Request;
+      getBucketLifecycleConfiguration(params: S3.GetBucketLifecycleConfigurationRequest, callback?: (err: any, data: S3.GetBucketLifecycleConfigurationOutput|any) => void): Request;
+      getBucketLocation(params: S3.GetBucketLocationRequest, callback?: (err: any, data: S3.GetBucketLocationOutput|any) => void): Request;
+      getBucketLogging(params: S3.GetBucketLoggingRequest, callback?: (err: any, data: S3.GetBucketLoggingOutput|any) => void): Request;
+      getBucketNotification(params: S3.GetBucketNotificationConfigurationRequest, callback?: (err: any, data: S3.NotificationConfigurationDeprecated|any) => void): Request;
+      getBucketNotificationConfiguration(params: S3.GetBucketNotificationConfigurationRequest, callback?: (err: any, data: S3.NotificationConfiguration|any) => void): Request;
+      getBucketPolicy(params: S3.GetBucketPolicyRequest, callback?: (err: any, data: S3.GetBucketPolicyOutput|any) => void): Request;
+      getBucketReplication(params: S3.GetBucketReplicationRequest, callback?: (err: any, data: S3.GetBucketReplicationOutput|any) => void): Request;
+      getBucketRequestPayment(params: S3.GetBucketRequestPaymentRequest, callback?: (err: any, data: S3.GetBucketRequestPaymentOutput|any) => void): Request;
+      getBucketTagging(params: S3.GetBucketTaggingRequest, callback?: (err: any, data: S3.GetBucketTaggingOutput|any) => void): Request;
+      getBucketVersioning(params: S3.GetBucketVersioningRequest, callback?: (err: any, data: S3.GetBucketVersioningOutput|any) => void): Request;
+      getBucketWebsite(params: S3.GetBucketWebsiteRequest, callback?: (err: any, data: S3.GetBucketWebsiteOutput|any) => void): Request;
+      getObject(params: S3.GetObjectRequest, callback?: (err: S3.NoSuchKey|any, data: S3.GetObjectOutput|any) => void): Request;
+      getObjectAcl(params: S3.GetObjectAclRequest, callback?: (err: S3.NoSuchKey|any, data: S3.GetObjectAclOutput|any) => void): Request;
+      getObjectTorrent(params: S3.GetObjectTorrentRequest, callback?: (err: any, data: S3.GetObjectTorrentOutput|any) => void): Request;
+      headBucket(params: S3.HeadBucketRequest, callback?: (err: S3.NoSuchBucket|any, data: any) => void): Request;
+      headObject(params: S3.HeadObjectRequest, callback?: (err: S3.NoSuchKey|any, data: S3.HeadObjectOutput|any) => void): Request;
+      listBuckets(callback?: (err: any, data: S3.ListBucketsOutput|any) => void): Request;
+      listMultipartUploads(params: S3.ListMultipartUploadsRequest, callback?: (err: any, data: S3.ListMultipartUploadsOutput|any) => void): Request;
+      listObjectVersions(params: S3.ListObjectVersionsRequest, callback?: (err: any, data: S3.ListObjectVersionsOutput|any) => void): Request;
+      listObjects(params: S3.ListObjectsRequest, callback?: (err: S3.NoSuchBucket|any, data: S3.ListObjectsOutput|any) => void): Request;
+      listParts(params: S3.ListPartsRequest, callback?: (err: any, data: S3.ListPartsOutput|any) => void): Request;
+      putBucketAcl(params: S3.PutBucketAclRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketCors(params: S3.PutBucketCorsRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketLifecycle(params: S3.PutBucketLifecycleRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketLifecycleConfiguration(params: S3.PutBucketLifecycleConfigurationRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketLogging(params: S3.PutBucketLoggingRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketNotification(params: S3.PutBucketNotificationRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketNotificationConfiguration(params: S3.PutBucketNotificationConfigurationRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketPolicy(params: S3.PutBucketPolicyRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketReplication(params: S3.PutBucketReplicationRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketRequestPayment(params: S3.PutBucketRequestPaymentRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketTagging(params: S3.PutBucketTaggingRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketVersioning(params: S3.PutBucketVersioningRequest, callback?: (err: any, data: any) => void): Request;
+      putBucketWebsite(params: S3.PutBucketWebsiteRequest, callback?: (err: any, data: any) => void): Request;
+      putObject(params: S3.PutObjectRequest, callback?: (err: any, data: S3.PutObjectOutput|any) => void): Request;
+      putObjectAcl(params: S3.PutObjectAclRequest, callback?: (err: S3.NoSuchKey|any, data: S3.PutObjectAclOutput|any) => void): Request;
+      restoreObject(params: S3.RestoreObjectRequest, callback?: (err: S3.ObjectAlreadyInActiveTierError|any, data: S3.RestoreObjectOutput|any) => void): Request;
+      uploadPart(params: S3.UploadPartRequest, callback?: (err: any, data: S3.UploadPartOutput|any) => void): Request;
+      uploadPartCopy(params: S3.UploadPartCopyRequest, callback?: (err: any, data: S3.UploadPartCopyOutput|any) => void): Request;
+    }
+    
+    export module S3 {
+        export type AcceptRanges = string;
+        export type AllowedHeader = string;
+        export type AllowedHeaders = AllowedHeader[];
+        export type AllowedMethod = string;
+        export type AllowedMethods = AllowedMethod[];
+        export type AllowedOrigin = string;
+        export type AllowedOrigins = AllowedOrigin[];
+        export type Body = any;    // type: blob
+        export type BucketCannedACL = string;
+        export type BucketLocationConstraint = string;
+        export type BucketLogsPermission = string;
+        export type BucketName = string;
+        export type BucketVersioningStatus = string;
+        export type Buckets = Bucket[];
+        export type CORSRules = CORSRule[];
+        export type CacheControl = string;
+        export type CloudFunction = string;
+        export type CloudFunctionInvocationRole = string;
+        export type Code = string;
+        export type CommonPrefixList = CommonPrefix[];
+        export type CompletedPartList = CompletedPart[];
+        export type ContentDisposition = string;
+        export type ContentEncoding = string;
+        export type ContentLanguage = string;
+        export type ContentLength = number;
+        export type ContentMD5 = string;
+        export type ContentRange = string;
+        export type ContentType = string;
+        export type CopySource = string;    // pattern: &quot;\/.+\/.+&quot;
+        export type CopySourceIfMatch = string;
+        export type CopySourceIfModifiedSince = number;
+        export type CopySourceIfNoneMatch = string;
+        export type CopySourceIfUnmodifiedSince = number;
+        export type CopySourceRange = string;
+        export type CopySourceSSECustomerAlgorithm = string;
+        export type CopySourceSSECustomerKey = any;    // type: blob
+        export type CopySourceSSECustomerKeyMD5 = string;
+        export type CopySourceVersionId = string;
+        export type CreationDate = number;
+        export type Date = number;
+        export type Days = number;
+        export type DeleteMarker = boolean;
+        export type DeleteMarkerVersionId = string;
+        export type DeleteMarkers = DeleteMarkerEntry[];
+        export type DeletedObjects = DeletedObject[];
+        export type Delimiter = string;
+        export type DisplayName = string;
+        export type ETag = string;
+        export type EmailAddress = string;
+        export type EncodingType = string;
+        export type Errors = Error[];
+        export type Event = string;
+        export type EventList = Event[];
+        export type Expiration = string;
+        export type ExpirationStatus = string;
+        export type Expires = number;
+        export type ExposeHeader = string;
+        export type ExposeHeaders = ExposeHeader[];
+        export type FilterRuleList = FilterRule[];
+        export type FilterRuleName = string;
+        export type FilterRuleValue = string;
+        export type GrantFullControl = string;
+        export type GrantRead = string;
+        export type GrantReadACP = string;
+        export type GrantWrite = string;
+        export type GrantWriteACP = string;
+        export type Grants = Grant[];
+        export type HostName = string;
+        export type HttpErrorCodeReturnedEquals = string;
+        export type HttpRedirectCode = string;
+        export type ID = string;
+        export type IfMatch = string;
+        export type IfModifiedSince = number;
+        export type IfNoneMatch = string;
+        export type IfUnmodifiedSince = number;
+        export type Initiated = number;
+        export type IsLatest = boolean;
+        export type IsTruncated = boolean;
+        export type KeyMarker = string;
+        export type KeyPrefixEquals = string;
+        export type LambdaFunctionArn = string;
+        export type LambdaFunctionConfigurationList = LambdaFunctionConfiguration[];
+        export type LastModified = number;
+        export type LifecycleRules = LifecycleRule[];
+        export type Location = string;
+        export type MFA = string;
+        export type MFADelete = string;
+        export type MFADeleteStatus = string;
+        export type Marker = string;
+        export type MaxAgeSeconds = number;
+        export type MaxKeys = number;
+        export type MaxParts = number;
+        export type MaxUploads = number;
+        export type Message = string;
+        export type Metadata = {[key:string]: MetadataValue};
+        export type MetadataDirective = string;
+        export type MetadataKey = string;
+        export type MetadataValue = string;
+        export type MissingMeta = number;
+        export type MultipartUploadId = string;
+        export type MultipartUploadList = MultipartUpload[];
+        export type NextKeyMarker = string;
+        export type NextMarker = string;
+        export type NextPartNumberMarker = number;
+        export type NextUploadIdMarker = string;
+        export type NextVersionIdMarker = string;
+        export type NoncurrentVersionTransitionList = NoncurrentVersionTransition[];
+        export type NotificationId = string;
+        export type ObjectCannedACL = string;
+        export type ObjectIdentifierList = ObjectIdentifier[];
+        export type ObjectKey = string;    // min: 1
+        export type ObjectList = Object[];
+        export type ObjectStorageClass = string;
+        export type ObjectVersionId = string;
+        export type ObjectVersionList = ObjectVersion[];
+        export type ObjectVersionStorageClass = string;
+        export type PartNumber = number;
+        export type PartNumberMarker = number;
+        export type Parts = Part[];
+        export type Payer = string;
+        export type Permission = string;
+        export type Policy = string;
+        export type Prefix = string;
+        export type Protocol = string;
+        export type QueueArn = string;
+        export type QueueConfigurationList = QueueConfiguration[];
+        export type Quiet = boolean;
+        export type Range = string;
+        export type ReplaceKeyPrefixWith = string;
+        export type ReplaceKeyWith = string;
+        export type ReplicationRuleStatus = string;
+        export type ReplicationRules = ReplicationRule[];
+        export type ReplicationStatus = string;
+        export type RequestCharged = string;
+        export type RequestPayer = string;
+        export type ResponseCacheControl = string;
+        export type ResponseContentDisposition = string;
+        export type ResponseContentEncoding = string;
+        export type ResponseContentLanguage = string;
+        export type ResponseContentType = string;
+        export type ResponseExpires = number;
+        export type Restore = string;
+        export type Role = string;
+        export type RoutingRules = RoutingRule[];
+        export type Rules = Rule[];
+        export type SSECustomerAlgorithm = string;
+        export type SSECustomerKey = any;    // type: blob
+        export type SSECustomerKeyMD5 = string;
+        export type SSEKMSKeyId = string;
+        export type ServerSideEncryption = string;
+        export type Size = number;
+        export type StorageClass = string;
+        export type Suffix = string;
+        export type TagSet = Tag[];
+        export type TargetBucket = string;
+        export type TargetGrants = TargetGrant[];
+        export type TargetPrefix = string;
+        export type TopicArn = string;
+        export type TopicConfigurationList = TopicConfiguration[];
+        export type TransitionList = Transition[];
+        export type TransitionStorageClass = string;
+        export type Type = string;
+        export type URI = string;
+        export type UploadIdMarker = string;
+        export type Value = string;
+        export type VersionIdMarker = string;
+        export type WebsiteRedirectLocation = string;
+
+        export interface AbortMultipartUploadOutput {
+            RequestCharged?: RequestCharged;            
+        }
+        export interface AbortMultipartUploadRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            UploadId: MultipartUploadId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface AccessControlPolicy {
+            Grants?: Grants;            
+            Owner?: Owner;            
+        }
+        export interface Bucket {
+            Name?: BucketName;            
+            CreationDate?: CreationDate;            
+        }
+        export interface BucketAlreadyExists {
+        }
+        export interface BucketLifecycleConfiguration {
+            Rules: LifecycleRules;            
+        }
+        export interface BucketLoggingStatus {
+            LoggingEnabled?: LoggingEnabled;            
+        }
+        export interface CORSConfiguration {
+            CORSRules: CORSRules;            
+        }
+        export interface CORSRule {
+            AllowedHeaders?: AllowedHeaders;            
+            AllowedMethods: AllowedMethods;            
+            AllowedOrigins: AllowedOrigins;            
+            ExposeHeaders?: ExposeHeaders;            
+            MaxAgeSeconds?: MaxAgeSeconds;            
+        }
+        export interface CloudFunctionConfiguration {
+            Id?: NotificationId;            
+            Event?: Event;            
+            Events?: EventList;            
+            CloudFunction?: CloudFunction;            
+            InvocationRole?: CloudFunctionInvocationRole;            
+        }
+        export interface CommonPrefix {
+            Prefix?: Prefix;            
+        }
+        export interface CompleteMultipartUploadOutput {
+            Location?: Location;            
+            Bucket?: BucketName;            
+            Key?: ObjectKey;            
+            Expiration?: Expiration;            
+            ETag?: ETag;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            VersionId?: ObjectVersionId;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface CompleteMultipartUploadRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            MultipartUpload?: CompletedMultipartUpload;            
+            UploadId: MultipartUploadId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface CompletedMultipartUpload {
+            Parts?: CompletedPartList;            
+        }
+        export interface CompletedPart {
+            ETag?: ETag;            
+            PartNumber?: PartNumber;            
+        }
+        export interface Condition {
+            HttpErrorCodeReturnedEquals?: HttpErrorCodeReturnedEquals;            
+            KeyPrefixEquals?: KeyPrefixEquals;            
+        }
+        export interface CopyObjectOutput {
+            CopyObjectResult?: CopyObjectResult;            
+            Expiration?: Expiration;            
+            CopySourceVersionId?: CopySourceVersionId;            
+            VersionId?: ObjectVersionId;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface CopyObjectRequest {
+            ACL?: ObjectCannedACL;            
+            Bucket: BucketName;            
+            CacheControl?: CacheControl;            
+            ContentDisposition?: ContentDisposition;            
+            ContentEncoding?: ContentEncoding;            
+            ContentLanguage?: ContentLanguage;            
+            ContentType?: ContentType;            
+            CopySource: CopySource;            
+            CopySourceIfMatch?: CopySourceIfMatch;            
+            CopySourceIfModifiedSince?: CopySourceIfModifiedSince;            
+            CopySourceIfNoneMatch?: CopySourceIfNoneMatch;            
+            CopySourceIfUnmodifiedSince?: CopySourceIfUnmodifiedSince;            
+            Expires?: Expires;            
+            GrantFullControl?: GrantFullControl;            
+            GrantRead?: GrantRead;            
+            GrantReadACP?: GrantReadACP;            
+            GrantWriteACP?: GrantWriteACP;            
+            Key: ObjectKey;            
+            Metadata?: Metadata;            
+            MetadataDirective?: MetadataDirective;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            StorageClass?: StorageClass;            
+            WebsiteRedirectLocation?: WebsiteRedirectLocation;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            CopySourceSSECustomerAlgorithm?: CopySourceSSECustomerAlgorithm;            
+            CopySourceSSECustomerKey?: CopySourceSSECustomerKey;            
+            CopySourceSSECustomerKeyMD5?: CopySourceSSECustomerKeyMD5;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface CopyObjectResult {
+            ETag?: ETag;            
+            LastModified?: LastModified;            
+        }
+        export interface CopyPartResult {
+            ETag?: ETag;            
+            LastModified?: LastModified;            
+        }
+        export interface CreateBucketConfiguration {
+            LocationConstraint?: BucketLocationConstraint;            
+        }
+        export interface CreateBucketOutput {
+            Location?: Location;            
+        }
+        export interface CreateBucketRequest {
+            ACL?: BucketCannedACL;            
+            Bucket: BucketName;            
+            CreateBucketConfiguration?: CreateBucketConfiguration;            
+            GrantFullControl?: GrantFullControl;            
+            GrantRead?: GrantRead;            
+            GrantReadACP?: GrantReadACP;            
+            GrantWrite?: GrantWrite;            
+            GrantWriteACP?: GrantWriteACP;            
+        }
+        export interface CreateMultipartUploadOutput {
+            Bucket?: BucketName;            
+            Key?: ObjectKey;            
+            UploadId?: MultipartUploadId;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface CreateMultipartUploadRequest {
+            ACL?: ObjectCannedACL;            
+            Bucket: BucketName;            
+            CacheControl?: CacheControl;            
+            ContentDisposition?: ContentDisposition;            
+            ContentEncoding?: ContentEncoding;            
+            ContentLanguage?: ContentLanguage;            
+            ContentType?: ContentType;            
+            Expires?: Expires;            
+            GrantFullControl?: GrantFullControl;            
+            GrantRead?: GrantRead;            
+            GrantReadACP?: GrantReadACP;            
+            GrantWriteACP?: GrantWriteACP;            
+            Key: ObjectKey;            
+            Metadata?: Metadata;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            StorageClass?: StorageClass;            
+            WebsiteRedirectLocation?: WebsiteRedirectLocation;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface Delete {
+            Objects: ObjectIdentifierList;            
+            Quiet?: Quiet;            
+        }
+        export interface DeleteBucketCorsRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteBucketLifecycleRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteBucketPolicyRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteBucketReplicationRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteBucketRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteBucketTaggingRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteBucketWebsiteRequest {
+            Bucket: BucketName;            
+        }
+        export interface DeleteMarkerEntry {
+            Owner?: Owner;            
+            Key?: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+            IsLatest?: IsLatest;            
+            LastModified?: LastModified;            
+        }
+        export interface DeleteObjectOutput {
+            DeleteMarker?: DeleteMarker;            
+            VersionId?: ObjectVersionId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface DeleteObjectRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            MFA?: MFA;            
+            VersionId?: ObjectVersionId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface DeleteObjectsOutput {
+            Deleted?: DeletedObjects;            
+            RequestCharged?: RequestCharged;            
+            Errors?: Errors;            
+        }
+        export interface DeleteObjectsRequest {
+            Bucket: BucketName;            
+            Delete: Delete;            
+            MFA?: MFA;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface DeletedObject {
+            Key?: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+            DeleteMarker?: DeleteMarker;            
+            DeleteMarkerVersionId?: DeleteMarkerVersionId;            
+        }
+        export interface Destination {
+            Bucket: BucketName;            
+            StorageClass?: StorageClass;            
+        }
+        export interface Error {
+            Key?: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+            Code?: Code;            
+            Message?: Message;            
+        }
+        export interface ErrorDocument {
+            Key: ObjectKey;            
+        }
+        export interface FilterRule {
+            Name?: FilterRuleName;            
+            Value?: FilterRuleValue;            
+        }
+        export interface GetBucketAclOutput {
+            Owner?: Owner;            
+            Grants?: Grants;            
+        }
+        export interface GetBucketAclRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketCorsOutput {
+            CORSRules?: CORSRules;            
+        }
+        export interface GetBucketCorsRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketLifecycleConfigurationOutput {
+            Rules?: LifecycleRules;            
+        }
+        export interface GetBucketLifecycleConfigurationRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketLifecycleOutput {
+            Rules?: Rules;            
+        }
+        export interface GetBucketLifecycleRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketLocationOutput {
+            LocationConstraint?: BucketLocationConstraint;            
+        }
+        export interface GetBucketLocationRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketLoggingOutput {
+            LoggingEnabled?: LoggingEnabled;            
+        }
+        export interface GetBucketLoggingRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketNotificationConfigurationRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketPolicyOutput {
+            Policy?: Policy;            
+        }
+        export interface GetBucketPolicyRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketReplicationOutput {
+            ReplicationConfiguration?: ReplicationConfiguration;            
+        }
+        export interface GetBucketReplicationRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketRequestPaymentOutput {
+            Payer?: Payer;            
+        }
+        export interface GetBucketRequestPaymentRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketTaggingOutput {
+            TagSet: TagSet;            
+        }
+        export interface GetBucketTaggingRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketVersioningOutput {
+            Status?: BucketVersioningStatus;            
+            MFADelete?: MFADeleteStatus;            
+        }
+        export interface GetBucketVersioningRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetBucketWebsiteOutput {
+            RedirectAllRequestsTo?: RedirectAllRequestsTo;            
+            IndexDocument?: IndexDocument;            
+            ErrorDocument?: ErrorDocument;            
+            RoutingRules?: RoutingRules;            
+        }
+        export interface GetBucketWebsiteRequest {
+            Bucket: BucketName;            
+        }
+        export interface GetObjectAclOutput {
+            Owner?: Owner;            
+            Grants?: Grants;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface GetObjectAclRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface GetObjectOutput {
+            Body?: Body;            
+            DeleteMarker?: DeleteMarker;            
+            AcceptRanges?: AcceptRanges;            
+            Expiration?: Expiration;            
+            Restore?: Restore;            
+            LastModified?: LastModified;            
+            ContentLength?: ContentLength;            
+            ETag?: ETag;            
+            MissingMeta?: MissingMeta;            
+            VersionId?: ObjectVersionId;            
+            CacheControl?: CacheControl;            
+            ContentDisposition?: ContentDisposition;            
+            ContentEncoding?: ContentEncoding;            
+            ContentLanguage?: ContentLanguage;            
+            ContentRange?: ContentRange;            
+            ContentType?: ContentType;            
+            Expires?: Expires;            
+            WebsiteRedirectLocation?: WebsiteRedirectLocation;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            Metadata?: Metadata;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            StorageClass?: StorageClass;            
+            RequestCharged?: RequestCharged;            
+            ReplicationStatus?: ReplicationStatus;            
+        }
+        export interface GetObjectRequest {
+            Bucket: BucketName;            
+            IfMatch?: IfMatch;            
+            IfModifiedSince?: IfModifiedSince;            
+            IfNoneMatch?: IfNoneMatch;            
+            IfUnmodifiedSince?: IfUnmodifiedSince;            
+            Key: ObjectKey;            
+            Range?: Range;            
+            ResponseCacheControl?: ResponseCacheControl;            
+            ResponseContentDisposition?: ResponseContentDisposition;            
+            ResponseContentEncoding?: ResponseContentEncoding;            
+            ResponseContentLanguage?: ResponseContentLanguage;            
+            ResponseContentType?: ResponseContentType;            
+            ResponseExpires?: ResponseExpires;            
+            VersionId?: ObjectVersionId;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface GetObjectTorrentOutput {
+            Body?: Body;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface GetObjectTorrentRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface Grant {
+            Grantee?: Grantee;            
+            Permission?: Permission;            
+        }
+        export interface Grantee {
+            DisplayName?: DisplayName;            
+            EmailAddress?: EmailAddress;            
+            ID?: ID;            
+            Type: Type;            
+            URI?: URI;            
+        }
+        export interface HeadBucketRequest {
+            Bucket: BucketName;            
+        }
+        export interface HeadObjectOutput {
+            DeleteMarker?: DeleteMarker;            
+            AcceptRanges?: AcceptRanges;            
+            Expiration?: Expiration;            
+            Restore?: Restore;            
+            LastModified?: LastModified;            
+            ContentLength?: ContentLength;            
+            ETag?: ETag;            
+            MissingMeta?: MissingMeta;            
+            VersionId?: ObjectVersionId;            
+            CacheControl?: CacheControl;            
+            ContentDisposition?: ContentDisposition;            
+            ContentEncoding?: ContentEncoding;            
+            ContentLanguage?: ContentLanguage;            
+            ContentType?: ContentType;            
+            Expires?: Expires;            
+            WebsiteRedirectLocation?: WebsiteRedirectLocation;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            Metadata?: Metadata;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            StorageClass?: StorageClass;            
+            RequestCharged?: RequestCharged;            
+            ReplicationStatus?: ReplicationStatus;            
+        }
+        export interface HeadObjectRequest {
+            Bucket: BucketName;            
+            IfMatch?: IfMatch;            
+            IfModifiedSince?: IfModifiedSince;            
+            IfNoneMatch?: IfNoneMatch;            
+            IfUnmodifiedSince?: IfUnmodifiedSince;            
+            Key: ObjectKey;            
+            Range?: Range;            
+            VersionId?: ObjectVersionId;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface IndexDocument {
+            Suffix: Suffix;            
+        }
+        export interface Initiator {
+            ID?: ID;            
+            DisplayName?: DisplayName;            
+        }
+        export interface LambdaFunctionConfiguration {
+            Id?: NotificationId;            
+            LambdaFunctionArn: LambdaFunctionArn;            
+            Events: EventList;            
+            Filter?: NotificationConfigurationFilter;            
+        }
+        export interface LifecycleConfiguration {
+            Rules: Rules;            
+        }
+        export interface LifecycleExpiration {
+            Date?: Date;            
+            Days?: Days;            
+        }
+        export interface LifecycleRule {
+            Expiration?: LifecycleExpiration;            
+            ID?: ID;            
+            Prefix: Prefix;            
+            Status: ExpirationStatus;            
+            Transitions?: TransitionList;            
+            NoncurrentVersionTransitions?: NoncurrentVersionTransitionList;            
+            NoncurrentVersionExpiration?: NoncurrentVersionExpiration;            
+        }
+        export interface ListBucketsOutput {
+            Buckets?: Buckets;            
+            Owner?: Owner;            
+        }
+        export interface ListMultipartUploadsOutput {
+            Bucket?: BucketName;            
+            KeyMarker?: KeyMarker;            
+            UploadIdMarker?: UploadIdMarker;            
+            NextKeyMarker?: NextKeyMarker;            
+            Prefix?: Prefix;            
+            Delimiter?: Delimiter;            
+            NextUploadIdMarker?: NextUploadIdMarker;            
+            MaxUploads?: MaxUploads;            
+            IsTruncated?: IsTruncated;            
+            Uploads?: MultipartUploadList;            
+            CommonPrefixes?: CommonPrefixList;            
+            EncodingType?: EncodingType;            
+        }
+        export interface ListMultipartUploadsRequest {
+            Bucket: BucketName;            
+            Delimiter?: Delimiter;            
+            EncodingType?: EncodingType;            
+            KeyMarker?: KeyMarker;            
+            MaxUploads?: MaxUploads;            
+            Prefix?: Prefix;            
+            UploadIdMarker?: UploadIdMarker;            
+        }
+        export interface ListObjectVersionsOutput {
+            IsTruncated?: IsTruncated;            
+            KeyMarker?: KeyMarker;            
+            VersionIdMarker?: VersionIdMarker;            
+            NextKeyMarker?: NextKeyMarker;            
+            NextVersionIdMarker?: NextVersionIdMarker;            
+            Versions?: ObjectVersionList;            
+            DeleteMarkers?: DeleteMarkers;            
+            Name?: BucketName;            
+            Prefix?: Prefix;            
+            Delimiter?: Delimiter;            
+            MaxKeys?: MaxKeys;            
+            CommonPrefixes?: CommonPrefixList;            
+            EncodingType?: EncodingType;            
+        }
+        export interface ListObjectVersionsRequest {
+            Bucket: BucketName;            
+            Delimiter?: Delimiter;            
+            EncodingType?: EncodingType;            
+            KeyMarker?: KeyMarker;            
+            MaxKeys?: MaxKeys;            
+            Prefix?: Prefix;            
+            VersionIdMarker?: VersionIdMarker;            
+        }
+        export interface ListObjectsOutput {
+            IsTruncated?: IsTruncated;            
+            Marker?: Marker;            
+            NextMarker?: NextMarker;            
+            Contents?: ObjectList;            
+            Name?: BucketName;            
+            Prefix?: Prefix;            
+            Delimiter?: Delimiter;            
+            MaxKeys?: MaxKeys;            
+            CommonPrefixes?: CommonPrefixList;            
+            EncodingType?: EncodingType;            
+        }
+        export interface ListObjectsRequest {
+            Bucket: BucketName;            
+            Delimiter?: Delimiter;            
+            EncodingType?: EncodingType;            
+            Marker?: Marker;            
+            MaxKeys?: MaxKeys;            
+            Prefix?: Prefix;            
+        }
+        export interface ListPartsOutput {
+            Bucket?: BucketName;            
+            Key?: ObjectKey;            
+            UploadId?: MultipartUploadId;            
+            PartNumberMarker?: PartNumberMarker;            
+            NextPartNumberMarker?: NextPartNumberMarker;            
+            MaxParts?: MaxParts;            
+            IsTruncated?: IsTruncated;            
+            Parts?: Parts;            
+            Initiator?: Initiator;            
+            Owner?: Owner;            
+            StorageClass?: StorageClass;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface ListPartsRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            MaxParts?: MaxParts;            
+            PartNumberMarker?: PartNumberMarker;            
+            UploadId: MultipartUploadId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface LoggingEnabled {
+            TargetBucket?: TargetBucket;            
+            TargetGrants?: TargetGrants;            
+            TargetPrefix?: TargetPrefix;            
+        }
+        export interface MultipartUpload {
+            UploadId?: MultipartUploadId;            
+            Key?: ObjectKey;            
+            Initiated?: Initiated;            
+            StorageClass?: StorageClass;            
+            Owner?: Owner;            
+            Initiator?: Initiator;            
+        }
+        export interface NoSuchBucket {
+        }
+        export interface NoSuchKey {
+        }
+        export interface NoSuchUpload {
+        }
+        export interface NoncurrentVersionExpiration {
+            NoncurrentDays?: Days;            
+        }
+        export interface NoncurrentVersionTransition {
+            NoncurrentDays?: Days;            
+            StorageClass?: TransitionStorageClass;            
+        }
+        export interface NotificationConfiguration {
+            TopicConfigurations?: TopicConfigurationList;            
+            QueueConfigurations?: QueueConfigurationList;            
+            LambdaFunctionConfigurations?: LambdaFunctionConfigurationList;            
+        }
+        export interface NotificationConfigurationDeprecated {
+            TopicConfiguration?: TopicConfigurationDeprecated;            
+            QueueConfiguration?: QueueConfigurationDeprecated;            
+            CloudFunctionConfiguration?: CloudFunctionConfiguration;            
+        }
+        export interface NotificationConfigurationFilter {
+            Key?: S3KeyFilter;            
+        }
+        export interface Object {
+            Key?: ObjectKey;            
+            LastModified?: LastModified;            
+            ETag?: ETag;            
+            Size?: Size;            
+            StorageClass?: ObjectStorageClass;            
+            Owner?: Owner;            
+        }
+        export interface ObjectAlreadyInActiveTierError {
+        }
+        export interface ObjectIdentifier {
+            Key: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+        }
+        export interface ObjectNotInActiveTierError {
+        }
+        export interface ObjectVersion {
+            ETag?: ETag;            
+            Size?: Size;            
+            StorageClass?: ObjectVersionStorageClass;            
+            Key?: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+            IsLatest?: IsLatest;            
+            LastModified?: LastModified;            
+            Owner?: Owner;            
+        }
+        export interface Owner {
+            DisplayName?: DisplayName;            
+            ID?: ID;            
+        }
+        export interface Part {
+            PartNumber?: PartNumber;            
+            LastModified?: LastModified;            
+            ETag?: ETag;            
+            Size?: Size;            
+        }
+        export interface PutBucketAclRequest {
+            ACL?: BucketCannedACL;            
+            AccessControlPolicy?: AccessControlPolicy;            
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            GrantFullControl?: GrantFullControl;            
+            GrantRead?: GrantRead;            
+            GrantReadACP?: GrantReadACP;            
+            GrantWrite?: GrantWrite;            
+            GrantWriteACP?: GrantWriteACP;            
+        }
+        export interface PutBucketCorsRequest {
+            Bucket: BucketName;            
+            CORSConfiguration: CORSConfiguration;            
+            ContentMD5?: ContentMD5;            
+        }
+        export interface PutBucketLifecycleConfigurationRequest {
+            Bucket: BucketName;            
+            LifecycleConfiguration?: BucketLifecycleConfiguration;            
+        }
+        export interface PutBucketLifecycleRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            LifecycleConfiguration?: LifecycleConfiguration;            
+        }
+        export interface PutBucketLoggingRequest {
+            Bucket: BucketName;            
+            BucketLoggingStatus: BucketLoggingStatus;            
+            ContentMD5?: ContentMD5;            
+        }
+        export interface PutBucketNotificationConfigurationRequest {
+            Bucket: BucketName;            
+            NotificationConfiguration: NotificationConfiguration;            
+        }
+        export interface PutBucketNotificationRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            NotificationConfiguration: NotificationConfigurationDeprecated;            
+        }
+        export interface PutBucketPolicyRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            Policy: Policy;            
+        }
+        export interface PutBucketReplicationRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            ReplicationConfiguration: ReplicationConfiguration;            
+        }
+        export interface PutBucketRequestPaymentRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            RequestPaymentConfiguration: RequestPaymentConfiguration;            
+        }
+        export interface PutBucketTaggingRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            Tagging: Tagging;            
+        }
+        export interface PutBucketVersioningRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            MFA?: MFA;            
+            VersioningConfiguration: VersioningConfiguration;            
+        }
+        export interface PutBucketWebsiteRequest {
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            WebsiteConfiguration: WebsiteConfiguration;            
+        }
+        export interface PutObjectAclOutput {
+            RequestCharged?: RequestCharged;            
+        }
+        export interface PutObjectAclRequest {
+            ACL?: ObjectCannedACL;            
+            AccessControlPolicy?: AccessControlPolicy;            
+            Bucket: BucketName;            
+            ContentMD5?: ContentMD5;            
+            GrantFullControl?: GrantFullControl;            
+            GrantRead?: GrantRead;            
+            GrantReadACP?: GrantReadACP;            
+            GrantWrite?: GrantWrite;            
+            GrantWriteACP?: GrantWriteACP;            
+            Key: ObjectKey;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface PutObjectOutput {
+            Expiration?: Expiration;            
+            ETag?: ETag;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            VersionId?: ObjectVersionId;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface PutObjectRequest {
+            ACL?: ObjectCannedACL;            
+            Body?: Body;            
+            Bucket: BucketName;            
+            CacheControl?: CacheControl;            
+            ContentDisposition?: ContentDisposition;            
+            ContentEncoding?: ContentEncoding;            
+            ContentLanguage?: ContentLanguage;            
+            ContentLength?: ContentLength;            
+            ContentMD5?: ContentMD5;            
+            ContentType?: ContentType;            
+            Expires?: Expires;            
+            GrantFullControl?: GrantFullControl;            
+            GrantRead?: GrantRead;            
+            GrantReadACP?: GrantReadACP;            
+            GrantWriteACP?: GrantWriteACP;            
+            Key: ObjectKey;            
+            Metadata?: Metadata;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            StorageClass?: StorageClass;            
+            WebsiteRedirectLocation?: WebsiteRedirectLocation;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface QueueConfiguration {
+            Id?: NotificationId;            
+            QueueArn: QueueArn;            
+            Events: EventList;            
+            Filter?: NotificationConfigurationFilter;            
+        }
+        export interface QueueConfigurationDeprecated {
+            Id?: NotificationId;            
+            Event?: Event;            
+            Events?: EventList;            
+            Queue?: QueueArn;            
+        }
+        export interface Redirect {
+            HostName?: HostName;            
+            HttpRedirectCode?: HttpRedirectCode;            
+            Protocol?: Protocol;            
+            ReplaceKeyPrefixWith?: ReplaceKeyPrefixWith;            
+            ReplaceKeyWith?: ReplaceKeyWith;            
+        }
+        export interface RedirectAllRequestsTo {
+            HostName: HostName;            
+            Protocol?: Protocol;            
+        }
+        export interface ReplicationConfiguration {
+            Role: Role;            
+            Rules: ReplicationRules;            
+        }
+        export interface ReplicationRule {
+            ID?: ID;            
+            Prefix: Prefix;            
+            Status: ReplicationRuleStatus;            
+            Destination: Destination;            
+        }
+        export interface RequestPaymentConfiguration {
+            Payer: Payer;            
+        }
+        export interface RestoreObjectOutput {
+            RequestCharged?: RequestCharged;            
+        }
+        export interface RestoreObjectRequest {
+            Bucket: BucketName;            
+            Key: ObjectKey;            
+            VersionId?: ObjectVersionId;            
+            RestoreRequest?: RestoreRequest;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface RestoreRequest {
+            Days: Days;            
+        }
+        export interface RoutingRule {
+            Condition?: Condition;            
+            Redirect: Redirect;            
+        }
+        export interface Rule {
+            Expiration?: LifecycleExpiration;            
+            ID?: ID;            
+            Prefix: Prefix;            
+            Status: ExpirationStatus;            
+            Transition?: Transition;            
+            NoncurrentVersionTransition?: NoncurrentVersionTransition;            
+            NoncurrentVersionExpiration?: NoncurrentVersionExpiration;            
+        }
+        export interface S3KeyFilter {
+            FilterRules?: FilterRuleList;            
+        }
+        export interface Tag {
+            Key: ObjectKey;            
+            Value: Value;            
+        }
+        export interface Tagging {
+            TagSet: TagSet;            
+        }
+        export interface TargetGrant {
+            Grantee?: Grantee;            
+            Permission?: BucketLogsPermission;            
+        }
+        export interface TopicConfiguration {
+            Id?: NotificationId;            
+            TopicArn: TopicArn;            
+            Events: EventList;            
+            Filter?: NotificationConfigurationFilter;            
+        }
+        export interface TopicConfigurationDeprecated {
+            Id?: NotificationId;            
+            Events?: EventList;            
+            Event?: Event;            
+            Topic?: TopicArn;            
+        }
+        export interface Transition {
+            Date?: Date;            
+            Days?: Days;            
+            StorageClass?: TransitionStorageClass;            
+        }
+        export interface UploadPartCopyOutput {
+            CopySourceVersionId?: CopySourceVersionId;            
+            CopyPartResult?: CopyPartResult;            
+            ServerSideEncryption?: ServerSideEncryption;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface UploadPartCopyRequest {
+            Bucket: BucketName;            
+            CopySource: CopySource;            
+            CopySourceIfMatch?: CopySourceIfMatch;            
+            CopySourceIfModifiedSince?: CopySourceIfModifiedSince;            
+            CopySourceIfNoneMatch?: CopySourceIfNoneMatch;            
+            CopySourceIfUnmodifiedSince?: CopySourceIfUnmodifiedSince;            
+            CopySourceRange?: CopySourceRange;            
+            Key: ObjectKey;            
+            PartNumber: PartNumber;            
+            UploadId: MultipartUploadId;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            CopySourceSSECustomerAlgorithm?: CopySourceSSECustomerAlgorithm;            
+            CopySourceSSECustomerKey?: CopySourceSSECustomerKey;            
+            CopySourceSSECustomerKeyMD5?: CopySourceSSECustomerKeyMD5;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface UploadPartOutput {
+            ServerSideEncryption?: ServerSideEncryption;            
+            ETag?: ETag;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            SSEKMSKeyId?: SSEKMSKeyId;            
+            RequestCharged?: RequestCharged;            
+        }
+        export interface UploadPartRequest {
+            Body?: Body;            
+            Bucket: BucketName;            
+            ContentLength?: ContentLength;            
+            ContentMD5?: ContentMD5;            
+            Key: ObjectKey;            
+            PartNumber: PartNumber;            
+            UploadId: MultipartUploadId;            
+            SSECustomerAlgorithm?: SSECustomerAlgorithm;            
+            SSECustomerKey?: SSECustomerKey;            
+            SSECustomerKeyMD5?: SSECustomerKeyMD5;            
+            RequestPayer?: RequestPayer;            
+        }
+        export interface VersioningConfiguration {
+            MFADelete?: MFADelete;            
+            Status?: BucketVersioningStatus;            
+        }
+        export interface WebsiteConfiguration {
+            ErrorDocument?: ErrorDocument;            
+            IndexDocument?: IndexDocument;            
+            RedirectAllRequestsTo?: RedirectAllRequestsTo;            
+            RoutingRules?: RoutingRules;            
+        }
 
-    export type S3Grants = Array<S3Grant>;
-    export interface S3HeadBucketRequest {
-        Bucket: S3BucketName;
     }
-
-    export interface S3HeadObjectOutput {
-        DeleteMarker?: S3DeleteMarker;
-        AcceptRanges?: S3AcceptRanges;
-        Expiration?: S3Expiration;
-        Restore?: S3Restore;
-        LastModified?: S3LastModified;
-        ContentLength?: S3ContentLength;
-        ETag?: S3ETag;
-        MissingMeta?: S3MissingMeta;
-        VersionId?: S3ObjectVersionId;
-        CacheControl?: S3CacheControl;
-        ContentDisposition?: S3ContentDisposition;
-        ContentEncoding?: S3ContentEncoding;
-        ContentLanguage?: S3ContentLanguage;
-        ContentType?: S3ContentType;
-        Expires?: S3Expires;
-        WebsiteRedirectLocation?: S3WebsiteRedirectLocation;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        Metadata?: S3Metadata;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        StorageClass?: S3StorageClass;
-        RequestCharged?: S3RequestCharged;
-        ReplicationStatus?: S3ReplicationStatus;
-    }
-
-    export interface S3HeadObjectRequest {
-        Bucket: S3BucketName;
-        IfMatch?: S3IfMatch;
-        IfModifiedSince?: S3IfModifiedSince;
-        IfNoneMatch?: S3IfNoneMatch;
-        IfUnmodifiedSince?: S3IfUnmodifiedSince;
-        Key: S3ObjectKey;
-        Range?: S3Range;
-        VersionId?: S3ObjectVersionId;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export type S3HostName = string;
-    export type S3HttpErrorCodeReturnedEquals = string;
-    export type S3HttpRedirectCode = string;
-    export type S3ID = string;
-    export type S3IfMatch = string;
-    export type S3IfModifiedSince = number;
-    export type S3IfNoneMatch = string;
-    export type S3IfUnmodifiedSince = number;
-    export interface S3IndexDocument {
-        Suffix: S3Suffix;
-    }
-
-    export type S3Initiated = number;
-    export interface S3Initiator {
-        ID?: S3ID;
-        DisplayName?: S3DisplayName;
-    }
-
-    export type S3IsLatest = boolean;
-    export type S3IsTruncated = boolean;
-    export type S3KeyMarker = string;
-    export type S3KeyPrefixEquals = string;
-    export type S3LambdaFunctionArn = string;
-    export interface S3LambdaFunctionConfiguration {
-        Id?: S3NotificationId;
-        LambdaFunctionArn: S3LambdaFunctionArn;
-        Events: S3EventList;
-        Filter?: S3NotificationConfigurationFilter;
-    }
-
-    export type S3LambdaFunctionConfigurationList = Array<S3LambdaFunctionConfiguration>;
-    export type S3LastModified = number;
-    export interface S3LifecycleConfiguration {
-        Rules: S3Rules;
-    }
-
-    export interface S3LifecycleExpiration {
-        Date?: S3Date;
-        Days?: S3Days;
-    }
-
-    export interface S3LifecycleRule {
-        Expiration?: S3LifecycleExpiration;
-        ID?: S3ID;
-        Prefix: S3Prefix;
-        Status: S3ExpirationStatus;
-        Transitions?: S3TransitionList;
-        NoncurrentVersionTransitions?: S3NoncurrentVersionTransitionList;
-        NoncurrentVersionExpiration?: S3NoncurrentVersionExpiration;
-    }
-
-    export type S3LifecycleRules = Array<S3LifecycleRule>;
-    export interface S3ListBucketsOutput {
-        Buckets?: S3Buckets;
-        Owner?: S3Owner;
-    }
-
-    export interface S3ListMultipartUploadsOutput {
-        Bucket?: S3BucketName;
-        KeyMarker?: S3KeyMarker;
-        UploadIdMarker?: S3UploadIdMarker;
-        NextKeyMarker?: S3NextKeyMarker;
-        Prefix?: S3Prefix;
-        Delimiter?: S3Delimiter;
-        NextUploadIdMarker?: S3NextUploadIdMarker;
-        MaxUploads?: S3MaxUploads;
-        IsTruncated?: S3IsTruncated;
-        Uploads?: S3MultipartUploadList;
-        CommonPrefixes?: S3CommonPrefixList;
-        EncodingType?: S3EncodingType;
-    }
-
-    export interface S3ListMultipartUploadsRequest {
-        Bucket: S3BucketName;
-        Delimiter?: S3Delimiter;
-        EncodingType?: S3EncodingType;
-        KeyMarker?: S3KeyMarker;
-        MaxUploads?: S3MaxUploads;
-        Prefix?: S3Prefix;
-        UploadIdMarker?: S3UploadIdMarker;
-    }
-
-    export interface S3ListObjectVersionsOutput {
-        IsTruncated?: S3IsTruncated;
-        KeyMarker?: S3KeyMarker;
-        VersionIdMarker?: S3VersionIdMarker;
-        NextKeyMarker?: S3NextKeyMarker;
-        NextVersionIdMarker?: S3NextVersionIdMarker;
-        Versions?: S3ObjectVersionList;
-        DeleteMarkers?: S3DeleteMarkers;
-        Name?: S3BucketName;
-        Prefix?: S3Prefix;
-        Delimiter?: S3Delimiter;
-        MaxKeys?: S3MaxKeys;
-        CommonPrefixes?: S3CommonPrefixList;
-        EncodingType?: S3EncodingType;
-    }
-
-    export interface S3ListObjectVersionsRequest {
-        Bucket: S3BucketName;
-        Delimiter?: S3Delimiter;
-        EncodingType?: S3EncodingType;
-        KeyMarker?: S3KeyMarker;
-        MaxKeys?: S3MaxKeys;
-        Prefix?: S3Prefix;
-        VersionIdMarker?: S3VersionIdMarker;
-    }
-
-    export interface S3ListObjectsOutput {
-        IsTruncated?: S3IsTruncated;
-        Marker?: S3Marker;
-        NextMarker?: S3NextMarker;
-        Contents?: S3ObjectList;
-        Name?: S3BucketName;
-        Prefix?: S3Prefix;
-        Delimiter?: S3Delimiter;
-        MaxKeys?: S3MaxKeys;
-        CommonPrefixes?: S3CommonPrefixList;
-        EncodingType?: S3EncodingType;
-    }
-
-    export interface S3ListObjectsRequest {
-        Bucket: S3BucketName;
-        Delimiter?: S3Delimiter;
-        EncodingType?: S3EncodingType;
-        Marker?: S3Marker;
-        MaxKeys?: S3MaxKeys;
-        Prefix?: S3Prefix;
-    }
-
-    export interface S3ListPartsOutput {
-        Bucket?: S3BucketName;
-        Key?: S3ObjectKey;
-        UploadId?: S3MultipartUploadId;
-        PartNumberMarker?: S3PartNumberMarker;
-        NextPartNumberMarker?: S3NextPartNumberMarker;
-        MaxParts?: S3MaxParts;
-        IsTruncated?: S3IsTruncated;
-        Parts?: S3Parts;
-        Initiator?: S3Initiator;
-        Owner?: S3Owner;
-        StorageClass?: S3StorageClass;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3ListPartsRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        MaxParts?: S3MaxParts;
-        PartNumberMarker?: S3PartNumberMarker;
-        UploadId: S3MultipartUploadId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export type S3Location = string;
-    export interface S3LoggingEnabled {
-        TargetBucket?: S3TargetBucket;
-        TargetGrants?: S3TargetGrants;
-        TargetPrefix?: S3TargetPrefix;
-    }
-
-    export type S3MFA = string;
-    export type S3MFADelete = string;
-    export type S3MFADeleteStatus = string;
-    export type S3Marker = string;
-    export type S3MaxAgeSeconds = number;
-    export type S3MaxKeys = number;
-    export type S3MaxParts = number;
-    export type S3MaxUploads = number;
-    export type S3Message = string;
-    export type S3Metadata = any; // not really - it was 'map' instead - must fix this one
-    export type S3MetadataDirective = string;
-    export type S3MetadataKey = string;
-    export type S3MetadataValue = string;
-    export type S3MissingMeta = number;
-    export interface S3MultipartUpload {
-        UploadId?: S3MultipartUploadId;
-        Key?: S3ObjectKey;
-        Initiated?: S3Initiated;
-        StorageClass?: S3StorageClass;
-        Owner?: S3Owner;
-        Initiator?: S3Initiator;
-    }
-
-    export type S3MultipartUploadId = string;
-    export type S3MultipartUploadList = Array<S3MultipartUpload>;
-    export type S3NextKeyMarker = string;
-    export type S3NextMarker = string;
-    export type S3NextPartNumberMarker = number;
-    export type S3NextUploadIdMarker = string;
-    export type S3NextVersionIdMarker = string;
-    export interface S3NoSuchBucket {
-    }
-
-    export interface S3NoSuchKey {
-    }
-
-    export interface S3NoSuchUpload {
-    }
-
-    export interface S3NoncurrentVersionExpiration {
-        NoncurrentDays?: S3Days;
-    }
-
-    export interface S3NoncurrentVersionTransition {
-        NoncurrentDays?: S3Days;
-        StorageClass?: S3TransitionStorageClass;
-    }
-
-    export type S3NoncurrentVersionTransitionList = Array<S3NoncurrentVersionTransition>;
-    export interface S3NotificationConfiguration {
-        TopicConfigurations?: S3TopicConfigurationList;
-        QueueConfigurations?: S3QueueConfigurationList;
-        LambdaFunctionConfigurations?: S3LambdaFunctionConfigurationList;
-    }
-
-    export interface S3NotificationConfigurationDeprecated {
-        TopicConfiguration?: S3TopicConfigurationDeprecated;
-        QueueConfiguration?: S3QueueConfigurationDeprecated;
-        CloudFunctionConfiguration?: S3CloudFunctionConfiguration;
-    }
-
-    export interface S3NotificationConfigurationFilter {
-        Key?: S3S3KeyFilter;
-    }
-
-    export type S3NotificationId = string;
-    export interface S3Object {
-        Key?: S3ObjectKey;
-        LastModified?: S3LastModified;
-        ETag?: S3ETag;
-        Size?: S3Size;
-        StorageClass?: S3ObjectStorageClass;
-        Owner?: S3Owner;
-    }
-
-    export interface S3ObjectAlreadyInActiveTierError {
-    }
-
-    export type S3ObjectCannedACL = string;
-    export interface S3ObjectIdentifier {
-        Key: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-    }
-
-    export type S3ObjectIdentifierList = Array<S3ObjectIdentifier>;
-    export type S3ObjectKey = string;
-    export type S3ObjectList = Array<S3Object>;
-    export interface S3ObjectNotInActiveTierError {
-    }
-
-    export type S3ObjectStorageClass = string;
-    export interface S3ObjectVersion {
-        ETag?: S3ETag;
-        Size?: S3Size;
-        StorageClass?: S3ObjectVersionStorageClass;
-        Key?: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-        IsLatest?: S3IsLatest;
-        LastModified?: S3LastModified;
-        Owner?: S3Owner;
-    }
-
-    export type S3ObjectVersionId = string;
-    export type S3ObjectVersionList = Array<S3ObjectVersion>;
-    export type S3ObjectVersionStorageClass = string;
-    export interface S3Owner {
-        DisplayName?: S3DisplayName;
-        ID?: S3ID;
-    }
-
-    export interface S3Part {
-        PartNumber?: S3PartNumber;
-        LastModified?: S3LastModified;
-        ETag?: S3ETag;
-        Size?: S3Size;
-    }
-
-    export type S3PartNumber = number;
-    export type S3PartNumberMarker = number;
-    export type S3Parts = Array<S3Part>;
-    export type S3Payer = string;
-    export type S3Permission = string;
-    export type S3Policy = string;
-    export type S3Prefix = string;
-    export type S3Protocol = string;
-    export interface S3PutBucketAclRequest {
-        ACL?: S3BucketCannedACL;
-        AccessControlPolicy?: S3AccessControlPolicy;
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        GrantFullControl?: S3GrantFullControl;
-        GrantRead?: S3GrantRead;
-        GrantReadACP?: S3GrantReadACP;
-        GrantWrite?: S3GrantWrite;
-        GrantWriteACP?: S3GrantWriteACP;
-    }
-
-    export interface S3PutBucketCorsRequest {
-        Bucket: S3BucketName;
-        CORSConfiguration: S3CORSConfiguration;
-        ContentMD5?: S3ContentMD5;
-    }
-
-    export interface S3PutBucketLifecycleConfigurationRequest {
-        Bucket: S3BucketName;
-        LifecycleConfiguration?: S3BucketLifecycleConfiguration;
-    }
-
-    export interface S3PutBucketLifecycleRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        LifecycleConfiguration?: S3LifecycleConfiguration;
-    }
-
-    export interface S3PutBucketLoggingRequest {
-        Bucket: S3BucketName;
-        BucketLoggingStatus: S3BucketLoggingStatus;
-        ContentMD5?: S3ContentMD5;
-    }
-
-    export interface S3PutBucketNotificationConfigurationRequest {
-        Bucket: S3BucketName;
-        NotificationConfiguration: S3NotificationConfiguration;
-    }
-
-    export interface S3PutBucketNotificationRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        NotificationConfiguration: S3NotificationConfigurationDeprecated;
-    }
-
-    export interface S3PutBucketPolicyRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        Policy: S3Policy;
-    }
-
-    export interface S3PutBucketReplicationRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        ReplicationConfiguration: S3ReplicationConfiguration;
-    }
-
-    export interface S3PutBucketRequestPaymentRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        RequestPaymentConfiguration: S3RequestPaymentConfiguration;
-    }
-
-    export interface S3PutBucketTaggingRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        Tagging: S3Tagging;
-    }
-
-    export interface S3PutBucketVersioningRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        MFA?: S3MFA;
-        VersioningConfiguration: S3VersioningConfiguration;
-    }
-
-    export interface S3PutBucketWebsiteRequest {
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        WebsiteConfiguration: S3WebsiteConfiguration;
-    }
-
-    export interface S3PutObjectAclOutput {
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3PutObjectAclRequest {
-        ACL?: S3ObjectCannedACL;
-        AccessControlPolicy?: S3AccessControlPolicy;
-        Bucket: S3BucketName;
-        ContentMD5?: S3ContentMD5;
-        GrantFullControl?: S3GrantFullControl;
-        GrantRead?: S3GrantRead;
-        GrantReadACP?: S3GrantReadACP;
-        GrantWrite?: S3GrantWrite;
-        GrantWriteACP?: S3GrantWriteACP;
-        Key: S3ObjectKey;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3PutObjectOutput {
-        Expiration?: S3Expiration;
-        ETag?: S3ETag;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        VersionId?: S3ObjectVersionId;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3PutObjectRequest {
-        ACL?: S3ObjectCannedACL;
-        Body?: S3Body;
-        Bucket: S3BucketName;
-        CacheControl?: S3CacheControl;
-        ContentDisposition?: S3ContentDisposition;
-        ContentEncoding?: S3ContentEncoding;
-        ContentLanguage?: S3ContentLanguage;
-        ContentLength?: S3ContentLength;
-        ContentMD5?: S3ContentMD5;
-        ContentType?: S3ContentType;
-        Expires?: S3Expires;
-        GrantFullControl?: S3GrantFullControl;
-        GrantRead?: S3GrantRead;
-        GrantReadACP?: S3GrantReadACP;
-        GrantWriteACP?: S3GrantWriteACP;
-        Key: S3ObjectKey;
-        Metadata?: S3Metadata;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        StorageClass?: S3StorageClass;
-        WebsiteRedirectLocation?: S3WebsiteRedirectLocation;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export type S3QueueArn = string;
-    export interface S3QueueConfiguration {
-        Id?: S3NotificationId;
-        QueueArn: S3QueueArn;
-        Events: S3EventList;
-        Filter?: S3NotificationConfigurationFilter;
-    }
-
-    export interface S3QueueConfigurationDeprecated {
-        Id?: S3NotificationId;
-        Event?: S3Event;
-        Events?: S3EventList;
-        Queue?: S3QueueArn;
-    }
-
-    export type S3QueueConfigurationList = Array<S3QueueConfiguration>;
-    export type S3Quiet = boolean;
-    export type S3Range = string;
-    export interface S3Redirect {
-        HostName?: S3HostName;
-        HttpRedirectCode?: S3HttpRedirectCode;
-        Protocol?: S3Protocol;
-        ReplaceKeyPrefixWith?: S3ReplaceKeyPrefixWith;
-        ReplaceKeyWith?: S3ReplaceKeyWith;
-    }
-
-    export interface S3RedirectAllRequestsTo {
-        HostName: S3HostName;
-        Protocol?: S3Protocol;
-    }
-
-    export type S3ReplaceKeyPrefixWith = string;
-    export type S3ReplaceKeyWith = string;
-    export interface S3ReplicationConfiguration {
-        Role: S3Role;
-        Rules: S3ReplicationRules;
-    }
-
-    export interface S3ReplicationRule {
-        ID?: S3ID;
-        Prefix: S3Prefix;
-        Status: S3ReplicationRuleStatus;
-        Destination: S3Destination;
-    }
-
-    export type S3ReplicationRuleStatus = string;
-    export type S3ReplicationRules = Array<S3ReplicationRule>;
-    export type S3ReplicationStatus = string;
-    export type S3RequestCharged = string;
-    export type S3RequestPayer = string;
-    export interface S3RequestPaymentConfiguration {
-        Payer: S3Payer;
-    }
-
-    export type S3ResponseCacheControl = string;
-    export type S3ResponseContentDisposition = string;
-    export type S3ResponseContentEncoding = string;
-    export type S3ResponseContentLanguage = string;
-    export type S3ResponseContentType = string;
-    export type S3ResponseExpires = number;
-    export type S3Restore = string;
-    export interface S3RestoreObjectOutput {
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3RestoreObjectRequest {
-        Bucket: S3BucketName;
-        Key: S3ObjectKey;
-        VersionId?: S3ObjectVersionId;
-        RestoreRequest?: S3RestoreRequest;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3RestoreRequest {
-        Days: S3Days;
-    }
-
-    export type S3Role = string;
-    export interface S3RoutingRule {
-        Condition?: S3Condition;
-        Redirect: S3Redirect;
-    }
-
-    export type S3RoutingRules = Array<S3RoutingRule>;
-    export interface S3Rule {
-        Expiration?: S3LifecycleExpiration;
-        ID?: S3ID;
-        Prefix: S3Prefix;
-        Status: S3ExpirationStatus;
-        Transition?: S3Transition;
-        NoncurrentVersionTransition?: S3NoncurrentVersionTransition;
-        NoncurrentVersionExpiration?: S3NoncurrentVersionExpiration;
-    }
-
-    export type S3Rules = Array<S3Rule>;
-    export interface S3S3KeyFilter {
-        FilterRules?: S3FilterRuleList;
-    }
-
-    export type S3SSECustomerAlgorithm = string;
-    export type S3SSECustomerKey = any; // not really - it was 'blob' instead - must fix this one
-    export type S3SSECustomerKeyMD5 = string;
-    export type S3SSEKMSKeyId = string;
-    export type S3ServerSideEncryption = string;
-    export type S3Size = number;
-    export type S3StorageClass = string;
-    export type S3Suffix = string;
-    export interface S3Tag {
-        Key: S3ObjectKey;
-        Value: S3Value;
-    }
-
-    export type S3TagSet = Array<S3Tag>;
-    export interface S3Tagging {
-        TagSet: S3TagSet;
-    }
-
-    export type S3TargetBucket = string;
-    export interface S3TargetGrant {
-        Grantee?: S3Grantee;
-        Permission?: S3BucketLogsPermission;
-    }
-
-    export type S3TargetGrants = Array<S3TargetGrant>;
-    export type S3TargetPrefix = string;
-    export type S3TopicArn = string;
-    export interface S3TopicConfiguration {
-        Id?: S3NotificationId;
-        TopicArn: S3TopicArn;
-        Events: S3EventList;
-        Filter?: S3NotificationConfigurationFilter;
-    }
-
-    export interface S3TopicConfigurationDeprecated {
-        Id?: S3NotificationId;
-        Events?: S3EventList;
-        Event?: S3Event;
-        Topic?: S3TopicArn;
-    }
-
-    export type S3TopicConfigurationList = Array<S3TopicConfiguration>;
-    export interface S3Transition {
-        Date?: S3Date;
-        Days?: S3Days;
-        StorageClass?: S3TransitionStorageClass;
-    }
-
-    export type S3TransitionList = Array<S3Transition>;
-    export type S3TransitionStorageClass = string;
-    export type S3Type = string;
-    export type S3URI = string;
-    export type S3UploadIdMarker = string;
-    export interface S3UploadPartCopyOutput {
-        CopySourceVersionId?: S3CopySourceVersionId;
-        CopyPartResult?: S3CopyPartResult;
-        ServerSideEncryption?: S3ServerSideEncryption;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3UploadPartCopyRequest {
-        Bucket: S3BucketName;
-        CopySource: S3CopySource;
-        CopySourceIfMatch?: S3CopySourceIfMatch;
-        CopySourceIfModifiedSince?: S3CopySourceIfModifiedSince;
-        CopySourceIfNoneMatch?: S3CopySourceIfNoneMatch;
-        CopySourceIfUnmodifiedSince?: S3CopySourceIfUnmodifiedSince;
-        CopySourceRange?: S3CopySourceRange;
-        Key: S3ObjectKey;
-        PartNumber: S3PartNumber;
-        UploadId: S3MultipartUploadId;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        CopySourceSSECustomerAlgorithm?: S3CopySourceSSECustomerAlgorithm;
-        CopySourceSSECustomerKey?: S3CopySourceSSECustomerKey;
-        CopySourceSSECustomerKeyMD5?: S3CopySourceSSECustomerKeyMD5;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export interface S3UploadPartOutput {
-        ServerSideEncryption?: S3ServerSideEncryption;
-        ETag?: S3ETag;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        SSEKMSKeyId?: S3SSEKMSKeyId;
-        RequestCharged?: S3RequestCharged;
-    }
-
-    export interface S3UploadPartRequest {
-        Body?: S3Body;
-        Bucket: S3BucketName;
-        ContentLength?: S3ContentLength;
-        ContentMD5?: S3ContentMD5;
-        Key: S3ObjectKey;
-        PartNumber: S3PartNumber;
-        UploadId: S3MultipartUploadId;
-        SSECustomerAlgorithm?: S3SSECustomerAlgorithm;
-        SSECustomerKey?: S3SSECustomerKey;
-        SSECustomerKeyMD5?: S3SSECustomerKeyMD5;
-        RequestPayer?: S3RequestPayer;
-    }
-
-    export type S3Value = string;
-    export type S3VersionIdMarker = string;
-    export interface S3VersioningConfiguration {
-        MFADelete?: S3MFADelete;
-        Status?: S3BucketVersioningStatus;
-    }
-
-    export interface S3WebsiteConfiguration {
-        ErrorDocument?: S3ErrorDocument;
-        IndexDocument?: S3IndexDocument;
-        RedirectAllRequestsTo?: S3RedirectAllRequestsTo;
-        RoutingRules?: S3RoutingRules;
-    }
-
-    export type S3WebsiteRedirectLocation = string;
 }

--- a/output/aws-sns.d.ts
+++ b/output/aws-sns.d.ts
@@ -6,317 +6,266 @@ declare module "aws-sdk" {
 
     export class SNS extends Service {
       constructor(options?: any);
-      addPermission(params: SNSAddPermissionInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: any) => void): Request;
-      confirmSubscription(params: SNSConfirmSubscriptionInput, callback?: (err: SNSSubscriptionLimitExceededException|SNSInvalidParameterException|SNSNotFoundException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: SNSConfirmSubscriptionResponse|any) => void): Request;
-      createPlatformApplication(params: SNSCreatePlatformApplicationInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: SNSCreatePlatformApplicationResponse|any) => void): Request;
-      createPlatformEndpoint(params: SNSCreatePlatformEndpointInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: SNSCreateEndpointResponse|any) => void): Request;
-      createTopic(params: SNSCreateTopicInput, callback?: (err: SNSInvalidParameterException|SNSTopicLimitExceededException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: SNSCreateTopicResponse|any) => void): Request;
-      deleteEndpoint(params: SNSDeleteEndpointInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: any) => void): Request;
-      deletePlatformApplication(params: SNSDeletePlatformApplicationInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: any) => void): Request;
-      deleteTopic(params: SNSDeleteTopicInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: any) => void): Request;
-      getEndpointAttributes(params: SNSGetEndpointAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: SNSGetEndpointAttributesResponse|any) => void): Request;
-      getPlatformApplicationAttributes(params: SNSGetPlatformApplicationAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: SNSGetPlatformApplicationAttributesResponse|any) => void): Request;
-      getSubscriptionAttributes(params: SNSGetSubscriptionAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSNotFoundException|SNSAuthorizationErrorException|any, data: SNSGetSubscriptionAttributesResponse|any) => void): Request;
-      getTopicAttributes(params: SNSGetTopicAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSNotFoundException|SNSAuthorizationErrorException|any, data: SNSGetTopicAttributesResponse|any) => void): Request;
-      listEndpointsByPlatformApplication(params: SNSListEndpointsByPlatformApplicationInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: SNSListEndpointsByPlatformApplicationResponse|any) => void): Request;
-      listPlatformApplications(params: SNSListPlatformApplicationsInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: SNSListPlatformApplicationsResponse|any) => void): Request;
-      listSubscriptions(params: SNSListSubscriptionsInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: SNSListSubscriptionsResponse|any) => void): Request;
-      listSubscriptionsByTopic(params: SNSListSubscriptionsByTopicInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSNotFoundException|SNSAuthorizationErrorException|any, data: SNSListSubscriptionsByTopicResponse|any) => void): Request;
-      listTopics(params: SNSListTopicsInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|any, data: SNSListTopicsResponse|any) => void): Request;
-      publish(params: SNSPublishInput, callback?: (err: SNSInvalidParameterException|SNSInvalidParameterValueException|SNSInternalErrorException|SNSNotFoundException|SNSEndpointDisabledException|SNSPlatformApplicationDisabledException|SNSAuthorizationErrorException|any, data: SNSPublishResponse|any) => void): Request;
-      removePermission(params: SNSRemovePermissionInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: any) => void): Request;
-      setEndpointAttributes(params: SNSSetEndpointAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: any) => void): Request;
-      setPlatformApplicationAttributes(params: SNSSetPlatformApplicationAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: any) => void): Request;
-      setSubscriptionAttributes(params: SNSSetSubscriptionAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSNotFoundException|SNSAuthorizationErrorException|any, data: any) => void): Request;
-      setTopicAttributes(params: SNSSetTopicAttributesInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSNotFoundException|SNSAuthorizationErrorException|any, data: any) => void): Request;
-      subscribe(params: SNSSubscribeInput, callback?: (err: SNSSubscriptionLimitExceededException|SNSInvalidParameterException|SNSInternalErrorException|SNSNotFoundException|SNSAuthorizationErrorException|any, data: SNSSubscribeResponse|any) => void): Request;
-      unsubscribe(params: SNSUnsubscribeInput, callback?: (err: SNSInvalidParameterException|SNSInternalErrorException|SNSAuthorizationErrorException|SNSNotFoundException|any, data: any) => void): Request;
+      addPermission(params: SNS.AddPermissionInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: any) => void): Request;
+      confirmSubscription(params: SNS.ConfirmSubscriptionInput, callback?: (err: SNS.SubscriptionLimitExceededException|SNS.InvalidParameterException|SNS.NotFoundException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: SNS.ConfirmSubscriptionResponse|any) => void): Request;
+      createPlatformApplication(params: SNS.CreatePlatformApplicationInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: SNS.CreatePlatformApplicationResponse|any) => void): Request;
+      createPlatformEndpoint(params: SNS.CreatePlatformEndpointInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: SNS.CreateEndpointResponse|any) => void): Request;
+      createTopic(params: SNS.CreateTopicInput, callback?: (err: SNS.InvalidParameterException|SNS.TopicLimitExceededException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: SNS.CreateTopicResponse|any) => void): Request;
+      deleteEndpoint(params: SNS.DeleteEndpointInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: any) => void): Request;
+      deletePlatformApplication(params: SNS.DeletePlatformApplicationInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: any) => void): Request;
+      deleteTopic(params: SNS.DeleteTopicInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: any) => void): Request;
+      getEndpointAttributes(params: SNS.GetEndpointAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: SNS.GetEndpointAttributesResponse|any) => void): Request;
+      getPlatformApplicationAttributes(params: SNS.GetPlatformApplicationAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: SNS.GetPlatformApplicationAttributesResponse|any) => void): Request;
+      getSubscriptionAttributes(params: SNS.GetSubscriptionAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.NotFoundException|SNS.AuthorizationErrorException|any, data: SNS.GetSubscriptionAttributesResponse|any) => void): Request;
+      getTopicAttributes(params: SNS.GetTopicAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.NotFoundException|SNS.AuthorizationErrorException|any, data: SNS.GetTopicAttributesResponse|any) => void): Request;
+      listEndpointsByPlatformApplication(params: SNS.ListEndpointsByPlatformApplicationInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: SNS.ListEndpointsByPlatformApplicationResponse|any) => void): Request;
+      listPlatformApplications(params: SNS.ListPlatformApplicationsInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: SNS.ListPlatformApplicationsResponse|any) => void): Request;
+      listSubscriptions(params: SNS.ListSubscriptionsInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: SNS.ListSubscriptionsResponse|any) => void): Request;
+      listSubscriptionsByTopic(params: SNS.ListSubscriptionsByTopicInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.NotFoundException|SNS.AuthorizationErrorException|any, data: SNS.ListSubscriptionsByTopicResponse|any) => void): Request;
+      listTopics(params: SNS.ListTopicsInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|any, data: SNS.ListTopicsResponse|any) => void): Request;
+      publish(params: SNS.PublishInput, callback?: (err: SNS.InvalidParameterException|SNS.InvalidParameterValueException|SNS.InternalErrorException|SNS.NotFoundException|SNS.EndpointDisabledException|SNS.PlatformApplicationDisabledException|SNS.AuthorizationErrorException|any, data: SNS.PublishResponse|any) => void): Request;
+      removePermission(params: SNS.RemovePermissionInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: any) => void): Request;
+      setEndpointAttributes(params: SNS.SetEndpointAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: any) => void): Request;
+      setPlatformApplicationAttributes(params: SNS.SetPlatformApplicationAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: any) => void): Request;
+      setSubscriptionAttributes(params: SNS.SetSubscriptionAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.NotFoundException|SNS.AuthorizationErrorException|any, data: any) => void): Request;
+      setTopicAttributes(params: SNS.SetTopicAttributesInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.NotFoundException|SNS.AuthorizationErrorException|any, data: any) => void): Request;
+      subscribe(params: SNS.SubscribeInput, callback?: (err: SNS.SubscriptionLimitExceededException|SNS.InvalidParameterException|SNS.InternalErrorException|SNS.NotFoundException|SNS.AuthorizationErrorException|any, data: SNS.SubscribeResponse|any) => void): Request;
+      unsubscribe(params: SNS.UnsubscribeInput, callback?: (err: SNS.InvalidParameterException|SNS.InternalErrorException|SNS.AuthorizationErrorException|SNS.NotFoundException|any, data: any) => void): Request;
     }
+    
+    export module SNS {
+        export type ActionsList = action[];
+        export type Binary = any;    // type: blob
+        export type DelegatesList = delegate[];
+        export type ListOfEndpoints = Endpoint[];
+        export type ListOfPlatformApplications = PlatformApplication[];
+        export type MapStringToString = {[key:string]: String};
+        export type MessageAttributeMap = {[key:string]: MessageAttributeValue};
+        export type String = string;
+        export type SubscriptionAttributesMap = {[key:string]: attributeValue};
+        export type SubscriptionsList = Subscription[];
+        export type TopicAttributesMap = {[key:string]: attributeValue};
+        export type TopicsList = Topic[];
+        export type account = string;
+        export type action = string;
+        export type attributeName = string;
+        export type attributeValue = string;
+        export type authenticateOnUnsubscribe = string;
+        export type delegate = string;
+        export type endpoint = string;
+        export type label = string;
+        export type message = string;
+        export type messageId = string;
+        export type messageStructure = string;
+        export type nextToken = string;
+        export type protocol = string;
+        export type subject = string;
+        export type subscriptionARN = string;
+        export type token = string;
+        export type topicARN = string;
+        export type topicName = string;
 
-    export type SNSActionsList = Array<SNSaction>;
-    export interface SNSAddPermissionInput {
-        TopicArn: SNStopicARN;
-        Label: SNSlabel;
-        AWSAccountId: SNSDelegatesList;
-        ActionName: SNSActionsList;
+        export interface AddPermissionInput {
+            TopicArn: topicARN;            
+            Label: label;            
+            AWSAccountId: DelegatesList;            
+            ActionName: ActionsList;            
+        }
+        export interface AuthorizationErrorException {
+            message?: string;            
+        }
+        export interface ConfirmSubscriptionInput {
+            TopicArn: topicARN;            
+            Token: token;            
+            AuthenticateOnUnsubscribe?: authenticateOnUnsubscribe;            
+        }
+        export interface ConfirmSubscriptionResponse {
+            SubscriptionArn?: subscriptionARN;            
+        }
+        export interface CreateEndpointResponse {
+            EndpointArn?: String;            
+        }
+        export interface CreatePlatformApplicationInput {
+            Name: String;            
+            Platform: String;            
+            Attributes: MapStringToString;            
+        }
+        export interface CreatePlatformApplicationResponse {
+            PlatformApplicationArn?: String;            
+        }
+        export interface CreatePlatformEndpointInput {
+            PlatformApplicationArn: String;            
+            Token: String;            
+            CustomUserData?: String;            
+            Attributes?: MapStringToString;            
+        }
+        export interface CreateTopicInput {
+            Name: topicName;            
+        }
+        export interface CreateTopicResponse {
+            TopicArn?: topicARN;            
+        }
+        export interface DeleteEndpointInput {
+            EndpointArn: String;            
+        }
+        export interface DeletePlatformApplicationInput {
+            PlatformApplicationArn: String;            
+        }
+        export interface DeleteTopicInput {
+            TopicArn: topicARN;            
+        }
+        export interface Endpoint {
+            EndpointArn?: String;            
+            Attributes?: MapStringToString;            
+        }
+        export interface EndpointDisabledException {
+            message?: string;            
+        }
+        export interface GetEndpointAttributesInput {
+            EndpointArn: String;            
+        }
+        export interface GetEndpointAttributesResponse {
+            Attributes?: MapStringToString;            
+        }
+        export interface GetPlatformApplicationAttributesInput {
+            PlatformApplicationArn: String;            
+        }
+        export interface GetPlatformApplicationAttributesResponse {
+            Attributes?: MapStringToString;            
+        }
+        export interface GetSubscriptionAttributesInput {
+            SubscriptionArn: subscriptionARN;            
+        }
+        export interface GetSubscriptionAttributesResponse {
+            Attributes?: SubscriptionAttributesMap;            
+        }
+        export interface GetTopicAttributesInput {
+            TopicArn: topicARN;            
+        }
+        export interface GetTopicAttributesResponse {
+            Attributes?: TopicAttributesMap;            
+        }
+        export interface InternalErrorException {
+            message?: string;            
+        }
+        export interface InvalidParameterException {
+            message?: string;            
+        }
+        export interface InvalidParameterValueException {
+            message?: string;            
+        }
+        export interface ListEndpointsByPlatformApplicationInput {
+            PlatformApplicationArn: String;            
+            NextToken?: String;            
+        }
+        export interface ListEndpointsByPlatformApplicationResponse {
+            Endpoints?: ListOfEndpoints;            
+            NextToken?: String;            
+        }
+        export interface ListPlatformApplicationsInput {
+            NextToken?: String;            
+        }
+        export interface ListPlatformApplicationsResponse {
+            PlatformApplications?: ListOfPlatformApplications;            
+            NextToken?: String;            
+        }
+        export interface ListSubscriptionsByTopicInput {
+            TopicArn: topicARN;            
+            NextToken?: nextToken;            
+        }
+        export interface ListSubscriptionsByTopicResponse {
+            Subscriptions?: SubscriptionsList;            
+            NextToken?: nextToken;            
+        }
+        export interface ListSubscriptionsInput {
+            NextToken?: nextToken;            
+        }
+        export interface ListSubscriptionsResponse {
+            Subscriptions?: SubscriptionsList;            
+            NextToken?: nextToken;            
+        }
+        export interface ListTopicsInput {
+            NextToken?: nextToken;            
+        }
+        export interface ListTopicsResponse {
+            Topics?: TopicsList;            
+            NextToken?: nextToken;            
+        }
+        export interface MessageAttributeValue {
+            DataType: String;            
+            StringValue?: String;            
+            BinaryValue?: Binary;            
+        }
+        export interface NotFoundException {
+            message?: string;            
+        }
+        export interface PlatformApplication {
+            PlatformApplicationArn?: String;            
+            Attributes?: MapStringToString;            
+        }
+        export interface PlatformApplicationDisabledException {
+            message?: string;            
+        }
+        export interface PublishInput {
+            TopicArn?: topicARN;            
+            TargetArn?: String;            
+            Message: message;            
+            Subject?: subject;            
+            MessageStructure?: messageStructure;            
+            MessageAttributes?: MessageAttributeMap;            
+        }
+        export interface PublishResponse {
+            MessageId?: messageId;            
+        }
+        export interface RemovePermissionInput {
+            TopicArn: topicARN;            
+            Label: label;            
+        }
+        export interface SetEndpointAttributesInput {
+            EndpointArn: String;            
+            Attributes: MapStringToString;            
+        }
+        export interface SetPlatformApplicationAttributesInput {
+            PlatformApplicationArn: String;            
+            Attributes: MapStringToString;            
+        }
+        export interface SetSubscriptionAttributesInput {
+            SubscriptionArn: subscriptionARN;            
+            AttributeName: attributeName;            
+            AttributeValue?: attributeValue;            
+        }
+        export interface SetTopicAttributesInput {
+            TopicArn: topicARN;            
+            AttributeName: attributeName;            
+            AttributeValue?: attributeValue;            
+        }
+        export interface SubscribeInput {
+            TopicArn: topicARN;            
+            Protocol: protocol;            
+            Endpoint?: endpoint;            
+        }
+        export interface SubscribeResponse {
+            SubscriptionArn?: subscriptionARN;            
+        }
+        export interface Subscription {
+            SubscriptionArn?: subscriptionARN;            
+            Owner?: account;            
+            Protocol?: protocol;            
+            Endpoint?: endpoint;            
+            TopicArn?: topicARN;            
+        }
+        export interface SubscriptionLimitExceededException {
+            message?: string;            
+        }
+        export interface Topic {
+            TopicArn?: topicARN;            
+        }
+        export interface TopicLimitExceededException {
+            message?: string;            
+        }
+        export interface UnsubscribeInput {
+            SubscriptionArn: subscriptionARN;            
+        }
+
     }
-
-    export interface SNSAuthorizationErrorException {
-        message?: SNSstring;
-    }
-
-    export type SNSBinary = any; // not really - it was 'blob' instead - must fix this one
-    export interface SNSConfirmSubscriptionInput {
-        TopicArn: SNStopicARN;
-        Token: SNStoken;
-        AuthenticateOnUnsubscribe?: SNSauthenticateOnUnsubscribe;
-    }
-
-    export interface SNSConfirmSubscriptionResponse {
-        SubscriptionArn?: SNSsubscriptionARN;
-    }
-
-    export interface SNSCreateEndpointResponse {
-        EndpointArn?: SNSString;
-    }
-
-    export interface SNSCreatePlatformApplicationInput {
-        Name: SNSString;
-        Platform: SNSString;
-        Attributes: SNSMapStringToString;
-    }
-
-    export interface SNSCreatePlatformApplicationResponse {
-        PlatformApplicationArn?: SNSString;
-    }
-
-    export interface SNSCreatePlatformEndpointInput {
-        PlatformApplicationArn: SNSString;
-        Token: SNSString;
-        CustomUserData?: SNSString;
-        Attributes?: SNSMapStringToString;
-    }
-
-    export interface SNSCreateTopicInput {
-        Name: SNStopicName;
-    }
-
-    export interface SNSCreateTopicResponse {
-        TopicArn?: SNStopicARN;
-    }
-
-    export type SNSDelegatesList = Array<SNSdelegate>;
-    export interface SNSDeleteEndpointInput {
-        EndpointArn: SNSString;
-    }
-
-    export interface SNSDeletePlatformApplicationInput {
-        PlatformApplicationArn: SNSString;
-    }
-
-    export interface SNSDeleteTopicInput {
-        TopicArn: SNStopicARN;
-    }
-
-    export interface SNSEndpoint {
-        EndpointArn?: SNSString;
-        Attributes?: SNSMapStringToString;
-    }
-
-    export interface SNSEndpointDisabledException {
-        message?: SNSstring;
-    }
-
-    export interface SNSGetEndpointAttributesInput {
-        EndpointArn: SNSString;
-    }
-
-    export interface SNSGetEndpointAttributesResponse {
-        Attributes?: SNSMapStringToString;
-    }
-
-    export interface SNSGetPlatformApplicationAttributesInput {
-        PlatformApplicationArn: SNSString;
-    }
-
-    export interface SNSGetPlatformApplicationAttributesResponse {
-        Attributes?: SNSMapStringToString;
-    }
-
-    export interface SNSGetSubscriptionAttributesInput {
-        SubscriptionArn: SNSsubscriptionARN;
-    }
-
-    export interface SNSGetSubscriptionAttributesResponse {
-        Attributes?: SNSSubscriptionAttributesMap;
-    }
-
-    export interface SNSGetTopicAttributesInput {
-        TopicArn: SNStopicARN;
-    }
-
-    export interface SNSGetTopicAttributesResponse {
-        Attributes?: SNSTopicAttributesMap;
-    }
-
-    export interface SNSInternalErrorException {
-        message?: SNSstring;
-    }
-
-    export interface SNSInvalidParameterException {
-        message?: SNSstring;
-    }
-
-    export interface SNSInvalidParameterValueException {
-        message?: SNSstring;
-    }
-
-    export interface SNSListEndpointsByPlatformApplicationInput {
-        PlatformApplicationArn: SNSString;
-        NextToken?: SNSString;
-    }
-
-    export interface SNSListEndpointsByPlatformApplicationResponse {
-        Endpoints?: SNSListOfEndpoints;
-        NextToken?: SNSString;
-    }
-
-    export type SNSListOfEndpoints = Array<SNSEndpoint>;
-    export type SNSListOfPlatformApplications = Array<SNSPlatformApplication>;
-    export interface SNSListPlatformApplicationsInput {
-        NextToken?: SNSString;
-    }
-
-    export interface SNSListPlatformApplicationsResponse {
-        PlatformApplications?: SNSListOfPlatformApplications;
-        NextToken?: SNSString;
-    }
-
-    export interface SNSListSubscriptionsByTopicInput {
-        TopicArn: SNStopicARN;
-        NextToken?: SNSnextToken;
-    }
-
-    export interface SNSListSubscriptionsByTopicResponse {
-        Subscriptions?: SNSSubscriptionsList;
-        NextToken?: SNSnextToken;
-    }
-
-    export interface SNSListSubscriptionsInput {
-        NextToken?: SNSnextToken;
-    }
-
-    export interface SNSListSubscriptionsResponse {
-        Subscriptions?: SNSSubscriptionsList;
-        NextToken?: SNSnextToken;
-    }
-
-    export interface SNSListTopicsInput {
-        NextToken?: SNSnextToken;
-    }
-
-    export interface SNSListTopicsResponse {
-        Topics?: SNSTopicsList;
-        NextToken?: SNSnextToken;
-    }
-
-    export type SNSMapStringToString = any; // not really - it was 'map' instead - must fix this one
-    export type SNSMessageAttributeMap = any; // not really - it was 'map' instead - must fix this one
-    export interface SNSMessageAttributeValue {
-        DataType: SNSString;
-        StringValue?: SNSString;
-        BinaryValue?: SNSBinary;
-    }
-
-    export interface SNSNotFoundException {
-        message?: SNSstring;
-    }
-
-    export interface SNSPlatformApplication {
-        PlatformApplicationArn?: SNSString;
-        Attributes?: SNSMapStringToString;
-    }
-
-    export interface SNSPlatformApplicationDisabledException {
-        message?: SNSstring;
-    }
-
-    export interface SNSPublishInput {
-        TopicArn?: SNStopicARN;
-        TargetArn?: SNSString;
-        Message: SNSmessage;
-        Subject?: SNSsubject;
-        MessageStructure?: SNSmessageStructure;
-        MessageAttributes?: SNSMessageAttributeMap;
-    }
-
-    export interface SNSPublishResponse {
-        MessageId?: SNSmessageId;
-    }
-
-    export interface SNSRemovePermissionInput {
-        TopicArn: SNStopicARN;
-        Label: SNSlabel;
-    }
-
-    export interface SNSSetEndpointAttributesInput {
-        EndpointArn: SNSString;
-        Attributes: SNSMapStringToString;
-    }
-
-    export interface SNSSetPlatformApplicationAttributesInput {
-        PlatformApplicationArn: SNSString;
-        Attributes: SNSMapStringToString;
-    }
-
-    export interface SNSSetSubscriptionAttributesInput {
-        SubscriptionArn: SNSsubscriptionARN;
-        AttributeName: SNSattributeName;
-        AttributeValue?: SNSattributeValue;
-    }
-
-    export interface SNSSetTopicAttributesInput {
-        TopicArn: SNStopicARN;
-        AttributeName: SNSattributeName;
-        AttributeValue?: SNSattributeValue;
-    }
-
-    export type SNSString = string;
-    export interface SNSSubscribeInput {
-        TopicArn: SNStopicARN;
-        Protocol: SNSprotocol;
-        Endpoint?: SNSendpoint;
-    }
-
-    export interface SNSSubscribeResponse {
-        SubscriptionArn?: SNSsubscriptionARN;
-    }
-
-    export interface SNSSubscription {
-        SubscriptionArn?: SNSsubscriptionARN;
-        Owner?: SNSaccount;
-        Protocol?: SNSprotocol;
-        Endpoint?: SNSendpoint;
-        TopicArn?: SNStopicARN;
-    }
-
-    export type SNSSubscriptionAttributesMap = any; // not really - it was 'map' instead - must fix this one
-    export interface SNSSubscriptionLimitExceededException {
-        message?: SNSstring;
-    }
-
-    export type SNSSubscriptionsList = Array<SNSSubscription>;
-    export interface SNSTopic {
-        TopicArn?: SNStopicARN;
-    }
-
-    export type SNSTopicAttributesMap = any; // not really - it was 'map' instead - must fix this one
-    export interface SNSTopicLimitExceededException {
-        message?: SNSstring;
-    }
-
-    export type SNSTopicsList = Array<SNSTopic>;
-    export interface SNSUnsubscribeInput {
-        SubscriptionArn: SNSsubscriptionARN;
-    }
-
-    export type SNSaccount = string;
-    export type SNSaction = string;
-    export type SNSattributeName = string;
-    export type SNSattributeValue = string;
-    export type SNSauthenticateOnUnsubscribe = string;
-    export type SNSdelegate = string;
-    export type SNSendpoint = string;
-    export type SNSlabel = string;
-    export type SNSmessage = string;
-    export type SNSmessageId = string;
-    export type SNSmessageStructure = string;
-    export type SNSnextToken = string;
-    export type SNSprotocol = string;
-    export type SNSstring = string;
-    export type SNSsubject = string;
-    export type SNSsubscriptionARN = string;
-    export type SNStoken = string;
-    export type SNStopicARN = string;
-    export type SNStopicName = string;
 }

--- a/output/aws-sqs.d.ts
+++ b/output/aws-sqs.d.ts
@@ -6,287 +6,239 @@ declare module "aws-sdk" {
 
     export class SQS extends Service {
       constructor(options?: any);
-      addPermission(params: SQSAddPermissionRequest, callback?: (err: SQSOverLimit|any, data: any) => void): Request;
-      changeMessageVisibility(params: SQSChangeMessageVisibilityRequest, callback?: (err: SQSMessageNotInflight|SQSReceiptHandleIsInvalid|any, data: any) => void): Request;
-      changeMessageVisibilityBatch(params: SQSChangeMessageVisibilityBatchRequest, callback?: (err: SQSTooManyEntriesInBatchRequest|SQSEmptyBatchRequest|SQSBatchEntryIdsNotDistinct|SQSInvalidBatchEntryId|any, data: SQSChangeMessageVisibilityBatchResult|any) => void): Request;
-      createQueue(params: SQSCreateQueueRequest, callback?: (err: SQSQueueDeletedRecently|SQSQueueNameExists|any, data: SQSCreateQueueResult|any) => void): Request;
-      deleteMessage(params: SQSDeleteMessageRequest, callback?: (err: SQSInvalidIdFormat|SQSReceiptHandleIsInvalid|any, data: any) => void): Request;
-      deleteMessageBatch(params: SQSDeleteMessageBatchRequest, callback?: (err: SQSTooManyEntriesInBatchRequest|SQSEmptyBatchRequest|SQSBatchEntryIdsNotDistinct|SQSInvalidBatchEntryId|any, data: SQSDeleteMessageBatchResult|any) => void): Request;
-      deleteQueue(params: SQSDeleteQueueRequest, callback?: (err: any, data: any) => void): Request;
-      getQueueAttributes(params: SQSGetQueueAttributesRequest, callback?: (err: SQSInvalidAttributeName|any, data: SQSGetQueueAttributesResult|any) => void): Request;
-      getQueueUrl(params: SQSGetQueueUrlRequest, callback?: (err: SQSQueueDoesNotExist|any, data: SQSGetQueueUrlResult|any) => void): Request;
-      listDeadLetterSourceQueues(params: SQSListDeadLetterSourceQueuesRequest, callback?: (err: SQSQueueDoesNotExist|any, data: SQSListDeadLetterSourceQueuesResult|any) => void): Request;
-      listQueues(params: SQSListQueuesRequest, callback?: (err: any, data: SQSListQueuesResult|any) => void): Request;
-      purgeQueue(params: SQSPurgeQueueRequest, callback?: (err: SQSQueueDoesNotExist|SQSPurgeQueueInProgress|any, data: any) => void): Request;
-      receiveMessage(params: SQSReceiveMessageRequest, callback?: (err: SQSOverLimit|any, data: SQSReceiveMessageResult|any) => void): Request;
-      removePermission(params: SQSRemovePermissionRequest, callback?: (err: any, data: any) => void): Request;
-      sendMessage(params: SQSSendMessageRequest, callback?: (err: SQSInvalidMessageContents|SQSUnsupportedOperation|any, data: SQSSendMessageResult|any) => void): Request;
-      sendMessageBatch(params: SQSSendMessageBatchRequest, callback?: (err: SQSTooManyEntriesInBatchRequest|SQSEmptyBatchRequest|SQSBatchEntryIdsNotDistinct|SQSBatchRequestTooLong|SQSInvalidBatchEntryId|SQSUnsupportedOperation|any, data: SQSSendMessageBatchResult|any) => void): Request;
-      setQueueAttributes(params: SQSSetQueueAttributesRequest, callback?: (err: SQSInvalidAttributeName|any, data: any) => void): Request;
+      addPermission(params: SQS.AddPermissionRequest, callback?: (err: SQS.OverLimit|any, data: any) => void): Request;
+      changeMessageVisibility(params: SQS.ChangeMessageVisibilityRequest, callback?: (err: SQS.MessageNotInflight|SQS.ReceiptHandleIsInvalid|any, data: any) => void): Request;
+      changeMessageVisibilityBatch(params: SQS.ChangeMessageVisibilityBatchRequest, callback?: (err: SQS.TooManyEntriesInBatchRequest|SQS.EmptyBatchRequest|SQS.BatchEntryIdsNotDistinct|SQS.InvalidBatchEntryId|any, data: SQS.ChangeMessageVisibilityBatchResult|any) => void): Request;
+      createQueue(params: SQS.CreateQueueRequest, callback?: (err: SQS.QueueDeletedRecently|SQS.QueueNameExists|any, data: SQS.CreateQueueResult|any) => void): Request;
+      deleteMessage(params: SQS.DeleteMessageRequest, callback?: (err: SQS.InvalidIdFormat|SQS.ReceiptHandleIsInvalid|any, data: any) => void): Request;
+      deleteMessageBatch(params: SQS.DeleteMessageBatchRequest, callback?: (err: SQS.TooManyEntriesInBatchRequest|SQS.EmptyBatchRequest|SQS.BatchEntryIdsNotDistinct|SQS.InvalidBatchEntryId|any, data: SQS.DeleteMessageBatchResult|any) => void): Request;
+      deleteQueue(params: SQS.DeleteQueueRequest, callback?: (err: any, data: any) => void): Request;
+      getQueueAttributes(params: SQS.GetQueueAttributesRequest, callback?: (err: SQS.InvalidAttributeName|any, data: SQS.GetQueueAttributesResult|any) => void): Request;
+      getQueueUrl(params: SQS.GetQueueUrlRequest, callback?: (err: SQS.QueueDoesNotExist|any, data: SQS.GetQueueUrlResult|any) => void): Request;
+      listDeadLetterSourceQueues(params: SQS.ListDeadLetterSourceQueuesRequest, callback?: (err: SQS.QueueDoesNotExist|any, data: SQS.ListDeadLetterSourceQueuesResult|any) => void): Request;
+      listQueues(params: SQS.ListQueuesRequest, callback?: (err: any, data: SQS.ListQueuesResult|any) => void): Request;
+      purgeQueue(params: SQS.PurgeQueueRequest, callback?: (err: SQS.QueueDoesNotExist|SQS.PurgeQueueInProgress|any, data: any) => void): Request;
+      receiveMessage(params: SQS.ReceiveMessageRequest, callback?: (err: SQS.OverLimit|any, data: SQS.ReceiveMessageResult|any) => void): Request;
+      removePermission(params: SQS.RemovePermissionRequest, callback?: (err: any, data: any) => void): Request;
+      sendMessage(params: SQS.SendMessageRequest, callback?: (err: SQS.InvalidMessageContents|SQS.UnsupportedOperation|any, data: SQS.SendMessageResult|any) => void): Request;
+      sendMessageBatch(params: SQS.SendMessageBatchRequest, callback?: (err: SQS.TooManyEntriesInBatchRequest|SQS.EmptyBatchRequest|SQS.BatchEntryIdsNotDistinct|SQS.BatchRequestTooLong|SQS.InvalidBatchEntryId|SQS.UnsupportedOperation|any, data: SQS.SendMessageBatchResult|any) => void): Request;
+      setQueueAttributes(params: SQS.SetQueueAttributesRequest, callback?: (err: SQS.InvalidAttributeName|any, data: any) => void): Request;
     }
+    
+    export module SQS {
+        export type AWSAccountIdList = String[];
+        export type ActionNameList = String[];
+        export type AttributeMap = {[key:string]: String};
+        export type AttributeNameList = QueueAttributeName[];
+        export type BatchResultErrorEntryList = BatchResultErrorEntry[];
+        export type Binary = any;    // type: blob
+        export type BinaryList = Binary[];
+        export type Boolean = boolean;
+        export type ChangeMessageVisibilityBatchRequestEntryList = ChangeMessageVisibilityBatchRequestEntry[];
+        export type ChangeMessageVisibilityBatchResultEntryList = ChangeMessageVisibilityBatchResultEntry[];
+        export type DeleteMessageBatchRequestEntryList = DeleteMessageBatchRequestEntry[];
+        export type DeleteMessageBatchResultEntryList = DeleteMessageBatchResultEntry[];
+        export type Integer = number;
+        export type MessageAttributeMap = {[key:string]: MessageAttributeValue};
+        export type MessageAttributeName = string;
+        export type MessageAttributeNameList = MessageAttributeName[];
+        export type MessageList = Message[];
+        export type QueueAttributeName = string;
+        export type QueueUrlList = String[];
+        export type SendMessageBatchRequestEntryList = SendMessageBatchRequestEntry[];
+        export type SendMessageBatchResultEntryList = SendMessageBatchResultEntry[];
+        export type String = string;
+        export type StringList = String[];
 
-    export type SQSAWSAccountIdList = Array<SQSString>;
-    export type SQSActionNameList = Array<SQSString>;
-    export interface SQSAddPermissionRequest {
-        QueueUrl: SQSString;
-        Label: SQSString;
-        AWSAccountIds: SQSAWSAccountIdList;
-        Actions: SQSActionNameList;
+        export interface AddPermissionRequest {
+            QueueUrl: String;            
+            Label: String;            
+            AWSAccountIds: AWSAccountIdList;            
+            Actions: ActionNameList;            
+        }
+        export interface BatchEntryIdsNotDistinct {
+        }
+        export interface BatchRequestTooLong {
+        }
+        export interface BatchResultErrorEntry {
+            Id: String;            
+            SenderFault: Boolean;            
+            Code: String;            
+            Message?: String;            
+        }
+        export interface ChangeMessageVisibilityBatchRequest {
+            QueueUrl: String;            
+            Entries: ChangeMessageVisibilityBatchRequestEntryList;            
+        }
+        export interface ChangeMessageVisibilityBatchRequestEntry {
+            Id: String;            
+            ReceiptHandle: String;            
+            VisibilityTimeout?: Integer;            
+        }
+        export interface ChangeMessageVisibilityBatchResult {
+            Successful: ChangeMessageVisibilityBatchResultEntryList;            
+            Failed: BatchResultErrorEntryList;            
+        }
+        export interface ChangeMessageVisibilityBatchResultEntry {
+            Id: String;            
+        }
+        export interface ChangeMessageVisibilityRequest {
+            QueueUrl: String;            
+            ReceiptHandle: String;            
+            VisibilityTimeout: Integer;            
+        }
+        export interface CreateQueueRequest {
+            QueueName: String;            
+            Attributes?: AttributeMap;            
+        }
+        export interface CreateQueueResult {
+            QueueUrl?: String;            
+        }
+        export interface DeleteMessageBatchRequest {
+            QueueUrl: String;            
+            Entries: DeleteMessageBatchRequestEntryList;            
+        }
+        export interface DeleteMessageBatchRequestEntry {
+            Id: String;            
+            ReceiptHandle: String;            
+        }
+        export interface DeleteMessageBatchResult {
+            Successful: DeleteMessageBatchResultEntryList;            
+            Failed: BatchResultErrorEntryList;            
+        }
+        export interface DeleteMessageBatchResultEntry {
+            Id: String;            
+        }
+        export interface DeleteMessageRequest {
+            QueueUrl: String;            
+            ReceiptHandle: String;            
+        }
+        export interface DeleteQueueRequest {
+            QueueUrl: String;            
+        }
+        export interface EmptyBatchRequest {
+        }
+        export interface GetQueueAttributesRequest {
+            QueueUrl: String;            
+            AttributeNames?: AttributeNameList;            
+        }
+        export interface GetQueueAttributesResult {
+            Attributes?: AttributeMap;            
+        }
+        export interface GetQueueUrlRequest {
+            QueueName: String;            
+            QueueOwnerAWSAccountId?: String;            
+        }
+        export interface GetQueueUrlResult {
+            QueueUrl?: String;            
+        }
+        export interface InvalidAttributeName {
+        }
+        export interface InvalidBatchEntryId {
+        }
+        export interface InvalidIdFormat {
+        }
+        export interface InvalidMessageContents {
+        }
+        export interface ListDeadLetterSourceQueuesRequest {
+            QueueUrl: String;            
+        }
+        export interface ListDeadLetterSourceQueuesResult {
+            queueUrls: QueueUrlList;            
+        }
+        export interface ListQueuesRequest {
+            QueueNamePrefix?: String;            
+        }
+        export interface ListQueuesResult {
+            QueueUrls?: QueueUrlList;            
+        }
+        export interface Message {
+            MessageId?: String;            
+            ReceiptHandle?: String;            
+            MD5OfBody?: String;            
+            Body?: String;            
+            Attributes?: AttributeMap;            
+            MD5OfMessageAttributes?: String;            
+            MessageAttributes?: MessageAttributeMap;            
+        }
+        export interface MessageAttributeValue {
+            StringValue?: String;            
+            BinaryValue?: Binary;            
+            StringListValues?: StringList;            
+            BinaryListValues?: BinaryList;            
+            DataType: String;            
+        }
+        export interface MessageNotInflight {
+        }
+        export interface OverLimit {
+        }
+        export interface PurgeQueueInProgress {
+        }
+        export interface PurgeQueueRequest {
+            QueueUrl: String;            
+        }
+        export interface QueueDeletedRecently {
+        }
+        export interface QueueDoesNotExist {
+        }
+        export interface QueueNameExists {
+        }
+        export interface ReceiptHandleIsInvalid {
+        }
+        export interface ReceiveMessageRequest {
+            QueueUrl: String;            
+            AttributeNames?: AttributeNameList;            
+            MessageAttributeNames?: MessageAttributeNameList;            
+            MaxNumberOfMessages?: Integer;            
+            VisibilityTimeout?: Integer;            
+            WaitTimeSeconds?: Integer;            
+        }
+        export interface ReceiveMessageResult {
+            Messages?: MessageList;            
+        }
+        export interface RemovePermissionRequest {
+            QueueUrl: String;            
+            Label: String;            
+        }
+        export interface SendMessageBatchRequest {
+            QueueUrl: String;            
+            Entries: SendMessageBatchRequestEntryList;            
+        }
+        export interface SendMessageBatchRequestEntry {
+            Id: String;            
+            MessageBody: String;            
+            DelaySeconds?: Integer;            
+            MessageAttributes?: MessageAttributeMap;            
+        }
+        export interface SendMessageBatchResult {
+            Successful: SendMessageBatchResultEntryList;            
+            Failed: BatchResultErrorEntryList;            
+        }
+        export interface SendMessageBatchResultEntry {
+            Id: String;            
+            MessageId: String;            
+            MD5OfMessageBody: String;            
+            MD5OfMessageAttributes?: String;            
+        }
+        export interface SendMessageRequest {
+            QueueUrl: String;            
+            MessageBody: String;            
+            DelaySeconds?: Integer;            
+            MessageAttributes?: MessageAttributeMap;            
+        }
+        export interface SendMessageResult {
+            MD5OfMessageBody?: String;            
+            MD5OfMessageAttributes?: String;            
+            MessageId?: String;            
+        }
+        export interface SetQueueAttributesRequest {
+            QueueUrl: String;            
+            Attributes: AttributeMap;            
+        }
+        export interface TooManyEntriesInBatchRequest {
+        }
+        export interface UnsupportedOperation {
+        }
+
     }
-
-    export type SQSAttributeMap = any; // not really - it was 'map' instead - must fix this one
-    export type SQSAttributeNameList = Array<SQSQueueAttributeName>;
-    export interface SQSBatchEntryIdsNotDistinct {
-    }
-
-    export interface SQSBatchRequestTooLong {
-    }
-
-    export interface SQSBatchResultErrorEntry {
-        Id: SQSString;
-        SenderFault: SQSBoolean;
-        Code: SQSString;
-        Message?: SQSString;
-    }
-
-    export type SQSBatchResultErrorEntryList = Array<SQSBatchResultErrorEntry>;
-    export type SQSBinary = any; // not really - it was 'blob' instead - must fix this one
-    export type SQSBinaryList = Array<SQSBinary>;
-    export type SQSBoolean = boolean;
-    export interface SQSChangeMessageVisibilityBatchRequest {
-        QueueUrl: SQSString;
-        Entries: SQSChangeMessageVisibilityBatchRequestEntryList;
-    }
-
-    export interface SQSChangeMessageVisibilityBatchRequestEntry {
-        Id: SQSString;
-        ReceiptHandle: SQSString;
-        VisibilityTimeout?: SQSInteger;
-    }
-
-    export type SQSChangeMessageVisibilityBatchRequestEntryList = Array<SQSChangeMessageVisibilityBatchRequestEntry>;
-    export interface SQSChangeMessageVisibilityBatchResult {
-        Successful: SQSChangeMessageVisibilityBatchResultEntryList;
-        Failed: SQSBatchResultErrorEntryList;
-    }
-
-    export interface SQSChangeMessageVisibilityBatchResultEntry {
-        Id: SQSString;
-    }
-
-    export type SQSChangeMessageVisibilityBatchResultEntryList = Array<SQSChangeMessageVisibilityBatchResultEntry>;
-    export interface SQSChangeMessageVisibilityRequest {
-        QueueUrl: SQSString;
-        ReceiptHandle: SQSString;
-        VisibilityTimeout: SQSInteger;
-    }
-
-    export interface SQSCreateQueueRequest {
-        QueueName: SQSString;
-        Attributes?: SQSAttributeMap;
-    }
-
-    export interface SQSCreateQueueResult {
-        QueueUrl?: SQSString;
-    }
-
-    export interface SQSDeleteMessageBatchRequest {
-        QueueUrl: SQSString;
-        Entries: SQSDeleteMessageBatchRequestEntryList;
-    }
-
-    export interface SQSDeleteMessageBatchRequestEntry {
-        Id: SQSString;
-        ReceiptHandle: SQSString;
-    }
-
-    export type SQSDeleteMessageBatchRequestEntryList = Array<SQSDeleteMessageBatchRequestEntry>;
-    export interface SQSDeleteMessageBatchResult {
-        Successful: SQSDeleteMessageBatchResultEntryList;
-        Failed: SQSBatchResultErrorEntryList;
-    }
-
-    export interface SQSDeleteMessageBatchResultEntry {
-        Id: SQSString;
-    }
-
-    export type SQSDeleteMessageBatchResultEntryList = Array<SQSDeleteMessageBatchResultEntry>;
-    export interface SQSDeleteMessageRequest {
-        QueueUrl: SQSString;
-        ReceiptHandle: SQSString;
-    }
-
-    export interface SQSDeleteQueueRequest {
-        QueueUrl: SQSString;
-    }
-
-    export interface SQSEmptyBatchRequest {
-    }
-
-    export interface SQSGetQueueAttributesRequest {
-        QueueUrl: SQSString;
-        AttributeNames?: SQSAttributeNameList;
-    }
-
-    export interface SQSGetQueueAttributesResult {
-        Attributes?: SQSAttributeMap;
-    }
-
-    export interface SQSGetQueueUrlRequest {
-        QueueName: SQSString;
-        QueueOwnerAWSAccountId?: SQSString;
-    }
-
-    export interface SQSGetQueueUrlResult {
-        QueueUrl?: SQSString;
-    }
-
-    export type SQSInteger = number;
-    export interface SQSInvalidAttributeName {
-    }
-
-    export interface SQSInvalidBatchEntryId {
-    }
-
-    export interface SQSInvalidIdFormat {
-    }
-
-    export interface SQSInvalidMessageContents {
-    }
-
-    export interface SQSListDeadLetterSourceQueuesRequest {
-        QueueUrl: SQSString;
-    }
-
-    export interface SQSListDeadLetterSourceQueuesResult {
-        queueUrls: SQSQueueUrlList;
-    }
-
-    export interface SQSListQueuesRequest {
-        QueueNamePrefix?: SQSString;
-    }
-
-    export interface SQSListQueuesResult {
-        QueueUrls?: SQSQueueUrlList;
-    }
-
-    export interface SQSMessage {
-        MessageId?: SQSString;
-        ReceiptHandle?: SQSString;
-        MD5OfBody?: SQSString;
-        Body?: SQSString;
-        Attributes?: SQSAttributeMap;
-        MD5OfMessageAttributes?: SQSString;
-        MessageAttributes?: SQSMessageAttributeMap;
-    }
-
-    export type SQSMessageAttributeMap = any; // not really - it was 'map' instead - must fix this one
-    export type SQSMessageAttributeName = string;
-    export type SQSMessageAttributeNameList = Array<SQSMessageAttributeName>;
-    export interface SQSMessageAttributeValue {
-        StringValue?: SQSString;
-        BinaryValue?: SQSBinary;
-        StringListValues?: SQSStringList;
-        BinaryListValues?: SQSBinaryList;
-        DataType: SQSString;
-    }
-
-    export type SQSMessageList = Array<SQSMessage>;
-    export interface SQSMessageNotInflight {
-    }
-
-    export interface SQSOverLimit {
-    }
-
-    export interface SQSPurgeQueueInProgress {
-    }
-
-    export interface SQSPurgeQueueRequest {
-        QueueUrl: SQSString;
-    }
-
-    export type SQSQueueAttributeName = string;
-    export interface SQSQueueDeletedRecently {
-    }
-
-    export interface SQSQueueDoesNotExist {
-    }
-
-    export interface SQSQueueNameExists {
-    }
-
-    export type SQSQueueUrlList = Array<SQSString>;
-    export interface SQSReceiptHandleIsInvalid {
-    }
-
-    export interface SQSReceiveMessageRequest {
-        QueueUrl: SQSString;
-        AttributeNames?: SQSAttributeNameList;
-        MessageAttributeNames?: SQSMessageAttributeNameList;
-        MaxNumberOfMessages?: SQSInteger;
-        VisibilityTimeout?: SQSInteger;
-        WaitTimeSeconds?: SQSInteger;
-    }
-
-    export interface SQSReceiveMessageResult {
-        Messages?: SQSMessageList;
-    }
-
-    export interface SQSRemovePermissionRequest {
-        QueueUrl: SQSString;
-        Label: SQSString;
-    }
-
-    export interface SQSSendMessageBatchRequest {
-        QueueUrl: SQSString;
-        Entries: SQSSendMessageBatchRequestEntryList;
-    }
-
-    export interface SQSSendMessageBatchRequestEntry {
-        Id: SQSString;
-        MessageBody: SQSString;
-        DelaySeconds?: SQSInteger;
-        MessageAttributes?: SQSMessageAttributeMap;
-    }
-
-    export type SQSSendMessageBatchRequestEntryList = Array<SQSSendMessageBatchRequestEntry>;
-    export interface SQSSendMessageBatchResult {
-        Successful: SQSSendMessageBatchResultEntryList;
-        Failed: SQSBatchResultErrorEntryList;
-    }
-
-    export interface SQSSendMessageBatchResultEntry {
-        Id: SQSString;
-        MessageId: SQSString;
-        MD5OfMessageBody: SQSString;
-        MD5OfMessageAttributes?: SQSString;
-    }
-
-    export type SQSSendMessageBatchResultEntryList = Array<SQSSendMessageBatchResultEntry>;
-    export interface SQSSendMessageRequest {
-        QueueUrl: SQSString;
-        MessageBody: SQSString;
-        DelaySeconds?: SQSInteger;
-        MessageAttributes?: SQSMessageAttributeMap;
-    }
-
-    export interface SQSSendMessageResult {
-        MD5OfMessageBody?: SQSString;
-        MD5OfMessageAttributes?: SQSString;
-        MessageId?: SQSString;
-    }
-
-    export interface SQSSetQueueAttributesRequest {
-        QueueUrl: SQSString;
-        Attributes: SQSAttributeMap;
-    }
-
-    export type SQSString = string;
-    export type SQSStringList = Array<SQSString>;
-    export interface SQSTooManyEntriesInBatchRequest {
-    }
-
-    export interface SQSUnsupportedOperation {
-    }
-
 }

--- a/output/aws-ssm.d.ts
+++ b/output/aws-ssm.d.ts
@@ -6,438 +6,373 @@ declare module "aws-sdk" {
 
     export class SSM extends Service {
       constructor(options?: any);
-      cancelCommand(params: SSMCancelCommandRequest, callback?: (err: SSMInvalidCommandId|SSMInvalidInstanceId|SSMDuplicateInstanceId|any, data: SSMCancelCommandResult|any) => void): Request;
-      createAssociation(params: SSMCreateAssociationRequest, callback?: (err: SSMAssociationAlreadyExists|SSMAssociationLimitExceeded|SSMInternalServerError|SSMInvalidDocument|SSMInvalidInstanceId|SSMUnsupportedPlatformType|SSMInvalidParameters|any, data: SSMCreateAssociationResult|any) => void): Request;
-      createAssociationBatch(params: SSMCreateAssociationBatchRequest, callback?: (err: SSMInternalServerError|SSMInvalidDocument|SSMInvalidInstanceId|SSMInvalidParameters|SSMDuplicateInstanceId|SSMAssociationLimitExceeded|SSMUnsupportedPlatformType|any, data: SSMCreateAssociationBatchResult|any) => void): Request;
-      createDocument(params: SSMCreateDocumentRequest, callback?: (err: SSMDocumentAlreadyExists|SSMMaxDocumentSizeExceeded|SSMInternalServerError|SSMInvalidDocumentContent|SSMDocumentLimitExceeded|any, data: SSMCreateDocumentResult|any) => void): Request;
-      deleteAssociation(params: SSMDeleteAssociationRequest, callback?: (err: SSMAssociationDoesNotExist|SSMInternalServerError|SSMInvalidDocument|SSMInvalidInstanceId|SSMTooManyUpdates|any, data: SSMDeleteAssociationResult|any) => void): Request;
-      deleteDocument(params: SSMDeleteDocumentRequest, callback?: (err: SSMInternalServerError|SSMInvalidDocument|SSMAssociatedInstances|any, data: SSMDeleteDocumentResult|any) => void): Request;
-      describeAssociation(params: SSMDescribeAssociationRequest, callback?: (err: SSMAssociationDoesNotExist|SSMInternalServerError|SSMInvalidDocument|SSMInvalidInstanceId|any, data: SSMDescribeAssociationResult|any) => void): Request;
-      describeDocument(params: SSMDescribeDocumentRequest, callback?: (err: SSMInternalServerError|SSMInvalidDocument|any, data: SSMDescribeDocumentResult|any) => void): Request;
-      describeInstanceInformation(params: SSMDescribeInstanceInformationRequest, callback?: (err: SSMInternalServerError|SSMInvalidInstanceId|SSMInvalidNextToken|SSMInvalidInstanceInformationFilterValue|SSMInvalidFilterKey|any, data: SSMDescribeInstanceInformationResult|any) => void): Request;
-      getDocument(params: SSMGetDocumentRequest, callback?: (err: SSMInternalServerError|SSMInvalidDocument|any, data: SSMGetDocumentResult|any) => void): Request;
-      listAssociations(params: SSMListAssociationsRequest, callback?: (err: SSMInternalServerError|SSMInvalidNextToken|any, data: SSMListAssociationsResult|any) => void): Request;
-      listCommandInvocations(params: SSMListCommandInvocationsRequest, callback?: (err: SSMInvalidCommandId|SSMInvalidInstanceId|SSMInvalidFilterKey|SSMInvalidNextToken|any, data: SSMListCommandInvocationsResult|any) => void): Request;
-      listCommands(params: SSMListCommandsRequest, callback?: (err: SSMInvalidCommandId|SSMInvalidInstanceId|SSMInvalidFilterKey|SSMInvalidNextToken|any, data: SSMListCommandsResult|any) => void): Request;
-      listDocuments(params: SSMListDocumentsRequest, callback?: (err: SSMInternalServerError|SSMInvalidNextToken|SSMInvalidFilterKey|any, data: SSMListDocumentsResult|any) => void): Request;
-      sendCommand(params: SSMSendCommandRequest, callback?: (err: SSMDuplicateInstanceId|SSMInvalidInstanceId|SSMInvalidDocument|SSMInvalidOutputFolder|SSMInvalidParameters|SSMUnsupportedPlatformType|any, data: SSMSendCommandResult|any) => void): Request;
-      updateAssociationStatus(params: SSMUpdateAssociationStatusRequest, callback?: (err: SSMInternalServerError|SSMInvalidInstanceId|SSMInvalidDocument|SSMAssociationDoesNotExist|SSMStatusUnchanged|SSMTooManyUpdates|any, data: SSMUpdateAssociationStatusResult|any) => void): Request;
-    }
-
-    export interface SSMAssociatedInstances {
-    }
-
-    export interface SSMAssociation {
-        Name?: SSMDocumentName;
-        InstanceId?: SSMInstanceId;
-    }
-
-    export interface SSMAssociationAlreadyExists {
-    }
-
-    export interface SSMAssociationDescription {
-        Name?: SSMDocumentName;
-        InstanceId?: SSMInstanceId;
-        Date?: SSMDateTime;
-        Status?: SSMAssociationStatus;
-        Parameters?: SSMParameters;
-    }
-
-    export type SSMAssociationDescriptionList = Array<SSMAssociationDescription>;
-    export interface SSMAssociationDoesNotExist {
-    }
-
-    export interface SSMAssociationFilter {
-        key: SSMAssociationFilterKey;
-        value: SSMAssociationFilterValue;
-    }
-
-    export type SSMAssociationFilterKey = string;
-    export type SSMAssociationFilterList = Array<SSMAssociationFilter>;
-    export type SSMAssociationFilterValue = string;
-    export interface SSMAssociationLimitExceeded {
-    }
-
-    export type SSMAssociationList = Array<SSMAssociation>;
-    export interface SSMAssociationStatus {
-        Date: SSMDateTime;
-        Name: SSMAssociationStatusName;
-        Message: SSMStatusMessage;
-        AdditionalInfo?: SSMStatusAdditionalInfo;
-    }
-
-    export type SSMAssociationStatusName = string;
-    export type SSMBatchErrorMessage = string;
-    export type SSMBoolean = boolean;
-    export interface SSMCancelCommandRequest {
-        CommandId: SSMCommandId;
-        InstanceIds?: SSMInstanceIdList;
-    }
-
-    export interface SSMCancelCommandResult {
-    }
-
-    export interface SSMCommand {
-        CommandId?: SSMCommandId;
-        DocumentName?: SSMDocumentName;
-        Comment?: SSMComment;
-        ExpiresAfter?: SSMDateTime;
-        Parameters?: SSMParameters;
-        InstanceIds?: SSMInstanceIdList;
-        RequestedDateTime?: SSMDateTime;
-        Status?: SSMCommandStatus;
-        OutputS3BucketName?: SSMS3BucketName;
-        OutputS3KeyPrefix?: SSMS3KeyPrefix;
-    }
-
-    export interface SSMCommandFilter {
-        key: SSMCommandFilterKey;
-        value: SSMCommandFilterValue;
-    }
-
-    export type SSMCommandFilterKey = string;
-    export type SSMCommandFilterList = Array<SSMCommandFilter>; // max: 3
-    export type SSMCommandFilterValue = string;
-    export type SSMCommandId = string;
-    export interface SSMCommandInvocation {
-        CommandId?: SSMCommandId;
-        InstanceId?: SSMInstanceId;
-        Comment?: SSMComment;
-        DocumentName?: SSMDocumentName;
-        RequestedDateTime?: SSMDateTime;
-        Status?: SSMCommandInvocationStatus;
-        TraceOutput?: SSMInvocationTraceOutput;
-        CommandPlugins?: SSMCommandPluginList;
-    }
-
-    export type SSMCommandInvocationList = Array<SSMCommandInvocation>;
-    export type SSMCommandInvocationStatus = string;
-    export type SSMCommandList = Array<SSMCommand>;
-    export type SSMCommandMaxResults = number;
-    export interface SSMCommandPlugin {
-        Name?: SSMCommandPluginName;
-        Status?: SSMCommandPluginStatus;
-        ResponseCode?: SSMResponseCode;
-        ResponseStartDateTime?: SSMDateTime;
-        ResponseFinishDateTime?: SSMDateTime;
-        Output?: SSMCommandPluginOutput;
-        OutputS3BucketName?: SSMS3BucketName;
-        OutputS3KeyPrefix?: SSMS3KeyPrefix;
-    }
-
-    export type SSMCommandPluginList = Array<SSMCommandPlugin>;
-    export type SSMCommandPluginName = string;
-    export type SSMCommandPluginOutput = string;
-    export type SSMCommandPluginStatus = string;
-    export type SSMCommandStatus = string;
-    export type SSMComment = string;
-    export interface SSMCreateAssociationBatchRequest {
-        Entries: SSMCreateAssociationBatchRequestEntries;
-    }
-
-    export type SSMCreateAssociationBatchRequestEntries = Array<SSMCreateAssociationBatchRequestEntry>;
-    export interface SSMCreateAssociationBatchRequestEntry {
-        Name?: SSMDocumentName;
-        InstanceId?: SSMInstanceId;
-        Parameters?: SSMParameters;
-    }
-
-    export interface SSMCreateAssociationBatchResult {
-        Successful?: SSMAssociationDescriptionList;
-        Failed?: SSMFailedCreateAssociationList;
-    }
-
-    export interface SSMCreateAssociationRequest {
-        Name: SSMDocumentName;
-        InstanceId: SSMInstanceId;
-        Parameters?: SSMParameters;
-    }
-
-    export interface SSMCreateAssociationResult {
-        AssociationDescription?: SSMAssociationDescription;
-    }
-
-    export interface SSMCreateDocumentRequest {
-        Content: SSMDocumentContent;
-        Name: SSMDocumentName;
-    }
-
-    export interface SSMCreateDocumentResult {
-        DocumentDescription?: SSMDocumentDescription;
-    }
-
-    export type SSMDateTime = number;
-    export interface SSMDeleteAssociationRequest {
-        Name: SSMDocumentName;
-        InstanceId: SSMInstanceId;
-    }
-
-    export interface SSMDeleteAssociationResult {
-    }
-
-    export interface SSMDeleteDocumentRequest {
-        Name: SSMDocumentName;
-    }
-
-    export interface SSMDeleteDocumentResult {
-    }
-
-    export interface SSMDescribeAssociationRequest {
-        Name: SSMDocumentName;
-        InstanceId: SSMInstanceId;
-    }
-
-    export interface SSMDescribeAssociationResult {
-        AssociationDescription?: SSMAssociationDescription;
-    }
-
-    export interface SSMDescribeDocumentRequest {
-        Name: SSMDocumentName;
-    }
-
-    export interface SSMDescribeDocumentResult {
-        Document?: SSMDocumentDescription;
-    }
-
-    export interface SSMDescribeInstanceInformationRequest {
-        InstanceInformationFilterList?: SSMInstanceInformationFilterList;
-        MaxResults?: SSMMaxResultsEC2Compatible;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMDescribeInstanceInformationResult {
-        InstanceInformationList?: SSMInstanceInformationList;
-        NextToken?: SSMNextToken;
-    }
-
-    export type SSMDescriptionInDocument = string;
-    export interface SSMDocumentAlreadyExists {
-    }
-
-    export type SSMDocumentContent = string;
-    export interface SSMDocumentDescription {
-        Sha1?: SSMDocumentSha1;
-        Name?: SSMDocumentName;
-        CreatedDate?: SSMDateTime;
-        Status?: SSMDocumentStatus;
-        Description?: SSMDescriptionInDocument;
-        Parameters?: SSMDocumentParameterList;
-        PlatformTypes?: SSMPlatformTypeList;
-    }
-
-    export interface SSMDocumentFilter {
-        key: SSMDocumentFilterKey;
-        value: SSMDocumentFilterValue;
-    }
+      cancelCommand(params: SSM.CancelCommandRequest, callback?: (err: SSM.InvalidCommandId|SSM.InvalidInstanceId|SSM.DuplicateInstanceId|any, data: SSM.CancelCommandResult|any) => void): Request;
+      createAssociation(params: SSM.CreateAssociationRequest, callback?: (err: SSM.AssociationAlreadyExists|SSM.AssociationLimitExceeded|SSM.InternalServerError|SSM.InvalidDocument|SSM.InvalidInstanceId|SSM.UnsupportedPlatformType|SSM.InvalidParameters|any, data: SSM.CreateAssociationResult|any) => void): Request;
+      createAssociationBatch(params: SSM.CreateAssociationBatchRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidDocument|SSM.InvalidInstanceId|SSM.InvalidParameters|SSM.DuplicateInstanceId|SSM.AssociationLimitExceeded|SSM.UnsupportedPlatformType|any, data: SSM.CreateAssociationBatchResult|any) => void): Request;
+      createDocument(params: SSM.CreateDocumentRequest, callback?: (err: SSM.DocumentAlreadyExists|SSM.MaxDocumentSizeExceeded|SSM.InternalServerError|SSM.InvalidDocumentContent|SSM.DocumentLimitExceeded|any, data: SSM.CreateDocumentResult|any) => void): Request;
+      deleteAssociation(params: SSM.DeleteAssociationRequest, callback?: (err: SSM.AssociationDoesNotExist|SSM.InternalServerError|SSM.InvalidDocument|SSM.InvalidInstanceId|SSM.TooManyUpdates|any, data: SSM.DeleteAssociationResult|any) => void): Request;
+      deleteDocument(params: SSM.DeleteDocumentRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidDocument|SSM.AssociatedInstances|any, data: SSM.DeleteDocumentResult|any) => void): Request;
+      describeAssociation(params: SSM.DescribeAssociationRequest, callback?: (err: SSM.AssociationDoesNotExist|SSM.InternalServerError|SSM.InvalidDocument|SSM.InvalidInstanceId|any, data: SSM.DescribeAssociationResult|any) => void): Request;
+      describeDocument(params: SSM.DescribeDocumentRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidDocument|any, data: SSM.DescribeDocumentResult|any) => void): Request;
+      describeInstanceInformation(params: SSM.DescribeInstanceInformationRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidInstanceId|SSM.InvalidNextToken|SSM.InvalidInstanceInformationFilterValue|SSM.InvalidFilterKey|any, data: SSM.DescribeInstanceInformationResult|any) => void): Request;
+      getDocument(params: SSM.GetDocumentRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidDocument|any, data: SSM.GetDocumentResult|any) => void): Request;
+      listAssociations(params: SSM.ListAssociationsRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidNextToken|any, data: SSM.ListAssociationsResult|any) => void): Request;
+      listCommandInvocations(params: SSM.ListCommandInvocationsRequest, callback?: (err: SSM.InvalidCommandId|SSM.InvalidInstanceId|SSM.InvalidFilterKey|SSM.InvalidNextToken|any, data: SSM.ListCommandInvocationsResult|any) => void): Request;
+      listCommands(params: SSM.ListCommandsRequest, callback?: (err: SSM.InvalidCommandId|SSM.InvalidInstanceId|SSM.InvalidFilterKey|SSM.InvalidNextToken|any, data: SSM.ListCommandsResult|any) => void): Request;
+      listDocuments(params: SSM.ListDocumentsRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidNextToken|SSM.InvalidFilterKey|any, data: SSM.ListDocumentsResult|any) => void): Request;
+      sendCommand(params: SSM.SendCommandRequest, callback?: (err: SSM.DuplicateInstanceId|SSM.InvalidInstanceId|SSM.InvalidDocument|SSM.InvalidOutputFolder|SSM.InvalidParameters|SSM.UnsupportedPlatformType|any, data: SSM.SendCommandResult|any) => void): Request;
+      updateAssociationStatus(params: SSM.UpdateAssociationStatusRequest, callback?: (err: SSM.InternalServerError|SSM.InvalidInstanceId|SSM.InvalidDocument|SSM.AssociationDoesNotExist|SSM.StatusUnchanged|SSM.TooManyUpdates|any, data: SSM.UpdateAssociationStatusResult|any) => void): Request;
+    }
+    
+    export module SSM {
+        export type AssociationDescriptionList = AssociationDescription[];
+        export type AssociationFilterKey = string;
+        export type AssociationFilterList = AssociationFilter[];    // min: 1
+        export type AssociationFilterValue = string;    // min: 1
+        export type AssociationList = Association[];
+        export type AssociationStatusName = string;
+        export type BatchErrorMessage = string;
+        export type Boolean = boolean;
+        export type CommandFilterKey = string;
+        export type CommandFilterList = CommandFilter[];    // max: 3, min: 1
+        export type CommandFilterValue = string;    // min: 1
+        export type CommandId = string;    // max: 36, min: 36
+        export type CommandInvocationList = CommandInvocation[];
+        export type CommandInvocationStatus = string;
+        export type CommandList = Command[];
+        export type CommandMaxResults = number;    // max: 50, min: 1
+        export type CommandPluginList = CommandPlugin[];
+        export type CommandPluginName = string;    // min: 4
+        export type CommandPluginOutput = string;    // max: 2500
+        export type CommandPluginStatus = string;
+        export type CommandStatus = string;
+        export type Comment = string;    // max: 100
+        export type CreateAssociationBatchRequestEntries = CreateAssociationBatchRequestEntry[];
+        export type DateTime = number;
+        export type DescriptionInDocument = string;
+        export type DocumentContent = string;    // min: 1
+        export type DocumentFilterKey = string;
+        export type DocumentFilterList = DocumentFilter[];    // min: 1
+        export type DocumentFilterValue = string;    // min: 1
+        export type DocumentIdentifierList = DocumentIdentifier[];
+        export type DocumentName = string;    // pattern: &quot;^[a-zA-Z0-9_\-.]{3,128}$&quot;
+        export type DocumentParameterDefaultValue = string;
+        export type DocumentParameterDescrption = string;
+        export type DocumentParameterList = DocumentParameter[];
+        export type DocumentParameterName = string;
+        export type DocumentParameterType = string;
+        export type DocumentSha1 = string;
+        export type DocumentStatus = string;
+        export type FailedCreateAssociationList = FailedCreateAssociation[];
+        export type Fault = string;
+        export type InstanceId = string;    // pattern: &quot;^(?=.{10}$)(i-(\w){8})&quot;, max: 10, min: 10
+        export type InstanceIdList = InstanceId[];    // max: 50, min: 1
+        export type InstanceInformationFilterKey = string;
+        export type InstanceInformationFilterList = InstanceInformationFilter[];    // min: 1
+        export type InstanceInformationFilterValue = string;    // min: 1
+        export type InstanceInformationFilterValueSet = InstanceInformationFilterValue[];    // max: 100, min: 1
+        export type InstanceInformationList = InstanceInformation[];
+        export type InvocationTraceOutput = string;    // max: 2500
+        export type MaxResults = number;    // max: 25, min: 1
+        export type MaxResultsEC2Compatible = number;    // max: 50, min: 5
+        export type NextToken = string;
+        export type ParameterName = string;
+        export type ParameterValue = string;
+        export type ParameterValueList = ParameterValue[];
+        export type Parameters = {[key:string]: ParameterValueList};
+        export type PingStatus = string;
+        export type PlatformType = string;
+        export type PlatformTypeList = PlatformType[];
+        export type ResponseCode = number;
+        export type S3BucketName = string;    // max: 63, min: 3
+        export type S3KeyPrefix = string;    // max: 500
+        export type StatusAdditionalInfo = string;    // max: 1024
+        export type StatusMessage = string;    // max: 1024
+        export type String = string;
+        export type TimeoutSeconds = number;    // max: 2592000, min: 30
+        export type Version = string;    // pattern: &quot;^[0-9]{1,6}(\.[0-9]{1,6}){2,3}$&quot;
+
+        export interface AssociatedInstances {
+        }
+        export interface Association {
+            Name?: DocumentName;            
+            InstanceId?: InstanceId;            
+        }
+        export interface AssociationAlreadyExists {
+        }
+        export interface AssociationDescription {
+            Name?: DocumentName;            
+            InstanceId?: InstanceId;            
+            Date?: DateTime;            
+            Status?: AssociationStatus;            
+            Parameters?: Parameters;            
+        }
+        export interface AssociationDoesNotExist {
+        }
+        export interface AssociationFilter {
+            key: AssociationFilterKey;            
+            value: AssociationFilterValue;            
+        }
+        export interface AssociationLimitExceeded {
+        }
+        export interface AssociationStatus {
+            Date: DateTime;            
+            Name: AssociationStatusName;            
+            Message: StatusMessage;            
+            AdditionalInfo?: StatusAdditionalInfo;            
+        }
+        export interface CancelCommandRequest {
+            CommandId: CommandId;            
+            InstanceIds?: InstanceIdList;            
+        }
+        export interface CancelCommandResult {
+        }
+        export interface Command {
+            CommandId?: CommandId;            
+            DocumentName?: DocumentName;            
+            Comment?: Comment;            
+            ExpiresAfter?: DateTime;            
+            Parameters?: Parameters;            
+            InstanceIds?: InstanceIdList;            
+            RequestedDateTime?: DateTime;            
+            Status?: CommandStatus;            
+            OutputS3BucketName?: S3BucketName;            
+            OutputS3KeyPrefix?: S3KeyPrefix;            
+        }
+        export interface CommandFilter {
+            key: CommandFilterKey;            
+            value: CommandFilterValue;            
+        }
+        export interface CommandInvocation {
+            CommandId?: CommandId;            
+            InstanceId?: InstanceId;            
+            Comment?: Comment;            
+            DocumentName?: DocumentName;            
+            RequestedDateTime?: DateTime;            
+            Status?: CommandInvocationStatus;            
+            TraceOutput?: InvocationTraceOutput;            
+            CommandPlugins?: CommandPluginList;            
+        }
+        export interface CommandPlugin {
+            Name?: CommandPluginName;            
+            Status?: CommandPluginStatus;            
+            ResponseCode?: ResponseCode;            
+            ResponseStartDateTime?: DateTime;            
+            ResponseFinishDateTime?: DateTime;            
+            Output?: CommandPluginOutput;            
+            OutputS3BucketName?: S3BucketName;            
+            OutputS3KeyPrefix?: S3KeyPrefix;            
+        }
+        export interface CreateAssociationBatchRequest {
+            Entries: CreateAssociationBatchRequestEntries;            
+        }
+        export interface CreateAssociationBatchRequestEntry {
+            Name?: DocumentName;            
+            InstanceId?: InstanceId;            
+            Parameters?: Parameters;            
+        }
+        export interface CreateAssociationBatchResult {
+            Successful?: AssociationDescriptionList;            
+            Failed?: FailedCreateAssociationList;            
+        }
+        export interface CreateAssociationRequest {
+            Name: DocumentName;            
+            InstanceId: InstanceId;            
+            Parameters?: Parameters;            
+        }
+        export interface CreateAssociationResult {
+            AssociationDescription?: AssociationDescription;            
+        }
+        export interface CreateDocumentRequest {
+            Content: DocumentContent;            
+            Name: DocumentName;            
+        }
+        export interface CreateDocumentResult {
+            DocumentDescription?: DocumentDescription;            
+        }
+        export interface DeleteAssociationRequest {
+            Name: DocumentName;            
+            InstanceId: InstanceId;            
+        }
+        export interface DeleteAssociationResult {
+        }
+        export interface DeleteDocumentRequest {
+            Name: DocumentName;            
+        }
+        export interface DeleteDocumentResult {
+        }
+        export interface DescribeAssociationRequest {
+            Name: DocumentName;            
+            InstanceId: InstanceId;            
+        }
+        export interface DescribeAssociationResult {
+            AssociationDescription?: AssociationDescription;            
+        }
+        export interface DescribeDocumentRequest {
+            Name: DocumentName;            
+        }
+        export interface DescribeDocumentResult {
+            Document?: DocumentDescription;            
+        }
+        export interface DescribeInstanceInformationRequest {
+            InstanceInformationFilterList?: InstanceInformationFilterList;            
+            MaxResults?: MaxResultsEC2Compatible;            
+            NextToken?: NextToken;            
+        }
+        export interface DescribeInstanceInformationResult {
+            InstanceInformationList?: InstanceInformationList;            
+            NextToken?: NextToken;            
+        }
+        export interface DocumentAlreadyExists {
+        }
+        export interface DocumentDescription {
+            Sha1?: DocumentSha1;            
+            Name?: DocumentName;            
+            CreatedDate?: DateTime;            
+            Status?: DocumentStatus;            
+            Description?: DescriptionInDocument;            
+            Parameters?: DocumentParameterList;            
+            PlatformTypes?: PlatformTypeList;            
+        }
+        export interface DocumentFilter {
+            key: DocumentFilterKey;            
+            value: DocumentFilterValue;            
+        }
+        export interface DocumentIdentifier {
+            Name?: DocumentName;            
+            PlatformTypes?: PlatformTypeList;            
+        }
+        export interface DocumentLimitExceeded {
+        }
+        export interface DocumentParameter {
+            Name?: DocumentParameterName;            
+            Type?: DocumentParameterType;            
+            Description?: DocumentParameterDescrption;            
+            DefaultValue?: DocumentParameterDefaultValue;            
+        }
+        export interface DuplicateInstanceId {
+        }
+        export interface FailedCreateAssociation {
+            Entry?: CreateAssociationBatchRequestEntry;            
+            Message?: BatchErrorMessage;            
+            Fault?: Fault;            
+        }
+        export interface GetDocumentRequest {
+            Name: DocumentName;            
+        }
+        export interface GetDocumentResult {
+            Name?: DocumentName;            
+            Content?: DocumentContent;            
+        }
+        export interface InstanceInformation {
+            InstanceId?: InstanceId;            
+            PingStatus?: PingStatus;            
+            LastPingDateTime?: DateTime;            
+            AgentVersion?: Version;            
+            IsLatestVersion?: Boolean;            
+            PlatformType?: PlatformType;            
+            PlatformName?: String;            
+            PlatformVersion?: String;            
+        }
+        export interface InstanceInformationFilter {
+            key: InstanceInformationFilterKey;            
+            valueSet: InstanceInformationFilterValueSet;            
+        }
+        export interface InternalServerError {
+            message?: String;            
+        }
+        export interface InvalidCommandId {
+        }
+        export interface InvalidDocument {
+            message?: String;            
+        }
+        export interface InvalidDocumentContent {
+            message?: String;            
+        }
+        export interface InvalidFilterKey {
+        }
+        export interface InvalidInstanceId {
+        }
+        export interface InvalidInstanceInformationFilterValue {
+            message?: String;            
+        }
+        export interface InvalidNextToken {
+        }
+        export interface InvalidOutputFolder {
+        }
+        export interface InvalidParameters {
+            message?: String;            
+        }
+        export interface ListAssociationsRequest {
+            AssociationFilterList: AssociationFilterList;            
+            MaxResults?: MaxResults;            
+            NextToken?: NextToken;            
+        }
+        export interface ListAssociationsResult {
+            Associations?: AssociationList;            
+            NextToken?: NextToken;            
+        }
+        export interface ListCommandInvocationsRequest {
+            CommandId?: CommandId;            
+            InstanceId?: InstanceId;            
+            MaxResults?: CommandMaxResults;            
+            NextToken?: NextToken;            
+            Filters?: CommandFilterList;            
+            Details?: Boolean;            
+        }
+        export interface ListCommandInvocationsResult {
+            CommandInvocations?: CommandInvocationList;            
+            NextToken?: NextToken;            
+        }
+        export interface ListCommandsRequest {
+            CommandId?: CommandId;            
+            InstanceId?: InstanceId;            
+            MaxResults?: CommandMaxResults;            
+            NextToken?: NextToken;            
+            Filters?: CommandFilterList;            
+        }
+        export interface ListCommandsResult {
+            Commands?: CommandList;            
+            NextToken?: NextToken;            
+        }
+        export interface ListDocumentsRequest {
+            DocumentFilterList?: DocumentFilterList;            
+            MaxResults?: MaxResults;            
+            NextToken?: NextToken;            
+        }
+        export interface ListDocumentsResult {
+            DocumentIdentifiers?: DocumentIdentifierList;            
+            NextToken?: NextToken;            
+        }
+        export interface MaxDocumentSizeExceeded {
+        }
+        export interface SendCommandRequest {
+            InstanceIds: InstanceIdList;            
+            DocumentName: DocumentName;            
+            TimeoutSeconds?: TimeoutSeconds;            
+            Comment?: Comment;            
+            Parameters?: Parameters;            
+            OutputS3BucketName?: S3BucketName;            
+            OutputS3KeyPrefix?: S3KeyPrefix;            
+        }
+        export interface SendCommandResult {
+            Command?: Command;            
+        }
+        export interface StatusUnchanged {
+        }
+        export interface TooManyUpdates {
+        }
+        export interface UnsupportedPlatformType {
+            message?: String;            
+        }
+        export interface UpdateAssociationStatusRequest {
+            Name: DocumentName;            
+            InstanceId: InstanceId;            
+            AssociationStatus: AssociationStatus;            
+        }
+        export interface UpdateAssociationStatusResult {
+            AssociationDescription?: AssociationDescription;            
+        }
 
-    export type SSMDocumentFilterKey = string;
-    export type SSMDocumentFilterList = Array<SSMDocumentFilter>;
-    export type SSMDocumentFilterValue = string;
-    export interface SSMDocumentIdentifier {
-        Name?: SSMDocumentName;
-        PlatformTypes?: SSMPlatformTypeList;
     }
-
-    export type SSMDocumentIdentifierList = Array<SSMDocumentIdentifier>;
-    export interface SSMDocumentLimitExceeded {
-    }
-
-    export type SSMDocumentName = string; // pattern: "^[a-zA-Z0-9_\-.]{3,128}$"
-    export interface SSMDocumentParameter {
-        Name?: SSMDocumentParameterName;
-        Type?: SSMDocumentParameterType;
-        Description?: SSMDocumentParameterDescrption;
-        DefaultValue?: SSMDocumentParameterDefaultValue;
-    }
-
-    export type SSMDocumentParameterDefaultValue = string;
-    export type SSMDocumentParameterDescrption = string;
-    export type SSMDocumentParameterList = Array<SSMDocumentParameter>;
-    export type SSMDocumentParameterName = string;
-    export type SSMDocumentParameterType = string;
-    export type SSMDocumentSha1 = string;
-    export type SSMDocumentStatus = string;
-    export interface SSMDuplicateInstanceId {
-    }
-
-    export interface SSMFailedCreateAssociation {
-        Entry?: SSMCreateAssociationBatchRequestEntry;
-        Message?: SSMBatchErrorMessage;
-        Fault?: SSMFault;
-    }
-
-    export type SSMFailedCreateAssociationList = Array<SSMFailedCreateAssociation>;
-    export type SSMFault = string;
-    export interface SSMGetDocumentRequest {
-        Name: SSMDocumentName;
-    }
-
-    export interface SSMGetDocumentResult {
-        Name?: SSMDocumentName;
-        Content?: SSMDocumentContent;
-    }
-
-    export type SSMInstanceId = string; // pattern: "^(?=.{10}$)(i-(\w){8})"
-    export type SSMInstanceIdList = Array<SSMInstanceId>; // max: 50
-    export interface SSMInstanceInformation {
-        InstanceId?: SSMInstanceId;
-        PingStatus?: SSMPingStatus;
-        LastPingDateTime?: SSMDateTime;
-        AgentVersion?: SSMVersion;
-        IsLatestVersion?: SSMBoolean;
-        PlatformType?: SSMPlatformType;
-        PlatformName?: SSMString;
-        PlatformVersion?: SSMString;
-    }
-
-    export interface SSMInstanceInformationFilter {
-        key: SSMInstanceInformationFilterKey;
-        valueSet: SSMInstanceInformationFilterValueSet;
-    }
-
-    export type SSMInstanceInformationFilterKey = string;
-    export type SSMInstanceInformationFilterList = Array<SSMInstanceInformationFilter>;
-    export type SSMInstanceInformationFilterValue = string;
-    export type SSMInstanceInformationFilterValueSet = Array<SSMInstanceInformationFilterValue>; // max: 100
-    export type SSMInstanceInformationList = Array<SSMInstanceInformation>;
-    export interface SSMInternalServerError {
-        message?: SSMString;
-    }
-
-    export interface SSMInvalidCommandId {
-    }
-
-    export interface SSMInvalidDocument {
-        message?: SSMString;
-    }
-
-    export interface SSMInvalidDocumentContent {
-        message?: SSMString;
-    }
-
-    export interface SSMInvalidFilterKey {
-    }
-
-    export interface SSMInvalidInstanceId {
-    }
-
-    export interface SSMInvalidInstanceInformationFilterValue {
-        message?: SSMString;
-    }
-
-    export interface SSMInvalidNextToken {
-    }
-
-    export interface SSMInvalidOutputFolder {
-    }
-
-    export interface SSMInvalidParameters {
-        message?: SSMString;
-    }
-
-    export type SSMInvocationTraceOutput = string;
-    export interface SSMListAssociationsRequest {
-        AssociationFilterList: SSMAssociationFilterList;
-        MaxResults?: SSMMaxResults;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMListAssociationsResult {
-        Associations?: SSMAssociationList;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMListCommandInvocationsRequest {
-        CommandId?: SSMCommandId;
-        InstanceId?: SSMInstanceId;
-        MaxResults?: SSMCommandMaxResults;
-        NextToken?: SSMNextToken;
-        Filters?: SSMCommandFilterList;
-        Details?: SSMBoolean;
-    }
-
-    export interface SSMListCommandInvocationsResult {
-        CommandInvocations?: SSMCommandInvocationList;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMListCommandsRequest {
-        CommandId?: SSMCommandId;
-        InstanceId?: SSMInstanceId;
-        MaxResults?: SSMCommandMaxResults;
-        NextToken?: SSMNextToken;
-        Filters?: SSMCommandFilterList;
-    }
-
-    export interface SSMListCommandsResult {
-        Commands?: SSMCommandList;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMListDocumentsRequest {
-        DocumentFilterList?: SSMDocumentFilterList;
-        MaxResults?: SSMMaxResults;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMListDocumentsResult {
-        DocumentIdentifiers?: SSMDocumentIdentifierList;
-        NextToken?: SSMNextToken;
-    }
-
-    export interface SSMMaxDocumentSizeExceeded {
-    }
-
-    export type SSMMaxResults = number;
-    export type SSMMaxResultsEC2Compatible = number;
-    export type SSMNextToken = string;
-    export type SSMParameterName = string;
-    export type SSMParameterValue = string;
-    export type SSMParameterValueList = Array<SSMParameterValue>;
-    export type SSMParameters = any; // not really - it was 'map' instead - must fix this one
-    export type SSMPingStatus = string;
-    export type SSMPlatformType = string;
-    export type SSMPlatformTypeList = Array<SSMPlatformType>;
-    export type SSMResponseCode = number;
-    export type SSMS3BucketName = string;
-    export type SSMS3KeyPrefix = string;
-    export interface SSMSendCommandRequest {
-        InstanceIds: SSMInstanceIdList;
-        DocumentName: SSMDocumentName;
-        TimeoutSeconds?: SSMTimeoutSeconds;
-        Comment?: SSMComment;
-        Parameters?: SSMParameters;
-        OutputS3BucketName?: SSMS3BucketName;
-        OutputS3KeyPrefix?: SSMS3KeyPrefix;
-    }
-
-    export interface SSMSendCommandResult {
-        Command?: SSMCommand;
-    }
-
-    export type SSMStatusAdditionalInfo = string;
-    export type SSMStatusMessage = string;
-    export interface SSMStatusUnchanged {
-    }
-
-    export type SSMString = string;
-    export type SSMTimeoutSeconds = number;
-    export interface SSMTooManyUpdates {
-    }
-
-    export interface SSMUnsupportedPlatformType {
-        message?: SSMString;
-    }
-
-    export interface SSMUpdateAssociationStatusRequest {
-        Name: SSMDocumentName;
-        InstanceId: SSMInstanceId;
-        AssociationStatus: SSMAssociationStatus;
-    }
-
-    export interface SSMUpdateAssociationStatusResult {
-        AssociationDescription?: SSMAssociationDescription;
-    }
-
-    export type SSMVersion = string; // pattern: "^[0-9]{1,6}(\.[0-9]{1,6}){2,3}$"
 }

--- a/output/aws-storagegateway.d.ts
+++ b/output/aws-storagegateway.d.ts
@@ -6,814 +6,692 @@ declare module "aws-sdk" {
 
     export class StorageGateway extends Service {
       constructor(options?: any);
-      activateGateway(params: StorageGatewayActivateGatewayInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayActivateGatewayOutput|any) => void): Request;
-      addCache(params: StorageGatewayAddCacheInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayAddCacheOutput|any) => void): Request;
-      addTagsToResource(params: StorageGatewayAddTagsToResourceInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayAddTagsToResourceOutput|any) => void): Request;
-      addUploadBuffer(params: StorageGatewayAddUploadBufferInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayAddUploadBufferOutput|any) => void): Request;
-      addWorkingStorage(params: StorageGatewayAddWorkingStorageInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayAddWorkingStorageOutput|any) => void): Request;
-      cancelArchival(params: StorageGatewayCancelArchivalInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCancelArchivalOutput|any) => void): Request;
-      cancelRetrieval(params: StorageGatewayCancelRetrievalInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCancelRetrievalOutput|any) => void): Request;
-      createCachediSCSIVolume(params: StorageGatewayCreateCachediSCSIVolumeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCreateCachediSCSIVolumeOutput|any) => void): Request;
-      createSnapshot(params: StorageGatewayCreateSnapshotInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCreateSnapshotOutput|any) => void): Request;
-      createSnapshotFromVolumeRecoveryPoint(params: StorageGatewayCreateSnapshotFromVolumeRecoveryPointInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCreateSnapshotFromVolumeRecoveryPointOutput|any) => void): Request;
-      createStorediSCSIVolume(params: StorageGatewayCreateStorediSCSIVolumeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCreateStorediSCSIVolumeOutput|any) => void): Request;
-      createTapes(params: StorageGatewayCreateTapesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayCreateTapesOutput|any) => void): Request;
-      deleteBandwidthRateLimit(params: StorageGatewayDeleteBandwidthRateLimitInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteBandwidthRateLimitOutput|any) => void): Request;
-      deleteChapCredentials(params: StorageGatewayDeleteChapCredentialsInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteChapCredentialsOutput|any) => void): Request;
-      deleteGateway(params: StorageGatewayDeleteGatewayInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteGatewayOutput|any) => void): Request;
-      deleteSnapshotSchedule(params: StorageGatewayDeleteSnapshotScheduleInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteSnapshotScheduleOutput|any) => void): Request;
-      deleteTape(params: StorageGatewayDeleteTapeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteTapeOutput|any) => void): Request;
-      deleteTapeArchive(params: StorageGatewayDeleteTapeArchiveInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteTapeArchiveOutput|any) => void): Request;
-      deleteVolume(params: StorageGatewayDeleteVolumeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDeleteVolumeOutput|any) => void): Request;
-      describeBandwidthRateLimit(params: StorageGatewayDescribeBandwidthRateLimitInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeBandwidthRateLimitOutput|any) => void): Request;
-      describeCache(params: StorageGatewayDescribeCacheInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeCacheOutput|any) => void): Request;
-      describeCachediSCSIVolumes(params: StorageGatewayDescribeCachediSCSIVolumesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeCachediSCSIVolumesOutput|any) => void): Request;
-      describeChapCredentials(params: StorageGatewayDescribeChapCredentialsInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeChapCredentialsOutput|any) => void): Request;
-      describeGatewayInformation(params: StorageGatewayDescribeGatewayInformationInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeGatewayInformationOutput|any) => void): Request;
-      describeMaintenanceStartTime(params: StorageGatewayDescribeMaintenanceStartTimeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeMaintenanceStartTimeOutput|any) => void): Request;
-      describeSnapshotSchedule(params: StorageGatewayDescribeSnapshotScheduleInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeSnapshotScheduleOutput|any) => void): Request;
-      describeStorediSCSIVolumes(params: StorageGatewayDescribeStorediSCSIVolumesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeStorediSCSIVolumesOutput|any) => void): Request;
-      describeTapeArchives(params: StorageGatewayDescribeTapeArchivesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeTapeArchivesOutput|any) => void): Request;
-      describeTapeRecoveryPoints(params: StorageGatewayDescribeTapeRecoveryPointsInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeTapeRecoveryPointsOutput|any) => void): Request;
-      describeTapes(params: StorageGatewayDescribeTapesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeTapesOutput|any) => void): Request;
-      describeUploadBuffer(params: StorageGatewayDescribeUploadBufferInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeUploadBufferOutput|any) => void): Request;
-      describeVTLDevices(params: StorageGatewayDescribeVTLDevicesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeVTLDevicesOutput|any) => void): Request;
-      describeWorkingStorage(params: StorageGatewayDescribeWorkingStorageInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDescribeWorkingStorageOutput|any) => void): Request;
-      disableGateway(params: StorageGatewayDisableGatewayInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayDisableGatewayOutput|any) => void): Request;
-      listGateways(params: StorageGatewayListGatewaysInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayListGatewaysOutput|any) => void): Request;
-      listLocalDisks(params: StorageGatewayListLocalDisksInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayListLocalDisksOutput|any) => void): Request;
-      listTagsForResource(params: StorageGatewayListTagsForResourceInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayListTagsForResourceOutput|any) => void): Request;
-      listVolumeInitiators(params: StorageGatewayListVolumeInitiatorsInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayListVolumeInitiatorsOutput|any) => void): Request;
-      listVolumeRecoveryPoints(params: StorageGatewayListVolumeRecoveryPointsInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayListVolumeRecoveryPointsOutput|any) => void): Request;
-      listVolumes(params: StorageGatewayListVolumesInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayListVolumesOutput|any) => void): Request;
-      removeTagsFromResource(params: StorageGatewayRemoveTagsFromResourceInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayRemoveTagsFromResourceOutput|any) => void): Request;
-      resetCache(params: StorageGatewayResetCacheInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayResetCacheOutput|any) => void): Request;
-      retrieveTapeArchive(params: StorageGatewayRetrieveTapeArchiveInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayRetrieveTapeArchiveOutput|any) => void): Request;
-      retrieveTapeRecoveryPoint(params: StorageGatewayRetrieveTapeRecoveryPointInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayRetrieveTapeRecoveryPointOutput|any) => void): Request;
-      shutdownGateway(params: StorageGatewayShutdownGatewayInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayShutdownGatewayOutput|any) => void): Request;
-      startGateway(params: StorageGatewayStartGatewayInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayStartGatewayOutput|any) => void): Request;
-      updateBandwidthRateLimit(params: StorageGatewayUpdateBandwidthRateLimitInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateBandwidthRateLimitOutput|any) => void): Request;
-      updateChapCredentials(params: StorageGatewayUpdateChapCredentialsInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateChapCredentialsOutput|any) => void): Request;
-      updateGatewayInformation(params: StorageGatewayUpdateGatewayInformationInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateGatewayInformationOutput|any) => void): Request;
-      updateGatewaySoftwareNow(params: StorageGatewayUpdateGatewaySoftwareNowInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateGatewaySoftwareNowOutput|any) => void): Request;
-      updateMaintenanceStartTime(params: StorageGatewayUpdateMaintenanceStartTimeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateMaintenanceStartTimeOutput|any) => void): Request;
-      updateSnapshotSchedule(params: StorageGatewayUpdateSnapshotScheduleInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateSnapshotScheduleOutput|any) => void): Request;
-      updateVTLDeviceType(params: StorageGatewayUpdateVTLDeviceTypeInput, callback?: (err: StorageGatewayInvalidGatewayRequestException|StorageGatewayInternalServerError|any, data: StorageGatewayUpdateVTLDeviceTypeOutput|any) => void): Request;
-    }
-
-    export interface StorageGatewayActivateGatewayInput {
-        ActivationKey: StorageGatewayActivationKey;
-        GatewayName: StorageGatewayGatewayName;
-        GatewayTimezone: StorageGatewayGatewayTimezone;
-        GatewayRegion: StorageGatewayRegionId;
-        GatewayType?: StorageGatewayGatewayType;
-        TapeDriveType?: StorageGatewayTapeDriveType;
-        MediumChangerType?: StorageGatewayMediumChangerType;
-    }
-
-    export interface StorageGatewayActivateGatewayOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export type StorageGatewayActivationKey = string;
-    export interface StorageGatewayAddCacheInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        DiskIds: StorageGatewayDiskIds;
-    }
-
-    export interface StorageGatewayAddCacheOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayAddTagsToResourceInput {
-        ResourceARN: StorageGatewayResourceARN;
-        Tags: StorageGatewayTags;
-    }
-
-    export interface StorageGatewayAddTagsToResourceOutput {
-        ResourceARN?: StorageGatewayResourceARN;
-    }
-
-    export interface StorageGatewayAddUploadBufferInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        DiskIds: StorageGatewayDiskIds;
-    }
-
-    export interface StorageGatewayAddUploadBufferOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayAddWorkingStorageInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        DiskIds: StorageGatewayDiskIds;
-    }
-
-    export interface StorageGatewayAddWorkingStorageOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export type StorageGatewayBandwidthDownloadRateLimit = number;
-    export type StorageGatewayBandwidthType = string;
-    export type StorageGatewayBandwidthUploadRateLimit = number;
-    export interface StorageGatewayCachediSCSIVolume {
-        VolumeARN?: StorageGatewayVolumeARN;
-        VolumeId?: StorageGatewayVolumeId;
-        VolumeType?: StorageGatewayVolumeType;
-        VolumeStatus?: StorageGatewayVolumeStatus;
-        VolumeSizeInBytes?: StorageGatewaylong;
-        VolumeProgress?: StorageGatewayDoubleObject;
-        SourceSnapshotId?: StorageGatewaySnapshotId;
-        VolumeiSCSIAttributes?: StorageGatewayVolumeiSCSIAttributes;
-    }
-
-    export type StorageGatewayCachediSCSIVolumes = Array<StorageGatewayCachediSCSIVolume>;
-    export interface StorageGatewayCancelArchivalInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        TapeARN: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayCancelArchivalOutput {
-        TapeARN?: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayCancelRetrievalInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        TapeARN: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayCancelRetrievalOutput {
-        TapeARN?: StorageGatewayTapeARN;
-    }
-
-    export type StorageGatewayChapCredentials = Array<StorageGatewayChapInfo>;
-    export interface StorageGatewayChapInfo {
-        TargetARN?: StorageGatewayTargetARN;
-        SecretToAuthenticateInitiator?: StorageGatewayChapSecret;
-        InitiatorName?: StorageGatewayIqnName;
-        SecretToAuthenticateTarget?: StorageGatewayChapSecret;
-    }
-
-    export type StorageGatewayChapSecret = string;
-    export type StorageGatewayClientToken = string;
-    export interface StorageGatewayCreateCachediSCSIVolumeInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        VolumeSizeInBytes: StorageGatewaylong;
-        SnapshotId?: StorageGatewaySnapshotId;
-        TargetName: StorageGatewayTargetName;
-        NetworkInterfaceId: StorageGatewayNetworkInterfaceId;
-        ClientToken: StorageGatewayClientToken;
-    }
-
-    export interface StorageGatewayCreateCachediSCSIVolumeOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-        TargetARN?: StorageGatewayTargetARN;
-    }
-
-    export interface StorageGatewayCreateSnapshotFromVolumeRecoveryPointInput {
-        VolumeARN: StorageGatewayVolumeARN;
-        SnapshotDescription: StorageGatewaySnapshotDescription;
-    }
-
-    export interface StorageGatewayCreateSnapshotFromVolumeRecoveryPointOutput {
-        SnapshotId?: StorageGatewaySnapshotId;
-        VolumeARN?: StorageGatewayVolumeARN;
-        VolumeRecoveryPointTime?: StorageGatewaystring;
-    }
-
-    export interface StorageGatewayCreateSnapshotInput {
-        VolumeARN: StorageGatewayVolumeARN;
-        SnapshotDescription: StorageGatewaySnapshotDescription;
-    }
-
-    export interface StorageGatewayCreateSnapshotOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-        SnapshotId?: StorageGatewaySnapshotId;
-    }
-
-    export interface StorageGatewayCreateStorediSCSIVolumeInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        DiskId: StorageGatewayDiskId;
-        SnapshotId?: StorageGatewaySnapshotId;
-        PreserveExistingData: StorageGatewayboolean;
-        TargetName: StorageGatewayTargetName;
-        NetworkInterfaceId: StorageGatewayNetworkInterfaceId;
-    }
-
-    export interface StorageGatewayCreateStorediSCSIVolumeOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-        VolumeSizeInBytes?: StorageGatewaylong;
-        TargetARN?: StorageGatewayTargetARN;
-    }
-
-    export interface StorageGatewayCreateTapesInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        TapeSizeInBytes: StorageGatewayTapeSize;
-        ClientToken: StorageGatewayClientToken;
-        NumTapesToCreate: StorageGatewayNumTapesToCreate;
-        TapeBarcodePrefix: StorageGatewayTapeBarcodePrefix;
-    }
-
-    export interface StorageGatewayCreateTapesOutput {
-        TapeARNs?: StorageGatewayTapeARNs;
-    }
-
-    export type StorageGatewayDayOfWeek = number;
-    export interface StorageGatewayDeleteBandwidthRateLimitInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        BandwidthType: StorageGatewayBandwidthType;
-    }
-
-    export interface StorageGatewayDeleteBandwidthRateLimitOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDeleteChapCredentialsInput {
-        TargetARN: StorageGatewayTargetARN;
-        InitiatorName: StorageGatewayIqnName;
-    }
-
-    export interface StorageGatewayDeleteChapCredentialsOutput {
-        TargetARN?: StorageGatewayTargetARN;
-        InitiatorName?: StorageGatewayIqnName;
-    }
-
-    export interface StorageGatewayDeleteGatewayInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDeleteGatewayOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDeleteSnapshotScheduleInput {
-        VolumeARN: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayDeleteSnapshotScheduleOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayDeleteTapeArchiveInput {
-        TapeARN: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayDeleteTapeArchiveOutput {
-        TapeARN?: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayDeleteTapeInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        TapeARN: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayDeleteTapeOutput {
-        TapeARN?: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayDeleteVolumeInput {
-        VolumeARN: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayDeleteVolumeOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayDescribeBandwidthRateLimitInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDescribeBandwidthRateLimitOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        AverageUploadRateLimitInBitsPerSec?: StorageGatewayBandwidthUploadRateLimit;
-        AverageDownloadRateLimitInBitsPerSec?: StorageGatewayBandwidthDownloadRateLimit;
-    }
-
-    export interface StorageGatewayDescribeCacheInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDescribeCacheOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        DiskIds?: StorageGatewayDiskIds;
-        CacheAllocatedInBytes?: StorageGatewaylong;
-        CacheUsedPercentage?: StorageGatewaydouble;
-        CacheDirtyPercentage?: StorageGatewaydouble;
-        CacheHitPercentage?: StorageGatewaydouble;
-        CacheMissPercentage?: StorageGatewaydouble;
-    }
-
-    export interface StorageGatewayDescribeCachediSCSIVolumesInput {
-        VolumeARNs: StorageGatewayVolumeARNs;
-    }
-
-    export interface StorageGatewayDescribeCachediSCSIVolumesOutput {
-        CachediSCSIVolumes?: StorageGatewayCachediSCSIVolumes;
-    }
-
-    export interface StorageGatewayDescribeChapCredentialsInput {
-        TargetARN: StorageGatewayTargetARN;
-    }
-
-    export interface StorageGatewayDescribeChapCredentialsOutput {
-        ChapCredentials?: StorageGatewayChapCredentials;
-    }
-
-    export interface StorageGatewayDescribeGatewayInformationInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDescribeGatewayInformationOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        GatewayId?: StorageGatewayGatewayId;
-        GatewayName?: StorageGatewaystring;
-        GatewayTimezone?: StorageGatewayGatewayTimezone;
-        GatewayState?: StorageGatewayGatewayState;
-        GatewayNetworkInterfaces?: StorageGatewayGatewayNetworkInterfaces;
-        GatewayType?: StorageGatewayGatewayType;
-        NextUpdateAvailabilityDate?: StorageGatewayNextUpdateAvailabilityDate;
-        LastSoftwareUpdate?: StorageGatewayLastSoftwareUpdate;
-    }
-
-    export interface StorageGatewayDescribeMaintenanceStartTimeInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDescribeMaintenanceStartTimeOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        HourOfDay?: StorageGatewayHourOfDay;
-        MinuteOfHour?: StorageGatewayMinuteOfHour;
-        DayOfWeek?: StorageGatewayDayOfWeek;
-        Timezone?: StorageGatewayGatewayTimezone;
-    }
-
-    export interface StorageGatewayDescribeSnapshotScheduleInput {
-        VolumeARN: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayDescribeSnapshotScheduleOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-        StartAt?: StorageGatewayHourOfDay;
-        RecurrenceInHours?: StorageGatewayRecurrenceInHours;
-        Description?: StorageGatewayDescription;
-        Timezone?: StorageGatewayGatewayTimezone;
-    }
-
-    export interface StorageGatewayDescribeStorediSCSIVolumesInput {
-        VolumeARNs: StorageGatewayVolumeARNs;
-    }
-
-    export interface StorageGatewayDescribeStorediSCSIVolumesOutput {
-        StorediSCSIVolumes?: StorageGatewayStorediSCSIVolumes;
-    }
-
-    export interface StorageGatewayDescribeTapeArchivesInput {
-        TapeARNs?: StorageGatewayTapeARNs;
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayDescribeTapeArchivesOutput {
-        TapeArchives?: StorageGatewayTapeArchives;
-        Marker?: StorageGatewayMarker;
-    }
-
-    export interface StorageGatewayDescribeTapeRecoveryPointsInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayDescribeTapeRecoveryPointsOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        TapeRecoveryPointInfos?: StorageGatewayTapeRecoveryPointInfos;
-        Marker?: StorageGatewayMarker;
-    }
-
-    export interface StorageGatewayDescribeTapesInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        TapeARNs?: StorageGatewayTapeARNs;
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayDescribeTapesOutput {
-        Tapes?: StorageGatewayTapes;
-        Marker?: StorageGatewayMarker;
-    }
-
-    export interface StorageGatewayDescribeUploadBufferInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDescribeUploadBufferOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        DiskIds?: StorageGatewayDiskIds;
-        UploadBufferUsedInBytes?: StorageGatewaylong;
-        UploadBufferAllocatedInBytes?: StorageGatewaylong;
-    }
-
-    export interface StorageGatewayDescribeVTLDevicesInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        VTLDeviceARNs?: StorageGatewayVTLDeviceARNs;
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayDescribeVTLDevicesOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        VTLDevices?: StorageGatewayVTLDevices;
-        Marker?: StorageGatewayMarker;
-    }
-
-    export interface StorageGatewayDescribeWorkingStorageInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDescribeWorkingStorageOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        DiskIds?: StorageGatewayDiskIds;
-        WorkingStorageUsedInBytes?: StorageGatewaylong;
-        WorkingStorageAllocatedInBytes?: StorageGatewaylong;
-    }
-
-    export type StorageGatewayDescription = string;
-    export type StorageGatewayDeviceType = string;
-    export interface StorageGatewayDeviceiSCSIAttributes {
-        TargetARN?: StorageGatewayTargetARN;
-        NetworkInterfaceId?: StorageGatewayNetworkInterfaceId;
-        NetworkInterfacePort?: StorageGatewayinteger;
-        ChapEnabled?: StorageGatewayboolean;
-    }
-
-    export interface StorageGatewayDisableGatewayInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDisableGatewayOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayDisk {
-        DiskId?: StorageGatewayDiskId;
-        DiskPath?: StorageGatewaystring;
-        DiskNode?: StorageGatewaystring;
-        DiskStatus?: StorageGatewaystring;
-        DiskSizeInBytes?: StorageGatewaylong;
-        DiskAllocationType?: StorageGatewayDiskAllocationType;
-        DiskAllocationResource?: StorageGatewaystring;
-    }
-
-    export type StorageGatewayDiskAllocationType = string;
-    export type StorageGatewayDiskId = string;
-    export type StorageGatewayDiskIds = Array<StorageGatewayDiskId>;
-    export type StorageGatewayDisks = Array<StorageGatewayDisk>;
-    export type StorageGatewayDoubleObject = number;
-    export type StorageGatewayErrorCode = string;
-    export type StorageGatewayGatewayARN = string;
-    export type StorageGatewayGatewayId = string;
-    export interface StorageGatewayGatewayInfo {
-        GatewayARN?: StorageGatewayGatewayARN;
-        GatewayType?: StorageGatewayGatewayType;
-        GatewayOperationalState?: StorageGatewayGatewayOperationalState;
-        GatewayName?: StorageGatewaystring;
-    }
-
-    export type StorageGatewayGatewayName = string; // pattern: "^[ -\.0-\[\]-~]*[!-\.0-\[\]-~][ -\.0-\[\]-~]*$"
-    export type StorageGatewayGatewayNetworkInterfaces = Array<StorageGatewayNetworkInterface>;
-    export type StorageGatewayGatewayOperationalState = string;
-    export type StorageGatewayGatewayState = string;
-    export type StorageGatewayGatewayTimezone = string;
-    export type StorageGatewayGatewayType = string;
-    export type StorageGatewayGateways = Array<StorageGatewayGatewayInfo>;
-    export type StorageGatewayHourOfDay = number;
-    export type StorageGatewayInitiator = string;
-    export type StorageGatewayInitiators = Array<StorageGatewayInitiator>;
-    export interface StorageGatewayInternalServerError {
-        message?: StorageGatewaystring;
-        error?: StorageGatewayStorageGatewayError;
-    }
-
-    export interface StorageGatewayInvalidGatewayRequestException {
-        message?: StorageGatewaystring;
-        error?: StorageGatewayStorageGatewayError;
-    }
-
-    export type StorageGatewayIqnName = string; // pattern: "[0-9a-z:.-]+"
-    export type StorageGatewayLastSoftwareUpdate = string;
-    export interface StorageGatewayListGatewaysInput {
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayListGatewaysOutput {
-        Gateways?: StorageGatewayGateways;
-        Marker?: StorageGatewayMarker;
-    }
-
-    export interface StorageGatewayListLocalDisksInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayListLocalDisksOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        Disks?: StorageGatewayDisks;
-    }
-
-    export interface StorageGatewayListTagsForResourceInput {
-        ResourceARN?: StorageGatewayResourceARN;
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayListTagsForResourceOutput {
-        ResourceARN?: StorageGatewayResourceARN;
-        Marker?: StorageGatewayMarker;
-        Tags?: StorageGatewayTags;
-    }
-
-    export interface StorageGatewayListVolumeInitiatorsInput {
-        VolumeARN: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayListVolumeInitiatorsOutput {
-        Initiators?: StorageGatewayInitiators;
-    }
-
-    export interface StorageGatewayListVolumeRecoveryPointsInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayListVolumeRecoveryPointsOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        VolumeRecoveryPointInfos?: StorageGatewayVolumeRecoveryPointInfos;
-    }
-
-    export interface StorageGatewayListVolumesInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        Marker?: StorageGatewayMarker;
-        Limit?: StorageGatewayPositiveIntObject;
-    }
-
-    export interface StorageGatewayListVolumesOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        Marker?: StorageGatewayMarker;
-        VolumeInfos?: StorageGatewayVolumeInfos;
-    }
-
-    export type StorageGatewayMarker = string;
-    export type StorageGatewayMediumChangerType = string;
-    export type StorageGatewayMinuteOfHour = number;
-    export interface StorageGatewayNetworkInterface {
-        Ipv4Address?: StorageGatewaystring;
-        MacAddress?: StorageGatewaystring;
-        Ipv6Address?: StorageGatewaystring;
-    }
-
-    export type StorageGatewayNetworkInterfaceId = string; // pattern: "\A(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\z"
-    export type StorageGatewayNextUpdateAvailabilityDate = string;
-    export type StorageGatewayNumTapesToCreate = number;
-    export type StorageGatewayPositiveIntObject = number;
-    export type StorageGatewayRecurrenceInHours = number;
-    export type StorageGatewayRegionId = string;
-    export interface StorageGatewayRemoveTagsFromResourceInput {
-        ResourceARN?: StorageGatewayResourceARN;
-        TagKeys?: StorageGatewayTagKeys;
-    }
-
-    export interface StorageGatewayRemoveTagsFromResourceOutput {
-        ResourceARN?: StorageGatewayResourceARN;
-    }
-
-    export interface StorageGatewayResetCacheInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayResetCacheOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export type StorageGatewayResourceARN = string;
-    export interface StorageGatewayRetrieveTapeArchiveInput {
-        TapeARN: StorageGatewayTapeARN;
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayRetrieveTapeArchiveOutput {
-        TapeARN?: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayRetrieveTapeRecoveryPointInput {
-        TapeARN: StorageGatewayTapeARN;
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayRetrieveTapeRecoveryPointOutput {
-        TapeARN?: StorageGatewayTapeARN;
-    }
-
-    export interface StorageGatewayShutdownGatewayInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayShutdownGatewayOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export type StorageGatewaySnapshotDescription = string;
-    export type StorageGatewaySnapshotId = string; // pattern: "\Asnap-[0-9a-fA-F]{8}\z"
-    export interface StorageGatewayStartGatewayInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayStartGatewayOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayStorageGatewayError {
-        errorCode?: StorageGatewayErrorCode;
-        errorDetails?: StorageGatewayerrorDetails;
-    }
-
-    export interface StorageGatewayStorediSCSIVolume {
-        VolumeARN?: StorageGatewayVolumeARN;
-        VolumeId?: StorageGatewayVolumeId;
-        VolumeType?: StorageGatewayVolumeType;
-        VolumeStatus?: StorageGatewayVolumeStatus;
-        VolumeSizeInBytes?: StorageGatewaylong;
-        VolumeProgress?: StorageGatewayDoubleObject;
-        VolumeDiskId?: StorageGatewayDiskId;
-        SourceSnapshotId?: StorageGatewaySnapshotId;
-        PreservedExistingData?: StorageGatewayboolean;
-        VolumeiSCSIAttributes?: StorageGatewayVolumeiSCSIAttributes;
-    }
-
-    export type StorageGatewayStorediSCSIVolumes = Array<StorageGatewayStorediSCSIVolume>;
-    export interface StorageGatewayTag {
-        Key: StorageGatewayTagKey;
-        Value: StorageGatewayTagValue;
-    }
-
-    export type StorageGatewayTagKey = string; // pattern: "^([\p{L}\p{Z}\p{N}_.:/=+\-%@]*)$"
-    export type StorageGatewayTagKeys = Array<StorageGatewayTagKey>;
-    export type StorageGatewayTagValue = string;
-    export type StorageGatewayTags = Array<StorageGatewayTag>;
-    export interface StorageGatewayTape {
-        TapeARN?: StorageGatewayTapeARN;
-        TapeBarcode?: StorageGatewayTapeBarcode;
-        TapeSizeInBytes?: StorageGatewayTapeSize;
-        TapeStatus?: StorageGatewayTapeStatus;
-        VTLDevice?: StorageGatewayVTLDeviceARN;
-        Progress?: StorageGatewayDoubleObject;
-    }
-
-    export type StorageGatewayTapeARN = string;
-    export type StorageGatewayTapeARNs = Array<StorageGatewayTapeARN>;
-    export interface StorageGatewayTapeArchive {
-        TapeARN?: StorageGatewayTapeARN;
-        TapeBarcode?: StorageGatewayTapeBarcode;
-        TapeSizeInBytes?: StorageGatewayTapeSize;
-        CompletionTime?: StorageGatewayTime;
-        RetrievedTo?: StorageGatewayGatewayARN;
-        TapeStatus?: StorageGatewayTapeArchiveStatus;
-    }
-
-    export type StorageGatewayTapeArchiveStatus = string;
-    export type StorageGatewayTapeArchives = Array<StorageGatewayTapeArchive>;
-    export type StorageGatewayTapeBarcode = string; // pattern: "^[A-Z0-9]*$"
-    export type StorageGatewayTapeBarcodePrefix = string; // pattern: "^[A-Z]*$"
-    export type StorageGatewayTapeDriveType = string;
-    export interface StorageGatewayTapeRecoveryPointInfo {
-        TapeARN?: StorageGatewayTapeARN;
-        TapeRecoveryPointTime?: StorageGatewayTime;
-        TapeSizeInBytes?: StorageGatewayTapeSize;
-        TapeStatus?: StorageGatewayTapeRecoveryPointStatus;
-    }
-
-    export type StorageGatewayTapeRecoveryPointInfos = Array<StorageGatewayTapeRecoveryPointInfo>;
-    export type StorageGatewayTapeRecoveryPointStatus = string;
-    export type StorageGatewayTapeSize = number;
-    export type StorageGatewayTapeStatus = string;
-    export type StorageGatewayTapes = Array<StorageGatewayTape>;
-    export type StorageGatewayTargetARN = string;
-    export type StorageGatewayTargetName = string; // pattern: "^[-\.;a-z0-9]+$"
-    export type StorageGatewayTime = number;
-    export interface StorageGatewayUpdateBandwidthRateLimitInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        AverageUploadRateLimitInBitsPerSec?: StorageGatewayBandwidthUploadRateLimit;
-        AverageDownloadRateLimitInBitsPerSec?: StorageGatewayBandwidthDownloadRateLimit;
-    }
-
-    export interface StorageGatewayUpdateBandwidthRateLimitOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
+      activateGateway(params: StorageGateway.ActivateGatewayInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ActivateGatewayOutput|any) => void): Request;
+      addCache(params: StorageGateway.AddCacheInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.AddCacheOutput|any) => void): Request;
+      addTagsToResource(params: StorageGateway.AddTagsToResourceInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.AddTagsToResourceOutput|any) => void): Request;
+      addUploadBuffer(params: StorageGateway.AddUploadBufferInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.AddUploadBufferOutput|any) => void): Request;
+      addWorkingStorage(params: StorageGateway.AddWorkingStorageInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.AddWorkingStorageOutput|any) => void): Request;
+      cancelArchival(params: StorageGateway.CancelArchivalInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CancelArchivalOutput|any) => void): Request;
+      cancelRetrieval(params: StorageGateway.CancelRetrievalInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CancelRetrievalOutput|any) => void): Request;
+      createCachediSCSIVolume(params: StorageGateway.CreateCachediSCSIVolumeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CreateCachediSCSIVolumeOutput|any) => void): Request;
+      createSnapshot(params: StorageGateway.CreateSnapshotInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CreateSnapshotOutput|any) => void): Request;
+      createSnapshotFromVolumeRecoveryPoint(params: StorageGateway.CreateSnapshotFromVolumeRecoveryPointInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CreateSnapshotFromVolumeRecoveryPointOutput|any) => void): Request;
+      createStorediSCSIVolume(params: StorageGateway.CreateStorediSCSIVolumeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CreateStorediSCSIVolumeOutput|any) => void): Request;
+      createTapes(params: StorageGateway.CreateTapesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.CreateTapesOutput|any) => void): Request;
+      deleteBandwidthRateLimit(params: StorageGateway.DeleteBandwidthRateLimitInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteBandwidthRateLimitOutput|any) => void): Request;
+      deleteChapCredentials(params: StorageGateway.DeleteChapCredentialsInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteChapCredentialsOutput|any) => void): Request;
+      deleteGateway(params: StorageGateway.DeleteGatewayInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteGatewayOutput|any) => void): Request;
+      deleteSnapshotSchedule(params: StorageGateway.DeleteSnapshotScheduleInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteSnapshotScheduleOutput|any) => void): Request;
+      deleteTape(params: StorageGateway.DeleteTapeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteTapeOutput|any) => void): Request;
+      deleteTapeArchive(params: StorageGateway.DeleteTapeArchiveInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteTapeArchiveOutput|any) => void): Request;
+      deleteVolume(params: StorageGateway.DeleteVolumeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DeleteVolumeOutput|any) => void): Request;
+      describeBandwidthRateLimit(params: StorageGateway.DescribeBandwidthRateLimitInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeBandwidthRateLimitOutput|any) => void): Request;
+      describeCache(params: StorageGateway.DescribeCacheInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeCacheOutput|any) => void): Request;
+      describeCachediSCSIVolumes(params: StorageGateway.DescribeCachediSCSIVolumesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeCachediSCSIVolumesOutput|any) => void): Request;
+      describeChapCredentials(params: StorageGateway.DescribeChapCredentialsInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeChapCredentialsOutput|any) => void): Request;
+      describeGatewayInformation(params: StorageGateway.DescribeGatewayInformationInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeGatewayInformationOutput|any) => void): Request;
+      describeMaintenanceStartTime(params: StorageGateway.DescribeMaintenanceStartTimeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeMaintenanceStartTimeOutput|any) => void): Request;
+      describeSnapshotSchedule(params: StorageGateway.DescribeSnapshotScheduleInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeSnapshotScheduleOutput|any) => void): Request;
+      describeStorediSCSIVolumes(params: StorageGateway.DescribeStorediSCSIVolumesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeStorediSCSIVolumesOutput|any) => void): Request;
+      describeTapeArchives(params: StorageGateway.DescribeTapeArchivesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeTapeArchivesOutput|any) => void): Request;
+      describeTapeRecoveryPoints(params: StorageGateway.DescribeTapeRecoveryPointsInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeTapeRecoveryPointsOutput|any) => void): Request;
+      describeTapes(params: StorageGateway.DescribeTapesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeTapesOutput|any) => void): Request;
+      describeUploadBuffer(params: StorageGateway.DescribeUploadBufferInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeUploadBufferOutput|any) => void): Request;
+      describeVTLDevices(params: StorageGateway.DescribeVTLDevicesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeVTLDevicesOutput|any) => void): Request;
+      describeWorkingStorage(params: StorageGateway.DescribeWorkingStorageInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DescribeWorkingStorageOutput|any) => void): Request;
+      disableGateway(params: StorageGateway.DisableGatewayInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.DisableGatewayOutput|any) => void): Request;
+      listGateways(params: StorageGateway.ListGatewaysInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ListGatewaysOutput|any) => void): Request;
+      listLocalDisks(params: StorageGateway.ListLocalDisksInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ListLocalDisksOutput|any) => void): Request;
+      listTagsForResource(params: StorageGateway.ListTagsForResourceInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ListTagsForResourceOutput|any) => void): Request;
+      listVolumeInitiators(params: StorageGateway.ListVolumeInitiatorsInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ListVolumeInitiatorsOutput|any) => void): Request;
+      listVolumeRecoveryPoints(params: StorageGateway.ListVolumeRecoveryPointsInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ListVolumeRecoveryPointsOutput|any) => void): Request;
+      listVolumes(params: StorageGateway.ListVolumesInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ListVolumesOutput|any) => void): Request;
+      removeTagsFromResource(params: StorageGateway.RemoveTagsFromResourceInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.RemoveTagsFromResourceOutput|any) => void): Request;
+      resetCache(params: StorageGateway.ResetCacheInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ResetCacheOutput|any) => void): Request;
+      retrieveTapeArchive(params: StorageGateway.RetrieveTapeArchiveInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.RetrieveTapeArchiveOutput|any) => void): Request;
+      retrieveTapeRecoveryPoint(params: StorageGateway.RetrieveTapeRecoveryPointInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.RetrieveTapeRecoveryPointOutput|any) => void): Request;
+      shutdownGateway(params: StorageGateway.ShutdownGatewayInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.ShutdownGatewayOutput|any) => void): Request;
+      startGateway(params: StorageGateway.StartGatewayInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.StartGatewayOutput|any) => void): Request;
+      updateBandwidthRateLimit(params: StorageGateway.UpdateBandwidthRateLimitInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateBandwidthRateLimitOutput|any) => void): Request;
+      updateChapCredentials(params: StorageGateway.UpdateChapCredentialsInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateChapCredentialsOutput|any) => void): Request;
+      updateGatewayInformation(params: StorageGateway.UpdateGatewayInformationInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateGatewayInformationOutput|any) => void): Request;
+      updateGatewaySoftwareNow(params: StorageGateway.UpdateGatewaySoftwareNowInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateGatewaySoftwareNowOutput|any) => void): Request;
+      updateMaintenanceStartTime(params: StorageGateway.UpdateMaintenanceStartTimeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateMaintenanceStartTimeOutput|any) => void): Request;
+      updateSnapshotSchedule(params: StorageGateway.UpdateSnapshotScheduleInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateSnapshotScheduleOutput|any) => void): Request;
+      updateVTLDeviceType(params: StorageGateway.UpdateVTLDeviceTypeInput, callback?: (err: StorageGateway.InvalidGatewayRequestException|StorageGateway.InternalServerError|any, data: StorageGateway.UpdateVTLDeviceTypeOutput|any) => void): Request;
+    }
+    
+    export module StorageGateway {
+        export type ActivationKey = string;    // max: 50, min: 1
+        export type BandwidthDownloadRateLimit = number;    // min: 102400
+        export type BandwidthType = string;    // max: 25, min: 3
+        export type BandwidthUploadRateLimit = number;    // min: 51200
+        export type CachediSCSIVolumes = CachediSCSIVolume[];
+        export type ChapCredentials = ChapInfo[];
+        export type ChapSecret = string;    // max: 100, min: 1
+        export type ClientToken = string;    // max: 100, min: 5
+        export type DayOfWeek = number;    // max: 6
+        export type Description = string;    // max: 255, min: 1
+        export type DeviceType = string;    // max: 50, min: 2
+        export type DiskAllocationType = string;    // max: 100, min: 3
+        export type DiskId = string;    // max: 300, min: 1
+        export type DiskIds = DiskId[];
+        export type Disks = Disk[];
+        export type DoubleObject = number;
+        export type ErrorCode = string;
+        export type GatewayARN = string;    // max: 500, min: 50
+        export type GatewayId = string;    // max: 30, min: 12
+        export type GatewayName = string;    // pattern: &quot;^[ -\.0-\[\]-~]*[!-\.0-\[\]-~][ -\.0-\[\]-~]*$&quot;, max: 255, min: 2
+        export type GatewayNetworkInterfaces = NetworkInterface[];
+        export type GatewayOperationalState = string;    // max: 25, min: 2
+        export type GatewayState = string;    // max: 25, min: 2
+        export type GatewayTimezone = string;    // max: 10, min: 3
+        export type GatewayType = string;    // max: 20, min: 2
+        export type Gateways = GatewayInfo[];
+        export type HourOfDay = number;    // max: 23
+        export type Initiator = string;    // max: 50, min: 1
+        export type Initiators = Initiator[];
+        export type IqnName = string;    // pattern: &quot;[0-9a-z:.-]+&quot;, max: 255, min: 1
+        export type LastSoftwareUpdate = string;    // max: 25, min: 1
+        export type Marker = string;    // max: 1000, min: 1
+        export type MediumChangerType = string;    // max: 50, min: 2
+        export type MinuteOfHour = number;    // max: 59
+        export type NetworkInterfaceId = string;    // pattern: &quot;\A(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\z&quot;
+        export type NextUpdateAvailabilityDate = string;    // max: 25, min: 1
+        export type NumTapesToCreate = number;    // max: 10, min: 1
+        export type PositiveIntObject = number;    // min: 1
+        export type RecurrenceInHours = number;    // max: 24, min: 1
+        export type RegionId = string;    // max: 25, min: 1
+        export type ResourceARN = string;    // max: 500, min: 50
+        export type SnapshotDescription = string;    // max: 255, min: 1
+        export type SnapshotId = string;    // pattern: &quot;\Asnap-[0-9a-fA-F]{8}\z&quot;
+        export type StorediSCSIVolumes = StorediSCSIVolume[];
+        export type TagKey = string;    // pattern: &quot;^([\p{L}\p{Z}\p{N}_.:/=+\-%@]*)$&quot;, max: 128, min: 1
+        export type TagKeys = TagKey[];
+        export type TagValue = string;    // max: 256
+        export type Tags = Tag[];
+        export type TapeARN = string;    // max: 500, min: 50
+        export type TapeARNs = TapeARN[];
+        export type TapeArchiveStatus = string;
+        export type TapeArchives = TapeArchive[];
+        export type TapeBarcode = string;    // pattern: &quot;^[A-Z0-9]*$&quot;, max: 16, min: 7
+        export type TapeBarcodePrefix = string;    // pattern: &quot;^[A-Z]*$&quot;, max: 4, min: 1
+        export type TapeDriveType = string;    // max: 50, min: 2
+        export type TapeRecoveryPointInfos = TapeRecoveryPointInfo[];
+        export type TapeRecoveryPointStatus = string;
+        export type TapeSize = number;
+        export type TapeStatus = string;
+        export type Tapes = Tape[];
+        export type TargetARN = string;    // max: 800, min: 50
+        export type TargetName = string;    // pattern: &quot;^[-\.;a-z0-9]+$&quot;, max: 200, min: 1
+        export type Time = number;
+        export type VTLDeviceARN = string;    // max: 500, min: 50
+        export type VTLDeviceARNs = VTLDeviceARN[];
+        export type VTLDeviceProductIdentifier = string;
+        export type VTLDeviceType = string;
+        export type VTLDeviceVendor = string;
+        export type VTLDevices = VTLDevice[];
+        export type VolumeARN = string;    // max: 500, min: 50
+        export type VolumeARNs = VolumeARN[];
+        export type VolumeId = string;    // max: 30, min: 12
+        export type VolumeInfos = VolumeInfo[];
+        export type VolumeRecoveryPointInfos = VolumeRecoveryPointInfo[];
+        export type VolumeStatus = string;    // max: 50, min: 3
+        export type VolumeType = string;    // max: 100, min: 3
+        export type double = number;
+        export type errorDetails = {[key:string]: string};
+        export type integer = number;
+        export type long = number;
+
+        export interface ActivateGatewayInput {
+            ActivationKey: ActivationKey;            
+            GatewayName: GatewayName;            
+            GatewayTimezone: GatewayTimezone;            
+            GatewayRegion: RegionId;            
+            GatewayType?: GatewayType;            
+            TapeDriveType?: TapeDriveType;            
+            MediumChangerType?: MediumChangerType;            
+        }
+        export interface ActivateGatewayOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface AddCacheInput {
+            GatewayARN: GatewayARN;            
+            DiskIds: DiskIds;            
+        }
+        export interface AddCacheOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface AddTagsToResourceInput {
+            ResourceARN: ResourceARN;            
+            Tags: Tags;            
+        }
+        export interface AddTagsToResourceOutput {
+            ResourceARN?: ResourceARN;            
+        }
+        export interface AddUploadBufferInput {
+            GatewayARN: GatewayARN;            
+            DiskIds: DiskIds;            
+        }
+        export interface AddUploadBufferOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface AddWorkingStorageInput {
+            GatewayARN: GatewayARN;            
+            DiskIds: DiskIds;            
+        }
+        export interface AddWorkingStorageOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface CachediSCSIVolume {
+            VolumeARN?: VolumeARN;            
+            VolumeId?: VolumeId;            
+            VolumeType?: VolumeType;            
+            VolumeStatus?: VolumeStatus;            
+            VolumeSizeInBytes?: long;            
+            VolumeProgress?: DoubleObject;            
+            SourceSnapshotId?: SnapshotId;            
+            VolumeiSCSIAttributes?: VolumeiSCSIAttributes;            
+        }
+        export interface CancelArchivalInput {
+            GatewayARN: GatewayARN;            
+            TapeARN: TapeARN;            
+        }
+        export interface CancelArchivalOutput {
+            TapeARN?: TapeARN;            
+        }
+        export interface CancelRetrievalInput {
+            GatewayARN: GatewayARN;            
+            TapeARN: TapeARN;            
+        }
+        export interface CancelRetrievalOutput {
+            TapeARN?: TapeARN;            
+        }
+        export interface ChapInfo {
+            TargetARN?: TargetARN;            
+            SecretToAuthenticateInitiator?: ChapSecret;            
+            InitiatorName?: IqnName;            
+            SecretToAuthenticateTarget?: ChapSecret;            
+        }
+        export interface CreateCachediSCSIVolumeInput {
+            GatewayARN: GatewayARN;            
+            VolumeSizeInBytes: long;            
+            SnapshotId?: SnapshotId;            
+            TargetName: TargetName;            
+            NetworkInterfaceId: NetworkInterfaceId;            
+            ClientToken: ClientToken;            
+        }
+        export interface CreateCachediSCSIVolumeOutput {
+            VolumeARN?: VolumeARN;            
+            TargetARN?: TargetARN;            
+        }
+        export interface CreateSnapshotFromVolumeRecoveryPointInput {
+            VolumeARN: VolumeARN;            
+            SnapshotDescription: SnapshotDescription;            
+        }
+        export interface CreateSnapshotFromVolumeRecoveryPointOutput {
+            SnapshotId?: SnapshotId;            
+            VolumeARN?: VolumeARN;            
+            VolumeRecoveryPointTime?: string;            
+        }
+        export interface CreateSnapshotInput {
+            VolumeARN: VolumeARN;            
+            SnapshotDescription: SnapshotDescription;            
+        }
+        export interface CreateSnapshotOutput {
+            VolumeARN?: VolumeARN;            
+            SnapshotId?: SnapshotId;            
+        }
+        export interface CreateStorediSCSIVolumeInput {
+            GatewayARN: GatewayARN;            
+            DiskId: DiskId;            
+            SnapshotId?: SnapshotId;            
+            PreserveExistingData: boolean;            
+            TargetName: TargetName;            
+            NetworkInterfaceId: NetworkInterfaceId;            
+        }
+        export interface CreateStorediSCSIVolumeOutput {
+            VolumeARN?: VolumeARN;            
+            VolumeSizeInBytes?: long;            
+            TargetARN?: TargetARN;            
+        }
+        export interface CreateTapesInput {
+            GatewayARN: GatewayARN;            
+            TapeSizeInBytes: TapeSize;            
+            ClientToken: ClientToken;            
+            NumTapesToCreate: NumTapesToCreate;            
+            TapeBarcodePrefix: TapeBarcodePrefix;            
+        }
+        export interface CreateTapesOutput {
+            TapeARNs?: TapeARNs;            
+        }
+        export interface DeleteBandwidthRateLimitInput {
+            GatewayARN: GatewayARN;            
+            BandwidthType: BandwidthType;            
+        }
+        export interface DeleteBandwidthRateLimitOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface DeleteChapCredentialsInput {
+            TargetARN: TargetARN;            
+            InitiatorName: IqnName;            
+        }
+        export interface DeleteChapCredentialsOutput {
+            TargetARN?: TargetARN;            
+            InitiatorName?: IqnName;            
+        }
+        export interface DeleteGatewayInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DeleteGatewayOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface DeleteSnapshotScheduleInput {
+            VolumeARN: VolumeARN;            
+        }
+        export interface DeleteSnapshotScheduleOutput {
+            VolumeARN?: VolumeARN;            
+        }
+        export interface DeleteTapeArchiveInput {
+            TapeARN: TapeARN;            
+        }
+        export interface DeleteTapeArchiveOutput {
+            TapeARN?: TapeARN;            
+        }
+        export interface DeleteTapeInput {
+            GatewayARN: GatewayARN;            
+            TapeARN: TapeARN;            
+        }
+        export interface DeleteTapeOutput {
+            TapeARN?: TapeARN;            
+        }
+        export interface DeleteVolumeInput {
+            VolumeARN: VolumeARN;            
+        }
+        export interface DeleteVolumeOutput {
+            VolumeARN?: VolumeARN;            
+        }
+        export interface DescribeBandwidthRateLimitInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DescribeBandwidthRateLimitOutput {
+            GatewayARN?: GatewayARN;            
+            AverageUploadRateLimitInBitsPerSec?: BandwidthUploadRateLimit;            
+            AverageDownloadRateLimitInBitsPerSec?: BandwidthDownloadRateLimit;            
+        }
+        export interface DescribeCacheInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DescribeCacheOutput {
+            GatewayARN?: GatewayARN;            
+            DiskIds?: DiskIds;            
+            CacheAllocatedInBytes?: long;            
+            CacheUsedPercentage?: double;            
+            CacheDirtyPercentage?: double;            
+            CacheHitPercentage?: double;            
+            CacheMissPercentage?: double;            
+        }
+        export interface DescribeCachediSCSIVolumesInput {
+            VolumeARNs: VolumeARNs;            
+        }
+        export interface DescribeCachediSCSIVolumesOutput {
+            CachediSCSIVolumes?: CachediSCSIVolumes;            
+        }
+        export interface DescribeChapCredentialsInput {
+            TargetARN: TargetARN;            
+        }
+        export interface DescribeChapCredentialsOutput {
+            ChapCredentials?: ChapCredentials;            
+        }
+        export interface DescribeGatewayInformationInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DescribeGatewayInformationOutput {
+            GatewayARN?: GatewayARN;            
+            GatewayId?: GatewayId;            
+            GatewayName?: string;            
+            GatewayTimezone?: GatewayTimezone;            
+            GatewayState?: GatewayState;            
+            GatewayNetworkInterfaces?: GatewayNetworkInterfaces;            
+            GatewayType?: GatewayType;            
+            NextUpdateAvailabilityDate?: NextUpdateAvailabilityDate;            
+            LastSoftwareUpdate?: LastSoftwareUpdate;            
+        }
+        export interface DescribeMaintenanceStartTimeInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DescribeMaintenanceStartTimeOutput {
+            GatewayARN?: GatewayARN;            
+            HourOfDay?: HourOfDay;            
+            MinuteOfHour?: MinuteOfHour;            
+            DayOfWeek?: DayOfWeek;            
+            Timezone?: GatewayTimezone;            
+        }
+        export interface DescribeSnapshotScheduleInput {
+            VolumeARN: VolumeARN;            
+        }
+        export interface DescribeSnapshotScheduleOutput {
+            VolumeARN?: VolumeARN;            
+            StartAt?: HourOfDay;            
+            RecurrenceInHours?: RecurrenceInHours;            
+            Description?: Description;            
+            Timezone?: GatewayTimezone;            
+        }
+        export interface DescribeStorediSCSIVolumesInput {
+            VolumeARNs: VolumeARNs;            
+        }
+        export interface DescribeStorediSCSIVolumesOutput {
+            StorediSCSIVolumes?: StorediSCSIVolumes;            
+        }
+        export interface DescribeTapeArchivesInput {
+            TapeARNs?: TapeARNs;            
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface DescribeTapeArchivesOutput {
+            TapeArchives?: TapeArchives;            
+            Marker?: Marker;            
+        }
+        export interface DescribeTapeRecoveryPointsInput {
+            GatewayARN: GatewayARN;            
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface DescribeTapeRecoveryPointsOutput {
+            GatewayARN?: GatewayARN;            
+            TapeRecoveryPointInfos?: TapeRecoveryPointInfos;            
+            Marker?: Marker;            
+        }
+        export interface DescribeTapesInput {
+            GatewayARN: GatewayARN;            
+            TapeARNs?: TapeARNs;            
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface DescribeTapesOutput {
+            Tapes?: Tapes;            
+            Marker?: Marker;            
+        }
+        export interface DescribeUploadBufferInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DescribeUploadBufferOutput {
+            GatewayARN?: GatewayARN;            
+            DiskIds?: DiskIds;            
+            UploadBufferUsedInBytes?: long;            
+            UploadBufferAllocatedInBytes?: long;            
+        }
+        export interface DescribeVTLDevicesInput {
+            GatewayARN: GatewayARN;            
+            VTLDeviceARNs?: VTLDeviceARNs;            
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface DescribeVTLDevicesOutput {
+            GatewayARN?: GatewayARN;            
+            VTLDevices?: VTLDevices;            
+            Marker?: Marker;            
+        }
+        export interface DescribeWorkingStorageInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DescribeWorkingStorageOutput {
+            GatewayARN?: GatewayARN;            
+            DiskIds?: DiskIds;            
+            WorkingStorageUsedInBytes?: long;            
+            WorkingStorageAllocatedInBytes?: long;            
+        }
+        export interface DeviceiSCSIAttributes {
+            TargetARN?: TargetARN;            
+            NetworkInterfaceId?: NetworkInterfaceId;            
+            NetworkInterfacePort?: integer;            
+            ChapEnabled?: boolean;            
+        }
+        export interface DisableGatewayInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface DisableGatewayOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface Disk {
+            DiskId?: DiskId;            
+            DiskPath?: string;            
+            DiskNode?: string;            
+            DiskStatus?: string;            
+            DiskSizeInBytes?: long;            
+            DiskAllocationType?: DiskAllocationType;            
+            DiskAllocationResource?: string;            
+        }
+        export interface GatewayInfo {
+            GatewayARN?: GatewayARN;            
+            GatewayType?: GatewayType;            
+            GatewayOperationalState?: GatewayOperationalState;            
+            GatewayName?: string;            
+        }
+        export interface InternalServerError {
+            message?: string;            
+            error?: StorageGatewayError;            
+        }
+        export interface InvalidGatewayRequestException {
+            message?: string;            
+            error?: StorageGatewayError;            
+        }
+        export interface ListGatewaysInput {
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface ListGatewaysOutput {
+            Gateways?: Gateways;            
+            Marker?: Marker;            
+        }
+        export interface ListLocalDisksInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface ListLocalDisksOutput {
+            GatewayARN?: GatewayARN;            
+            Disks?: Disks;            
+        }
+        export interface ListTagsForResourceInput {
+            ResourceARN?: ResourceARN;            
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface ListTagsForResourceOutput {
+            ResourceARN?: ResourceARN;            
+            Marker?: Marker;            
+            Tags?: Tags;            
+        }
+        export interface ListVolumeInitiatorsInput {
+            VolumeARN: VolumeARN;            
+        }
+        export interface ListVolumeInitiatorsOutput {
+            Initiators?: Initiators;            
+        }
+        export interface ListVolumeRecoveryPointsInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface ListVolumeRecoveryPointsOutput {
+            GatewayARN?: GatewayARN;            
+            VolumeRecoveryPointInfos?: VolumeRecoveryPointInfos;            
+        }
+        export interface ListVolumesInput {
+            GatewayARN: GatewayARN;            
+            Marker?: Marker;            
+            Limit?: PositiveIntObject;            
+        }
+        export interface ListVolumesOutput {
+            GatewayARN?: GatewayARN;            
+            Marker?: Marker;            
+            VolumeInfos?: VolumeInfos;            
+        }
+        export interface NetworkInterface {
+            Ipv4Address?: string;            
+            MacAddress?: string;            
+            Ipv6Address?: string;            
+        }
+        export interface RemoveTagsFromResourceInput {
+            ResourceARN?: ResourceARN;            
+            TagKeys?: TagKeys;            
+        }
+        export interface RemoveTagsFromResourceOutput {
+            ResourceARN?: ResourceARN;            
+        }
+        export interface ResetCacheInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface ResetCacheOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface RetrieveTapeArchiveInput {
+            TapeARN: TapeARN;            
+            GatewayARN: GatewayARN;            
+        }
+        export interface RetrieveTapeArchiveOutput {
+            TapeARN?: TapeARN;            
+        }
+        export interface RetrieveTapeRecoveryPointInput {
+            TapeARN: TapeARN;            
+            GatewayARN: GatewayARN;            
+        }
+        export interface RetrieveTapeRecoveryPointOutput {
+            TapeARN?: TapeARN;            
+        }
+        export interface ShutdownGatewayInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface ShutdownGatewayOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface StartGatewayInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface StartGatewayOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface StorageGatewayError {
+            errorCode?: ErrorCode;            
+            errorDetails?: errorDetails;            
+        }
+        export interface StorediSCSIVolume {
+            VolumeARN?: VolumeARN;            
+            VolumeId?: VolumeId;            
+            VolumeType?: VolumeType;            
+            VolumeStatus?: VolumeStatus;            
+            VolumeSizeInBytes?: long;            
+            VolumeProgress?: DoubleObject;            
+            VolumeDiskId?: DiskId;            
+            SourceSnapshotId?: SnapshotId;            
+            PreservedExistingData?: boolean;            
+            VolumeiSCSIAttributes?: VolumeiSCSIAttributes;            
+        }
+        export interface Tag {
+            Key: TagKey;            
+            Value: TagValue;            
+        }
+        export interface Tape {
+            TapeARN?: TapeARN;            
+            TapeBarcode?: TapeBarcode;            
+            TapeSizeInBytes?: TapeSize;            
+            TapeStatus?: TapeStatus;            
+            VTLDevice?: VTLDeviceARN;            
+            Progress?: DoubleObject;            
+        }
+        export interface TapeArchive {
+            TapeARN?: TapeARN;            
+            TapeBarcode?: TapeBarcode;            
+            TapeSizeInBytes?: TapeSize;            
+            CompletionTime?: Time;            
+            RetrievedTo?: GatewayARN;            
+            TapeStatus?: TapeArchiveStatus;            
+        }
+        export interface TapeRecoveryPointInfo {
+            TapeARN?: TapeARN;            
+            TapeRecoveryPointTime?: Time;            
+            TapeSizeInBytes?: TapeSize;            
+            TapeStatus?: TapeRecoveryPointStatus;            
+        }
+        export interface UpdateBandwidthRateLimitInput {
+            GatewayARN: GatewayARN;            
+            AverageUploadRateLimitInBitsPerSec?: BandwidthUploadRateLimit;            
+            AverageDownloadRateLimitInBitsPerSec?: BandwidthDownloadRateLimit;            
+        }
+        export interface UpdateBandwidthRateLimitOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface UpdateChapCredentialsInput {
+            TargetARN: TargetARN;            
+            SecretToAuthenticateInitiator: ChapSecret;            
+            InitiatorName: IqnName;            
+            SecretToAuthenticateTarget?: ChapSecret;            
+        }
+        export interface UpdateChapCredentialsOutput {
+            TargetARN?: TargetARN;            
+            InitiatorName?: IqnName;            
+        }
+        export interface UpdateGatewayInformationInput {
+            GatewayARN: GatewayARN;            
+            GatewayName?: GatewayName;            
+            GatewayTimezone?: GatewayTimezone;            
+        }
+        export interface UpdateGatewayInformationOutput {
+            GatewayARN?: GatewayARN;            
+            GatewayName?: string;            
+        }
+        export interface UpdateGatewaySoftwareNowInput {
+            GatewayARN: GatewayARN;            
+        }
+        export interface UpdateGatewaySoftwareNowOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface UpdateMaintenanceStartTimeInput {
+            GatewayARN: GatewayARN;            
+            HourOfDay: HourOfDay;            
+            MinuteOfHour: MinuteOfHour;            
+            DayOfWeek: DayOfWeek;            
+        }
+        export interface UpdateMaintenanceStartTimeOutput {
+            GatewayARN?: GatewayARN;            
+        }
+        export interface UpdateSnapshotScheduleInput {
+            VolumeARN: VolumeARN;            
+            StartAt: HourOfDay;            
+            RecurrenceInHours: RecurrenceInHours;            
+            Description?: Description;            
+        }
+        export interface UpdateSnapshotScheduleOutput {
+            VolumeARN?: VolumeARN;            
+        }
+        export interface UpdateVTLDeviceTypeInput {
+            VTLDeviceARN: VTLDeviceARN;            
+            DeviceType: DeviceType;            
+        }
+        export interface UpdateVTLDeviceTypeOutput {
+            VTLDeviceARN?: VTLDeviceARN;            
+        }
+        export interface VTLDevice {
+            VTLDeviceARN?: VTLDeviceARN;            
+            VTLDeviceType?: VTLDeviceType;            
+            VTLDeviceVendor?: VTLDeviceVendor;            
+            VTLDeviceProductIdentifier?: VTLDeviceProductIdentifier;            
+            DeviceiSCSIAttributes?: DeviceiSCSIAttributes;            
+        }
+        export interface VolumeInfo {
+            VolumeARN?: VolumeARN;            
+            VolumeType?: VolumeType;            
+        }
+        export interface VolumeRecoveryPointInfo {
+            VolumeARN?: VolumeARN;            
+            VolumeSizeInBytes?: long;            
+            VolumeUsageInBytes?: long;            
+            VolumeRecoveryPointTime?: string;            
+        }
+        export interface VolumeiSCSIAttributes {
+            TargetARN?: TargetARN;            
+            NetworkInterfaceId?: NetworkInterfaceId;            
+            NetworkInterfacePort?: integer;            
+            LunNumber?: PositiveIntObject;            
+            ChapEnabled?: boolean;            
+        }
 
-    export interface StorageGatewayUpdateChapCredentialsInput {
-        TargetARN: StorageGatewayTargetARN;
-        SecretToAuthenticateInitiator: StorageGatewayChapSecret;
-        InitiatorName: StorageGatewayIqnName;
-        SecretToAuthenticateTarget?: StorageGatewayChapSecret;
     }
-
-    export interface StorageGatewayUpdateChapCredentialsOutput {
-        TargetARN?: StorageGatewayTargetARN;
-        InitiatorName?: StorageGatewayIqnName;
-    }
-
-    export interface StorageGatewayUpdateGatewayInformationInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        GatewayName?: StorageGatewayGatewayName;
-        GatewayTimezone?: StorageGatewayGatewayTimezone;
-    }
-
-    export interface StorageGatewayUpdateGatewayInformationOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-        GatewayName?: StorageGatewaystring;
-    }
-
-    export interface StorageGatewayUpdateGatewaySoftwareNowInput {
-        GatewayARN: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayUpdateGatewaySoftwareNowOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayUpdateMaintenanceStartTimeInput {
-        GatewayARN: StorageGatewayGatewayARN;
-        HourOfDay: StorageGatewayHourOfDay;
-        MinuteOfHour: StorageGatewayMinuteOfHour;
-        DayOfWeek: StorageGatewayDayOfWeek;
-    }
-
-    export interface StorageGatewayUpdateMaintenanceStartTimeOutput {
-        GatewayARN?: StorageGatewayGatewayARN;
-    }
-
-    export interface StorageGatewayUpdateSnapshotScheduleInput {
-        VolumeARN: StorageGatewayVolumeARN;
-        StartAt: StorageGatewayHourOfDay;
-        RecurrenceInHours: StorageGatewayRecurrenceInHours;
-        Description?: StorageGatewayDescription;
-    }
-
-    export interface StorageGatewayUpdateSnapshotScheduleOutput {
-        VolumeARN?: StorageGatewayVolumeARN;
-    }
-
-    export interface StorageGatewayUpdateVTLDeviceTypeInput {
-        VTLDeviceARN: StorageGatewayVTLDeviceARN;
-        DeviceType: StorageGatewayDeviceType;
-    }
-
-    export interface StorageGatewayUpdateVTLDeviceTypeOutput {
-        VTLDeviceARN?: StorageGatewayVTLDeviceARN;
-    }
-
-    export interface StorageGatewayVTLDevice {
-        VTLDeviceARN?: StorageGatewayVTLDeviceARN;
-        VTLDeviceType?: StorageGatewayVTLDeviceType;
-        VTLDeviceVendor?: StorageGatewayVTLDeviceVendor;
-        VTLDeviceProductIdentifier?: StorageGatewayVTLDeviceProductIdentifier;
-        DeviceiSCSIAttributes?: StorageGatewayDeviceiSCSIAttributes;
-    }
-
-    export type StorageGatewayVTLDeviceARN = string;
-    export type StorageGatewayVTLDeviceARNs = Array<StorageGatewayVTLDeviceARN>;
-    export type StorageGatewayVTLDeviceProductIdentifier = string;
-    export type StorageGatewayVTLDeviceType = string;
-    export type StorageGatewayVTLDeviceVendor = string;
-    export type StorageGatewayVTLDevices = Array<StorageGatewayVTLDevice>;
-    export type StorageGatewayVolumeARN = string;
-    export type StorageGatewayVolumeARNs = Array<StorageGatewayVolumeARN>;
-    export type StorageGatewayVolumeId = string;
-    export interface StorageGatewayVolumeInfo {
-        VolumeARN?: StorageGatewayVolumeARN;
-        VolumeType?: StorageGatewayVolumeType;
-    }
-
-    export type StorageGatewayVolumeInfos = Array<StorageGatewayVolumeInfo>;
-    export interface StorageGatewayVolumeRecoveryPointInfo {
-        VolumeARN?: StorageGatewayVolumeARN;
-        VolumeSizeInBytes?: StorageGatewaylong;
-        VolumeUsageInBytes?: StorageGatewaylong;
-        VolumeRecoveryPointTime?: StorageGatewaystring;
-    }
-
-    export type StorageGatewayVolumeRecoveryPointInfos = Array<StorageGatewayVolumeRecoveryPointInfo>;
-    export type StorageGatewayVolumeStatus = string;
-    export type StorageGatewayVolumeType = string;
-    export interface StorageGatewayVolumeiSCSIAttributes {
-        TargetARN?: StorageGatewayTargetARN;
-        NetworkInterfaceId?: StorageGatewayNetworkInterfaceId;
-        NetworkInterfacePort?: StorageGatewayinteger;
-        LunNumber?: StorageGatewayPositiveIntObject;
-        ChapEnabled?: StorageGatewayboolean;
-    }
-
-    export type StorageGatewayboolean = boolean;
-    export type StorageGatewaydouble = number;
-    export type StorageGatewayerrorDetails = any; // not really - it was 'map' instead - must fix this one
-    export type StorageGatewayinteger = number;
-    export type StorageGatewaylong = number;
-    export type StorageGatewaystring = string;
 }

--- a/output/aws-sts.d.ts
+++ b/output/aws-sts.d.ts
@@ -6,174 +6,156 @@ declare module "aws-sdk" {
 
     export class STS extends Service {
       constructor(options?: any);
-      assumeRole(params: STSAssumeRoleRequest, callback?: (err: STSMalformedPolicyDocumentException|STSPackedPolicyTooLargeException|any, data: STSAssumeRoleResponse|any) => void): Request;
-      assumeRoleWithSAML(params: STSAssumeRoleWithSAMLRequest, callback?: (err: STSMalformedPolicyDocumentException|STSPackedPolicyTooLargeException|STSIDPRejectedClaimException|STSInvalidIdentityTokenException|STSExpiredTokenException|any, data: STSAssumeRoleWithSAMLResponse|any) => void): Request;
-      assumeRoleWithWebIdentity(params: STSAssumeRoleWithWebIdentityRequest, callback?: (err: STSMalformedPolicyDocumentException|STSPackedPolicyTooLargeException|STSIDPRejectedClaimException|STSIDPCommunicationErrorException|STSInvalidIdentityTokenException|STSExpiredTokenException|any, data: STSAssumeRoleWithWebIdentityResponse|any) => void): Request;
-      decodeAuthorizationMessage(params: STSDecodeAuthorizationMessageRequest, callback?: (err: STSInvalidAuthorizationMessageException|any, data: STSDecodeAuthorizationMessageResponse|any) => void): Request;
-      getFederationToken(params: STSGetFederationTokenRequest, callback?: (err: STSMalformedPolicyDocumentException|STSPackedPolicyTooLargeException|any, data: STSGetFederationTokenResponse|any) => void): Request;
-      getSessionToken(params: STSGetSessionTokenRequest, callback?: (err: any, data: STSGetSessionTokenResponse|any) => void): Request;
+      assumeRole(params: STS.AssumeRoleRequest, callback?: (err: STS.MalformedPolicyDocumentException|STS.PackedPolicyTooLargeException|any, data: STS.AssumeRoleResponse|any) => void): Request;
+      assumeRoleWithSAML(params: STS.AssumeRoleWithSAMLRequest, callback?: (err: STS.MalformedPolicyDocumentException|STS.PackedPolicyTooLargeException|STS.IDPRejectedClaimException|STS.InvalidIdentityTokenException|STS.ExpiredTokenException|any, data: STS.AssumeRoleWithSAMLResponse|any) => void): Request;
+      assumeRoleWithWebIdentity(params: STS.AssumeRoleWithWebIdentityRequest, callback?: (err: STS.MalformedPolicyDocumentException|STS.PackedPolicyTooLargeException|STS.IDPRejectedClaimException|STS.IDPCommunicationErrorException|STS.InvalidIdentityTokenException|STS.ExpiredTokenException|any, data: STS.AssumeRoleWithWebIdentityResponse|any) => void): Request;
+      decodeAuthorizationMessage(params: STS.DecodeAuthorizationMessageRequest, callback?: (err: STS.InvalidAuthorizationMessageException|any, data: STS.DecodeAuthorizationMessageResponse|any) => void): Request;
+      getFederationToken(params: STS.GetFederationTokenRequest, callback?: (err: STS.MalformedPolicyDocumentException|STS.PackedPolicyTooLargeException|any, data: STS.GetFederationTokenResponse|any) => void): Request;
+      getSessionToken(params: STS.GetSessionTokenRequest, callback?: (err: any, data: STS.GetSessionTokenResponse|any) => void): Request;
     }
+    
+    export module STS {
+        export type Audience = string;
+        export type Issuer = string;
+        export type NameQualifier = string;
+        export type SAMLAssertionType = string;    // max: 50000, min: 4
+        export type Subject = string;
+        export type SubjectType = string;
+        export type accessKeyIdType = string;    // pattern: &quot;[\w]*&quot;, max: 32, min: 16
+        export type accessKeySecretType = string;
+        export type arnType = string;    // max: 2048, min: 20
+        export type assumedRoleIdType = string;    // pattern: &quot;[\w+=,.@:-]*&quot;, max: 96, min: 2
+        export type clientTokenType = string;    // max: 2048, min: 4
+        export type dateType = number;
+        export type decodedMessageType = string;
+        export type durationSecondsType = number;    // max: 129600, min: 900
+        export type encodedMessageType = string;    // max: 10240, min: 1
+        export type expiredIdentityTokenMessage = string;
+        export type externalIdType = string;    // pattern: &quot;[\w+=,.@:\/-]*&quot;, max: 1224, min: 2
+        export type federatedIdType = string;    // pattern: &quot;[\w+=,.@\:-]*&quot;, max: 96, min: 2
+        export type idpCommunicationErrorMessage = string;
+        export type idpRejectedClaimMessage = string;
+        export type invalidAuthorizationMessage = string;
+        export type invalidIdentityTokenMessage = string;
+        export type malformedPolicyDocumentMessage = string;
+        export type nonNegativeIntegerType = number;
+        export type packedPolicyTooLargeMessage = string;
+        export type roleDurationSecondsType = number;    // max: 3600, min: 900
+        export type roleSessionNameType = string;    // pattern: &quot;[\w+=,.@-]*&quot;, max: 64, min: 2
+        export type serialNumberType = string;    // pattern: &quot;[\w+=/:,.@-]*&quot;, max: 256, min: 9
+        export type sessionPolicyDocumentType = string;    // pattern: &quot;[\u0009\u000A\u000D\u0020-\u00FF]+&quot;, max: 2048, min: 1
+        export type tokenCodeType = string;    // pattern: &quot;[\d]*&quot;, max: 6, min: 6
+        export type tokenType = string;
+        export type urlType = string;    // max: 2048, min: 4
+        export type userNameType = string;    // pattern: &quot;[\w+=,.@-]*&quot;, max: 32, min: 2
+        export type webIdentitySubjectType = string;    // max: 255, min: 6
 
-    export interface STSAssumeRoleRequest {
-        RoleArn: STSarnType;
-        RoleSessionName: STSroleSessionNameType;
-        Policy?: STSsessionPolicyDocumentType;
-        DurationSeconds?: STSroleDurationSecondsType;
-        ExternalId?: STSexternalIdType;
-        SerialNumber?: STSserialNumberType;
-        TokenCode?: STStokenCodeType;
+        export interface AssumeRoleRequest {
+            RoleArn: arnType;            
+            RoleSessionName: roleSessionNameType;            
+            Policy?: sessionPolicyDocumentType;            
+            DurationSeconds?: roleDurationSecondsType;            
+            ExternalId?: externalIdType;            
+            SerialNumber?: serialNumberType;            
+            TokenCode?: tokenCodeType;            
+        }
+        export interface AssumeRoleResponse {
+            Credentials?: Credentials;            
+            AssumedRoleUser?: AssumedRoleUser;            
+            PackedPolicySize?: nonNegativeIntegerType;            
+        }
+        export interface AssumeRoleWithSAMLRequest {
+            RoleArn: arnType;            
+            PrincipalArn: arnType;            
+            SAMLAssertion: SAMLAssertionType;            
+            Policy?: sessionPolicyDocumentType;            
+            DurationSeconds?: roleDurationSecondsType;            
+        }
+        export interface AssumeRoleWithSAMLResponse {
+            Credentials?: Credentials;            
+            AssumedRoleUser?: AssumedRoleUser;            
+            PackedPolicySize?: nonNegativeIntegerType;            
+            Subject?: Subject;            
+            SubjectType?: SubjectType;            
+            Issuer?: Issuer;            
+            Audience?: Audience;            
+            NameQualifier?: NameQualifier;            
+        }
+        export interface AssumeRoleWithWebIdentityRequest {
+            RoleArn: arnType;            
+            RoleSessionName: roleSessionNameType;            
+            WebIdentityToken: clientTokenType;            
+            ProviderId?: urlType;            
+            Policy?: sessionPolicyDocumentType;            
+            DurationSeconds?: roleDurationSecondsType;            
+        }
+        export interface AssumeRoleWithWebIdentityResponse {
+            Credentials?: Credentials;            
+            SubjectFromWebIdentityToken?: webIdentitySubjectType;            
+            AssumedRoleUser?: AssumedRoleUser;            
+            PackedPolicySize?: nonNegativeIntegerType;            
+            Provider?: Issuer;            
+            Audience?: Audience;            
+        }
+        export interface AssumedRoleUser {
+            AssumedRoleId: assumedRoleIdType;            
+            Arn: arnType;            
+        }
+        export interface Credentials {
+            AccessKeyId: accessKeyIdType;            
+            SecretAccessKey: accessKeySecretType;            
+            SessionToken: tokenType;            
+            Expiration: dateType;            
+        }
+        export interface DecodeAuthorizationMessageRequest {
+            EncodedMessage: encodedMessageType;            
+        }
+        export interface DecodeAuthorizationMessageResponse {
+            DecodedMessage?: decodedMessageType;            
+        }
+        export interface ExpiredTokenException {
+            message?: expiredIdentityTokenMessage;            
+        }
+        export interface FederatedUser {
+            FederatedUserId: federatedIdType;            
+            Arn: arnType;            
+        }
+        export interface GetFederationTokenRequest {
+            Name: userNameType;            
+            Policy?: sessionPolicyDocumentType;            
+            DurationSeconds?: durationSecondsType;            
+        }
+        export interface GetFederationTokenResponse {
+            Credentials?: Credentials;            
+            FederatedUser?: FederatedUser;            
+            PackedPolicySize?: nonNegativeIntegerType;            
+        }
+        export interface GetSessionTokenRequest {
+            DurationSeconds?: durationSecondsType;            
+            SerialNumber?: serialNumberType;            
+            TokenCode?: tokenCodeType;            
+        }
+        export interface GetSessionTokenResponse {
+            Credentials?: Credentials;            
+        }
+        export interface IDPCommunicationErrorException {
+            message?: idpCommunicationErrorMessage;            
+        }
+        export interface IDPRejectedClaimException {
+            message?: idpRejectedClaimMessage;            
+        }
+        export interface InvalidAuthorizationMessageException {
+            message?: invalidAuthorizationMessage;            
+        }
+        export interface InvalidIdentityTokenException {
+            message?: invalidIdentityTokenMessage;            
+        }
+        export interface MalformedPolicyDocumentException {
+            message?: malformedPolicyDocumentMessage;            
+        }
+        export interface PackedPolicyTooLargeException {
+            message?: packedPolicyTooLargeMessage;            
+        }
+
     }
-
-    export interface STSAssumeRoleResponse {
-        Credentials?: STSCredentials;
-        AssumedRoleUser?: STSAssumedRoleUser;
-        PackedPolicySize?: STSnonNegativeIntegerType;
-    }
-
-    export interface STSAssumeRoleWithSAMLRequest {
-        RoleArn: STSarnType;
-        PrincipalArn: STSarnType;
-        SAMLAssertion: STSSAMLAssertionType;
-        Policy?: STSsessionPolicyDocumentType;
-        DurationSeconds?: STSroleDurationSecondsType;
-    }
-
-    export interface STSAssumeRoleWithSAMLResponse {
-        Credentials?: STSCredentials;
-        AssumedRoleUser?: STSAssumedRoleUser;
-        PackedPolicySize?: STSnonNegativeIntegerType;
-        Subject?: STSSubject;
-        SubjectType?: STSSubjectType;
-        Issuer?: STSIssuer;
-        Audience?: STSAudience;
-        NameQualifier?: STSNameQualifier;
-    }
-
-    export interface STSAssumeRoleWithWebIdentityRequest {
-        RoleArn: STSarnType;
-        RoleSessionName: STSroleSessionNameType;
-        WebIdentityToken: STSclientTokenType;
-        ProviderId?: STSurlType;
-        Policy?: STSsessionPolicyDocumentType;
-        DurationSeconds?: STSroleDurationSecondsType;
-    }
-
-    export interface STSAssumeRoleWithWebIdentityResponse {
-        Credentials?: STSCredentials;
-        SubjectFromWebIdentityToken?: STSwebIdentitySubjectType;
-        AssumedRoleUser?: STSAssumedRoleUser;
-        PackedPolicySize?: STSnonNegativeIntegerType;
-        Provider?: STSIssuer;
-        Audience?: STSAudience;
-    }
-
-    export interface STSAssumedRoleUser {
-        AssumedRoleId: STSassumedRoleIdType;
-        Arn: STSarnType;
-    }
-
-    export type STSAudience = string;
-    export interface STSCredentials {
-        AccessKeyId: STSaccessKeyIdType;
-        SecretAccessKey: STSaccessKeySecretType;
-        SessionToken: STStokenType;
-        Expiration: STSdateType;
-    }
-
-    export interface STSDecodeAuthorizationMessageRequest {
-        EncodedMessage: STSencodedMessageType;
-    }
-
-    export interface STSDecodeAuthorizationMessageResponse {
-        DecodedMessage?: STSdecodedMessageType;
-    }
-
-    export interface STSExpiredTokenException {
-        message?: STSexpiredIdentityTokenMessage;
-    }
-
-    export interface STSFederatedUser {
-        FederatedUserId: STSfederatedIdType;
-        Arn: STSarnType;
-    }
-
-    export interface STSGetFederationTokenRequest {
-        Name: STSuserNameType;
-        Policy?: STSsessionPolicyDocumentType;
-        DurationSeconds?: STSdurationSecondsType;
-    }
-
-    export interface STSGetFederationTokenResponse {
-        Credentials?: STSCredentials;
-        FederatedUser?: STSFederatedUser;
-        PackedPolicySize?: STSnonNegativeIntegerType;
-    }
-
-    export interface STSGetSessionTokenRequest {
-        DurationSeconds?: STSdurationSecondsType;
-        SerialNumber?: STSserialNumberType;
-        TokenCode?: STStokenCodeType;
-    }
-
-    export interface STSGetSessionTokenResponse {
-        Credentials?: STSCredentials;
-    }
-
-    export interface STSIDPCommunicationErrorException {
-        message?: STSidpCommunicationErrorMessage;
-    }
-
-    export interface STSIDPRejectedClaimException {
-        message?: STSidpRejectedClaimMessage;
-    }
-
-    export interface STSInvalidAuthorizationMessageException {
-        message?: STSinvalidAuthorizationMessage;
-    }
-
-    export interface STSInvalidIdentityTokenException {
-        message?: STSinvalidIdentityTokenMessage;
-    }
-
-    export type STSIssuer = string;
-    export interface STSMalformedPolicyDocumentException {
-        message?: STSmalformedPolicyDocumentMessage;
-    }
-
-    export type STSNameQualifier = string;
-    export interface STSPackedPolicyTooLargeException {
-        message?: STSpackedPolicyTooLargeMessage;
-    }
-
-    export type STSSAMLAssertionType = string;
-    export type STSSubject = string;
-    export type STSSubjectType = string;
-    export type STSaccessKeyIdType = string; // pattern: "[\w]*"
-    export type STSaccessKeySecretType = string;
-    export type STSarnType = string;
-    export type STSassumedRoleIdType = string; // pattern: "[\w+=,.@:-]*"
-    export type STSclientTokenType = string;
-    export type STSdateType = number;
-    export type STSdecodedMessageType = string;
-    export type STSdurationSecondsType = number;
-    export type STSencodedMessageType = string;
-    export type STSexpiredIdentityTokenMessage = string;
-    export type STSexternalIdType = string; // pattern: "[\w+=,.@:\/-]*"
-    export type STSfederatedIdType = string; // pattern: "[\w+=,.@\:-]*"
-    export type STSidpCommunicationErrorMessage = string;
-    export type STSidpRejectedClaimMessage = string;
-    export type STSinvalidAuthorizationMessage = string;
-    export type STSinvalidIdentityTokenMessage = string;
-    export type STSmalformedPolicyDocumentMessage = string;
-    export type STSnonNegativeIntegerType = number;
-    export type STSpackedPolicyTooLargeMessage = string;
-    export type STSroleDurationSecondsType = number;
-    export type STSroleSessionNameType = string; // pattern: "[\w+=,.@-]*"
-    export type STSserialNumberType = string; // pattern: "[\w+=/:,.@-]*"
-    export type STSsessionPolicyDocumentType = string; // pattern: "[\u0009\u000A\u000D\u0020-\u00FF]+"
-    export type STStokenCodeType = string; // pattern: "[\d]*"
-    export type STStokenType = string;
-    export type STSurlType = string;
-    export type STSuserNameType = string; // pattern: "[\w+=,.@-]*"
-    export type STSwebIdentitySubjectType = string;
 }

--- a/output/aws-support.d.ts
+++ b/output/aws-support.d.ts
@@ -6,358 +6,309 @@ declare module "aws-sdk" {
 
     export class Support extends Service {
       constructor(options?: any);
-      addAttachmentsToSet(params: SupportAddAttachmentsToSetRequest, callback?: (err: SupportInternalServerError|SupportAttachmentSetIdNotFound|SupportAttachmentSetExpired|SupportAttachmentSetSizeLimitExceeded|SupportAttachmentLimitExceeded|any, data: SupportAddAttachmentsToSetResponse|any) => void): Request;
-      addCommunicationToCase(params: SupportAddCommunicationToCaseRequest, callback?: (err: SupportInternalServerError|SupportCaseIdNotFound|SupportAttachmentSetIdNotFound|SupportAttachmentSetExpired|any, data: SupportAddCommunicationToCaseResponse|any) => void): Request;
-      createCase(params: SupportCreateCaseRequest, callback?: (err: SupportInternalServerError|SupportCaseCreationLimitExceeded|SupportAttachmentSetIdNotFound|SupportAttachmentSetExpired|any, data: SupportCreateCaseResponse|any) => void): Request;
-      describeAttachment(params: SupportDescribeAttachmentRequest, callback?: (err: SupportInternalServerError|SupportDescribeAttachmentLimitExceeded|SupportAttachmentIdNotFound|any, data: SupportDescribeAttachmentResponse|any) => void): Request;
-      describeCases(params: SupportDescribeCasesRequest, callback?: (err: SupportInternalServerError|SupportCaseIdNotFound|any, data: SupportDescribeCasesResponse|any) => void): Request;
-      describeCommunications(params: SupportDescribeCommunicationsRequest, callback?: (err: SupportInternalServerError|SupportCaseIdNotFound|any, data: SupportDescribeCommunicationsResponse|any) => void): Request;
-      describeServices(params: SupportDescribeServicesRequest, callback?: (err: SupportInternalServerError|any, data: SupportDescribeServicesResponse|any) => void): Request;
-      describeSeverityLevels(params: SupportDescribeSeverityLevelsRequest, callback?: (err: SupportInternalServerError|any, data: SupportDescribeSeverityLevelsResponse|any) => void): Request;
-      describeTrustedAdvisorCheckRefreshStatuses(params: SupportDescribeTrustedAdvisorCheckRefreshStatusesRequest, callback?: (err: SupportInternalServerError|any, data: SupportDescribeTrustedAdvisorCheckRefreshStatusesResponse|any) => void): Request;
-      describeTrustedAdvisorCheckResult(params: SupportDescribeTrustedAdvisorCheckResultRequest, callback?: (err: SupportInternalServerError|any, data: SupportDescribeTrustedAdvisorCheckResultResponse|any) => void): Request;
-      describeTrustedAdvisorCheckSummaries(params: SupportDescribeTrustedAdvisorCheckSummariesRequest, callback?: (err: SupportInternalServerError|any, data: SupportDescribeTrustedAdvisorCheckSummariesResponse|any) => void): Request;
-      describeTrustedAdvisorChecks(params: SupportDescribeTrustedAdvisorChecksRequest, callback?: (err: SupportInternalServerError|any, data: SupportDescribeTrustedAdvisorChecksResponse|any) => void): Request;
-      refreshTrustedAdvisorCheck(params: SupportRefreshTrustedAdvisorCheckRequest, callback?: (err: SupportInternalServerError|any, data: SupportRefreshTrustedAdvisorCheckResponse|any) => void): Request;
-      resolveCase(params: SupportResolveCaseRequest, callback?: (err: SupportInternalServerError|SupportCaseIdNotFound|any, data: SupportResolveCaseResponse|any) => void): Request;
+      addAttachmentsToSet(params: Support.AddAttachmentsToSetRequest, callback?: (err: Support.InternalServerError|Support.AttachmentSetIdNotFound|Support.AttachmentSetExpired|Support.AttachmentSetSizeLimitExceeded|Support.AttachmentLimitExceeded|any, data: Support.AddAttachmentsToSetResponse|any) => void): Request;
+      addCommunicationToCase(params: Support.AddCommunicationToCaseRequest, callback?: (err: Support.InternalServerError|Support.CaseIdNotFound|Support.AttachmentSetIdNotFound|Support.AttachmentSetExpired|any, data: Support.AddCommunicationToCaseResponse|any) => void): Request;
+      createCase(params: Support.CreateCaseRequest, callback?: (err: Support.InternalServerError|Support.CaseCreationLimitExceeded|Support.AttachmentSetIdNotFound|Support.AttachmentSetExpired|any, data: Support.CreateCaseResponse|any) => void): Request;
+      describeAttachment(params: Support.DescribeAttachmentRequest, callback?: (err: Support.InternalServerError|Support.DescribeAttachmentLimitExceeded|Support.AttachmentIdNotFound|any, data: Support.DescribeAttachmentResponse|any) => void): Request;
+      describeCases(params: Support.DescribeCasesRequest, callback?: (err: Support.InternalServerError|Support.CaseIdNotFound|any, data: Support.DescribeCasesResponse|any) => void): Request;
+      describeCommunications(params: Support.DescribeCommunicationsRequest, callback?: (err: Support.InternalServerError|Support.CaseIdNotFound|any, data: Support.DescribeCommunicationsResponse|any) => void): Request;
+      describeServices(params: Support.DescribeServicesRequest, callback?: (err: Support.InternalServerError|any, data: Support.DescribeServicesResponse|any) => void): Request;
+      describeSeverityLevels(params: Support.DescribeSeverityLevelsRequest, callback?: (err: Support.InternalServerError|any, data: Support.DescribeSeverityLevelsResponse|any) => void): Request;
+      describeTrustedAdvisorCheckRefreshStatuses(params: Support.DescribeTrustedAdvisorCheckRefreshStatusesRequest, callback?: (err: Support.InternalServerError|any, data: Support.DescribeTrustedAdvisorCheckRefreshStatusesResponse|any) => void): Request;
+      describeTrustedAdvisorCheckResult(params: Support.DescribeTrustedAdvisorCheckResultRequest, callback?: (err: Support.InternalServerError|any, data: Support.DescribeTrustedAdvisorCheckResultResponse|any) => void): Request;
+      describeTrustedAdvisorCheckSummaries(params: Support.DescribeTrustedAdvisorCheckSummariesRequest, callback?: (err: Support.InternalServerError|any, data: Support.DescribeTrustedAdvisorCheckSummariesResponse|any) => void): Request;
+      describeTrustedAdvisorChecks(params: Support.DescribeTrustedAdvisorChecksRequest, callback?: (err: Support.InternalServerError|any, data: Support.DescribeTrustedAdvisorChecksResponse|any) => void): Request;
+      refreshTrustedAdvisorCheck(params: Support.RefreshTrustedAdvisorCheckRequest, callback?: (err: Support.InternalServerError|any, data: Support.RefreshTrustedAdvisorCheckResponse|any) => void): Request;
+      resolveCase(params: Support.ResolveCaseRequest, callback?: (err: Support.InternalServerError|Support.CaseIdNotFound|any, data: Support.ResolveCaseResponse|any) => void): Request;
     }
+    
+    export module Support {
+        export type AfterTime = string;
+        export type AttachmentId = string;
+        export type AttachmentSet = AttachmentDetails[];
+        export type AttachmentSetId = string;
+        export type Attachments = Attachment[];
+        export type BeforeTime = string;
+        export type Boolean = boolean;
+        export type CaseId = string;
+        export type CaseIdList = CaseId[];    // max: 100
+        export type CaseList = CaseDetails[];
+        export type CaseStatus = string;
+        export type CategoryCode = string;
+        export type CategoryList = Category[];
+        export type CategoryName = string;
+        export type CcEmailAddress = string;
+        export type CcEmailAddressList = CcEmailAddress[];
+        export type CommunicationBody = string;
+        export type CommunicationList = Communication[];
+        export type Data = any;    // type: blob
+        export type DisplayId = string;
+        export type Double = number;
+        export type ErrorMessage = string;
+        export type ExpiryTime = string;
+        export type FileName = string;
+        export type IncludeCommunications = boolean;
+        export type IncludeResolvedCases = boolean;
+        export type IssueType = string;
+        export type Language = string;
+        export type Long = number;
+        export type MaxResults = number;    // max: 100, min: 10
+        export type NextToken = string;
+        export type Result = boolean;
+        export type ServiceCode = string;    // pattern: &quot;[0-9a-z\-_]+&quot;
+        export type ServiceCodeList = ServiceCode[];    // max: 100
+        export type ServiceList = Service[];
+        export type ServiceName = string;
+        export type SeverityCode = string;
+        export type SeverityLevelCode = string;
+        export type SeverityLevelName = string;
+        export type SeverityLevelsList = SeverityLevel[];
+        export type Status = string;
+        export type String = string;
+        export type StringList = String[];
+        export type Subject = string;
+        export type SubmittedBy = string;
+        export type TimeCreated = string;
+        export type TrustedAdvisorCheckList = TrustedAdvisorCheckDescription[];
+        export type TrustedAdvisorCheckRefreshStatusList = TrustedAdvisorCheckRefreshStatus[];
+        export type TrustedAdvisorCheckSummaryList = TrustedAdvisorCheckSummary[];
+        export type TrustedAdvisorResourceDetailList = TrustedAdvisorResourceDetail[];
 
-    export interface SupportAddAttachmentsToSetRequest {
-        attachmentSetId?: SupportAttachmentSetId;
-        attachments: SupportAttachments;
+        export interface AddAttachmentsToSetRequest {
+            attachmentSetId?: AttachmentSetId;            
+            attachments: Attachments;            
+        }
+        export interface AddAttachmentsToSetResponse {
+            attachmentSetId?: AttachmentSetId;            
+            expiryTime?: ExpiryTime;            
+        }
+        export interface AddCommunicationToCaseRequest {
+            caseId?: CaseId;            
+            communicationBody: CommunicationBody;            
+            ccEmailAddresses?: CcEmailAddressList;            
+            attachmentSetId?: AttachmentSetId;            
+        }
+        export interface AddCommunicationToCaseResponse {
+            result?: Result;            
+        }
+        export interface Attachment {
+            fileName?: FileName;            
+            data?: Data;            
+        }
+        export interface AttachmentDetails {
+            attachmentId?: AttachmentId;            
+            fileName?: FileName;            
+        }
+        export interface AttachmentIdNotFound {
+            message?: ErrorMessage;            
+        }
+        export interface AttachmentLimitExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface AttachmentSetExpired {
+            message?: ErrorMessage;            
+        }
+        export interface AttachmentSetIdNotFound {
+            message?: ErrorMessage;            
+        }
+        export interface AttachmentSetSizeLimitExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface CaseCreationLimitExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface CaseDetails {
+            caseId?: CaseId;            
+            displayId?: DisplayId;            
+            subject?: Subject;            
+            status?: Status;            
+            serviceCode?: ServiceCode;            
+            categoryCode?: CategoryCode;            
+            severityCode?: SeverityCode;            
+            submittedBy?: SubmittedBy;            
+            timeCreated?: TimeCreated;            
+            recentCommunications?: RecentCaseCommunications;            
+            ccEmailAddresses?: CcEmailAddressList;            
+            language?: Language;            
+        }
+        export interface CaseIdNotFound {
+            message?: ErrorMessage;            
+        }
+        export interface Category {
+            code?: CategoryCode;            
+            name?: CategoryName;            
+        }
+        export interface Communication {
+            caseId?: CaseId;            
+            body?: CommunicationBody;            
+            submittedBy?: SubmittedBy;            
+            timeCreated?: TimeCreated;            
+            attachmentSet?: AttachmentSet;            
+        }
+        export interface CreateCaseRequest {
+            subject: Subject;            
+            serviceCode?: ServiceCode;            
+            severityCode?: SeverityCode;            
+            categoryCode?: CategoryCode;            
+            communicationBody: CommunicationBody;            
+            ccEmailAddresses?: CcEmailAddressList;            
+            language?: Language;            
+            issueType?: IssueType;            
+            attachmentSetId?: AttachmentSetId;            
+        }
+        export interface CreateCaseResponse {
+            caseId?: CaseId;            
+        }
+        export interface DescribeAttachmentLimitExceeded {
+            message?: ErrorMessage;            
+        }
+        export interface DescribeAttachmentRequest {
+            attachmentId: AttachmentId;            
+        }
+        export interface DescribeAttachmentResponse {
+            attachment?: Attachment;            
+        }
+        export interface DescribeCasesRequest {
+            caseIdList?: CaseIdList;            
+            displayId?: DisplayId;            
+            afterTime?: AfterTime;            
+            beforeTime?: BeforeTime;            
+            includeResolvedCases?: IncludeResolvedCases;            
+            nextToken?: NextToken;            
+            maxResults?: MaxResults;            
+            language?: Language;            
+            includeCommunications?: IncludeCommunications;            
+        }
+        export interface DescribeCasesResponse {
+            cases?: CaseList;            
+            nextToken?: NextToken;            
+        }
+        export interface DescribeCommunicationsRequest {
+            caseId: CaseId;            
+            beforeTime?: BeforeTime;            
+            afterTime?: AfterTime;            
+            nextToken?: NextToken;            
+            maxResults?: MaxResults;            
+        }
+        export interface DescribeCommunicationsResponse {
+            communications?: CommunicationList;            
+            nextToken?: NextToken;            
+        }
+        export interface DescribeServicesRequest {
+            serviceCodeList?: ServiceCodeList;            
+            language?: Language;            
+        }
+        export interface DescribeServicesResponse {
+            services?: ServiceList;            
+        }
+        export interface DescribeSeverityLevelsRequest {
+            language?: Language;            
+        }
+        export interface DescribeSeverityLevelsResponse {
+            severityLevels?: SeverityLevelsList;            
+        }
+        export interface DescribeTrustedAdvisorCheckRefreshStatusesRequest {
+            checkIds: StringList;            
+        }
+        export interface DescribeTrustedAdvisorCheckRefreshStatusesResponse {
+            statuses: TrustedAdvisorCheckRefreshStatusList;            
+        }
+        export interface DescribeTrustedAdvisorCheckResultRequest {
+            checkId: String;            
+            language?: String;            
+        }
+        export interface DescribeTrustedAdvisorCheckResultResponse {
+            result?: TrustedAdvisorCheckResult;            
+        }
+        export interface DescribeTrustedAdvisorCheckSummariesRequest {
+            checkIds: StringList;            
+        }
+        export interface DescribeTrustedAdvisorCheckSummariesResponse {
+            summaries: TrustedAdvisorCheckSummaryList;            
+        }
+        export interface DescribeTrustedAdvisorChecksRequest {
+            language: String;            
+        }
+        export interface DescribeTrustedAdvisorChecksResponse {
+            checks: TrustedAdvisorCheckList;            
+        }
+        export interface InternalServerError {
+            message?: ErrorMessage;            
+        }
+        export interface RecentCaseCommunications {
+            communications?: CommunicationList;            
+            nextToken?: NextToken;            
+        }
+        export interface RefreshTrustedAdvisorCheckRequest {
+            checkId: String;            
+        }
+        export interface RefreshTrustedAdvisorCheckResponse {
+            status: TrustedAdvisorCheckRefreshStatus;            
+        }
+        export interface ResolveCaseRequest {
+            caseId?: CaseId;            
+        }
+        export interface ResolveCaseResponse {
+            initialCaseStatus?: CaseStatus;            
+            finalCaseStatus?: CaseStatus;            
+        }
+        export interface Service {
+            code?: ServiceCode;            
+            name?: ServiceName;            
+            categories?: CategoryList;            
+        }
+        export interface SeverityLevel {
+            code?: SeverityLevelCode;            
+            name?: SeverityLevelName;            
+        }
+        export interface TrustedAdvisorCategorySpecificSummary {
+            costOptimizing?: TrustedAdvisorCostOptimizingSummary;            
+        }
+        export interface TrustedAdvisorCheckDescription {
+            id: String;            
+            name: String;            
+            description: String;            
+            category: String;            
+            metadata: StringList;            
+        }
+        export interface TrustedAdvisorCheckRefreshStatus {
+            checkId: String;            
+            status: String;            
+            millisUntilNextRefreshable: Long;            
+        }
+        export interface TrustedAdvisorCheckResult {
+            checkId: String;            
+            timestamp: String;            
+            status: String;            
+            resourcesSummary: TrustedAdvisorResourcesSummary;            
+            categorySpecificSummary: TrustedAdvisorCategorySpecificSummary;            
+            flaggedResources: TrustedAdvisorResourceDetailList;            
+        }
+        export interface TrustedAdvisorCheckSummary {
+            checkId: String;            
+            timestamp: String;            
+            status: String;            
+            hasFlaggedResources?: Boolean;            
+            resourcesSummary: TrustedAdvisorResourcesSummary;            
+            categorySpecificSummary: TrustedAdvisorCategorySpecificSummary;            
+        }
+        export interface TrustedAdvisorCostOptimizingSummary {
+            estimatedMonthlySavings: Double;            
+            estimatedPercentMonthlySavings: Double;            
+        }
+        export interface TrustedAdvisorResourceDetail {
+            status: String;            
+            region: String;            
+            resourceId: String;            
+            isSuppressed?: Boolean;            
+            metadata: StringList;            
+        }
+        export interface TrustedAdvisorResourcesSummary {
+            resourcesProcessed: Long;            
+            resourcesFlagged: Long;            
+            resourcesIgnored: Long;            
+            resourcesSuppressed: Long;            
+        }
+
     }
-
-    export interface SupportAddAttachmentsToSetResponse {
-        attachmentSetId?: SupportAttachmentSetId;
-        expiryTime?: SupportExpiryTime;
-    }
-
-    export interface SupportAddCommunicationToCaseRequest {
-        caseId?: SupportCaseId;
-        communicationBody: SupportCommunicationBody;
-        ccEmailAddresses?: SupportCcEmailAddressList;
-        attachmentSetId?: SupportAttachmentSetId;
-    }
-
-    export interface SupportAddCommunicationToCaseResponse {
-        result?: SupportResult;
-    }
-
-    export type SupportAfterTime = string;
-    export interface SupportAttachment {
-        fileName?: SupportFileName;
-        data?: SupportData;
-    }
-
-    export interface SupportAttachmentDetails {
-        attachmentId?: SupportAttachmentId;
-        fileName?: SupportFileName;
-    }
-
-    export type SupportAttachmentId = string;
-    export interface SupportAttachmentIdNotFound {
-        message?: SupportErrorMessage;
-    }
-
-    export interface SupportAttachmentLimitExceeded {
-        message?: SupportErrorMessage;
-    }
-
-    export type SupportAttachmentSet = Array<SupportAttachmentDetails>;
-    export interface SupportAttachmentSetExpired {
-        message?: SupportErrorMessage;
-    }
-
-    export type SupportAttachmentSetId = string;
-    export interface SupportAttachmentSetIdNotFound {
-        message?: SupportErrorMessage;
-    }
-
-    export interface SupportAttachmentSetSizeLimitExceeded {
-        message?: SupportErrorMessage;
-    }
-
-    export type SupportAttachments = Array<SupportAttachment>;
-    export type SupportBeforeTime = string;
-    export type SupportBoolean = boolean;
-    export interface SupportCaseCreationLimitExceeded {
-        message?: SupportErrorMessage;
-    }
-
-    export interface SupportCaseDetails {
-        caseId?: SupportCaseId;
-        displayId?: SupportDisplayId;
-        subject?: SupportSubject;
-        status?: SupportStatus;
-        serviceCode?: SupportServiceCode;
-        categoryCode?: SupportCategoryCode;
-        severityCode?: SupportSeverityCode;
-        submittedBy?: SupportSubmittedBy;
-        timeCreated?: SupportTimeCreated;
-        recentCommunications?: SupportRecentCaseCommunications;
-        ccEmailAddresses?: SupportCcEmailAddressList;
-        language?: SupportLanguage;
-    }
-
-    export type SupportCaseId = string;
-    export type SupportCaseIdList = Array<SupportCaseId>; // max: 100
-    export interface SupportCaseIdNotFound {
-        message?: SupportErrorMessage;
-    }
-
-    export type SupportCaseList = Array<SupportCaseDetails>;
-    export type SupportCaseStatus = string;
-    export interface SupportCategory {
-        code?: SupportCategoryCode;
-        name?: SupportCategoryName;
-    }
-
-    export type SupportCategoryCode = string;
-    export type SupportCategoryList = Array<SupportCategory>;
-    export type SupportCategoryName = string;
-    export type SupportCcEmailAddress = string;
-    export type SupportCcEmailAddressList = Array<SupportCcEmailAddress>;
-    export interface SupportCommunication {
-        caseId?: SupportCaseId;
-        body?: SupportCommunicationBody;
-        submittedBy?: SupportSubmittedBy;
-        timeCreated?: SupportTimeCreated;
-        attachmentSet?: SupportAttachmentSet;
-    }
-
-    export type SupportCommunicationBody = string;
-    export type SupportCommunicationList = Array<SupportCommunication>;
-    export interface SupportCreateCaseRequest {
-        subject: SupportSubject;
-        serviceCode?: SupportServiceCode;
-        severityCode?: SupportSeverityCode;
-        categoryCode?: SupportCategoryCode;
-        communicationBody: SupportCommunicationBody;
-        ccEmailAddresses?: SupportCcEmailAddressList;
-        language?: SupportLanguage;
-        issueType?: SupportIssueType;
-        attachmentSetId?: SupportAttachmentSetId;
-    }
-
-    export interface SupportCreateCaseResponse {
-        caseId?: SupportCaseId;
-    }
-
-    export type SupportData = any; // not really - it was 'blob' instead - must fix this one
-    export interface SupportDescribeAttachmentLimitExceeded {
-        message?: SupportErrorMessage;
-    }
-
-    export interface SupportDescribeAttachmentRequest {
-        attachmentId: SupportAttachmentId;
-    }
-
-    export interface SupportDescribeAttachmentResponse {
-        attachment?: SupportAttachment;
-    }
-
-    export interface SupportDescribeCasesRequest {
-        caseIdList?: SupportCaseIdList;
-        displayId?: SupportDisplayId;
-        afterTime?: SupportAfterTime;
-        beforeTime?: SupportBeforeTime;
-        includeResolvedCases?: SupportIncludeResolvedCases;
-        nextToken?: SupportNextToken;
-        maxResults?: SupportMaxResults;
-        language?: SupportLanguage;
-        includeCommunications?: SupportIncludeCommunications;
-    }
-
-    export interface SupportDescribeCasesResponse {
-        cases?: SupportCaseList;
-        nextToken?: SupportNextToken;
-    }
-
-    export interface SupportDescribeCommunicationsRequest {
-        caseId: SupportCaseId;
-        beforeTime?: SupportBeforeTime;
-        afterTime?: SupportAfterTime;
-        nextToken?: SupportNextToken;
-        maxResults?: SupportMaxResults;
-    }
-
-    export interface SupportDescribeCommunicationsResponse {
-        communications?: SupportCommunicationList;
-        nextToken?: SupportNextToken;
-    }
-
-    export interface SupportDescribeServicesRequest {
-        serviceCodeList?: SupportServiceCodeList;
-        language?: SupportLanguage;
-    }
-
-    export interface SupportDescribeServicesResponse {
-        services?: SupportServiceList;
-    }
-
-    export interface SupportDescribeSeverityLevelsRequest {
-        language?: SupportLanguage;
-    }
-
-    export interface SupportDescribeSeverityLevelsResponse {
-        severityLevels?: SupportSeverityLevelsList;
-    }
-
-    export interface SupportDescribeTrustedAdvisorCheckRefreshStatusesRequest {
-        checkIds: SupportStringList;
-    }
-
-    export interface SupportDescribeTrustedAdvisorCheckRefreshStatusesResponse {
-        statuses: SupportTrustedAdvisorCheckRefreshStatusList;
-    }
-
-    export interface SupportDescribeTrustedAdvisorCheckResultRequest {
-        checkId: SupportString;
-        language?: SupportString;
-    }
-
-    export interface SupportDescribeTrustedAdvisorCheckResultResponse {
-        result?: SupportTrustedAdvisorCheckResult;
-    }
-
-    export interface SupportDescribeTrustedAdvisorCheckSummariesRequest {
-        checkIds: SupportStringList;
-    }
-
-    export interface SupportDescribeTrustedAdvisorCheckSummariesResponse {
-        summaries: SupportTrustedAdvisorCheckSummaryList;
-    }
-
-    export interface SupportDescribeTrustedAdvisorChecksRequest {
-        language: SupportString;
-    }
-
-    export interface SupportDescribeTrustedAdvisorChecksResponse {
-        checks: SupportTrustedAdvisorCheckList;
-    }
-
-    export type SupportDisplayId = string;
-    export type SupportDouble = number;
-    export type SupportErrorMessage = string;
-    export type SupportExpiryTime = string;
-    export type SupportFileName = string;
-    export type SupportIncludeCommunications = boolean;
-    export type SupportIncludeResolvedCases = boolean;
-    export interface SupportInternalServerError {
-        message?: SupportErrorMessage;
-    }
-
-    export type SupportIssueType = string;
-    export type SupportLanguage = string;
-    export type SupportLong = number;
-    export type SupportMaxResults = number;
-    export type SupportNextToken = string;
-    export interface SupportRecentCaseCommunications {
-        communications?: SupportCommunicationList;
-        nextToken?: SupportNextToken;
-    }
-
-    export interface SupportRefreshTrustedAdvisorCheckRequest {
-        checkId: SupportString;
-    }
-
-    export interface SupportRefreshTrustedAdvisorCheckResponse {
-        status: SupportTrustedAdvisorCheckRefreshStatus;
-    }
-
-    export interface SupportResolveCaseRequest {
-        caseId?: SupportCaseId;
-    }
-
-    export interface SupportResolveCaseResponse {
-        initialCaseStatus?: SupportCaseStatus;
-        finalCaseStatus?: SupportCaseStatus;
-    }
-
-    export type SupportResult = boolean;
-    export interface SupportService {
-        code?: SupportServiceCode;
-        name?: SupportServiceName;
-        categories?: SupportCategoryList;
-    }
-
-    export type SupportServiceCode = string; // pattern: "[0-9a-z\-_]+"
-    export type SupportServiceCodeList = Array<SupportServiceCode>; // max: 100
-    export type SupportServiceList = Array<SupportService>;
-    export type SupportServiceName = string;
-    export type SupportSeverityCode = string;
-    export interface SupportSeverityLevel {
-        code?: SupportSeverityLevelCode;
-        name?: SupportSeverityLevelName;
-    }
-
-    export type SupportSeverityLevelCode = string;
-    export type SupportSeverityLevelName = string;
-    export type SupportSeverityLevelsList = Array<SupportSeverityLevel>;
-    export type SupportStatus = string;
-    export type SupportString = string;
-    export type SupportStringList = Array<SupportString>;
-    export type SupportSubject = string;
-    export type SupportSubmittedBy = string;
-    export type SupportTimeCreated = string;
-    export interface SupportTrustedAdvisorCategorySpecificSummary {
-        costOptimizing?: SupportTrustedAdvisorCostOptimizingSummary;
-    }
-
-    export interface SupportTrustedAdvisorCheckDescription {
-        id: SupportString;
-        name: SupportString;
-        description: SupportString;
-        category: SupportString;
-        metadata: SupportStringList;
-    }
-
-    export type SupportTrustedAdvisorCheckList = Array<SupportTrustedAdvisorCheckDescription>;
-    export interface SupportTrustedAdvisorCheckRefreshStatus {
-        checkId: SupportString;
-        status: SupportString;
-        millisUntilNextRefreshable: SupportLong;
-    }
-
-    export type SupportTrustedAdvisorCheckRefreshStatusList = Array<SupportTrustedAdvisorCheckRefreshStatus>;
-    export interface SupportTrustedAdvisorCheckResult {
-        checkId: SupportString;
-        timestamp: SupportString;
-        status: SupportString;
-        resourcesSummary: SupportTrustedAdvisorResourcesSummary;
-        categorySpecificSummary: SupportTrustedAdvisorCategorySpecificSummary;
-        flaggedResources: SupportTrustedAdvisorResourceDetailList;
-    }
-
-    export interface SupportTrustedAdvisorCheckSummary {
-        checkId: SupportString;
-        timestamp: SupportString;
-        status: SupportString;
-        hasFlaggedResources?: SupportBoolean;
-        resourcesSummary: SupportTrustedAdvisorResourcesSummary;
-        categorySpecificSummary: SupportTrustedAdvisorCategorySpecificSummary;
-    }
-
-    export type SupportTrustedAdvisorCheckSummaryList = Array<SupportTrustedAdvisorCheckSummary>;
-    export interface SupportTrustedAdvisorCostOptimizingSummary {
-        estimatedMonthlySavings: SupportDouble;
-        estimatedPercentMonthlySavings: SupportDouble;
-    }
-
-    export interface SupportTrustedAdvisorResourceDetail {
-        status: SupportString;
-        region: SupportString;
-        resourceId: SupportString;
-        isSuppressed?: SupportBoolean;
-        metadata: SupportStringList;
-    }
-
-    export type SupportTrustedAdvisorResourceDetailList = Array<SupportTrustedAdvisorResourceDetail>;
-    export interface SupportTrustedAdvisorResourcesSummary {
-        resourcesProcessed: SupportLong;
-        resourcesFlagged: SupportLong;
-        resourcesIgnored: SupportLong;
-        resourcesSuppressed: SupportLong;
-    }
-
 }

--- a/output/aws-swf.d.ts
+++ b/output/aws-swf.d.ts
@@ -6,1118 +6,980 @@ declare module "aws-sdk" {
 
     export class SWF extends Service {
       constructor(options?: any);
-      countClosedWorkflowExecutions(params: SWFCountClosedWorkflowExecutionsInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFWorkflowExecutionCount|any) => void): Request;
-      countOpenWorkflowExecutions(params: SWFCountOpenWorkflowExecutionsInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFWorkflowExecutionCount|any) => void): Request;
-      countPendingActivityTasks(params: SWFCountPendingActivityTasksInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFPendingTaskCount|any) => void): Request;
-      countPendingDecisionTasks(params: SWFCountPendingDecisionTasksInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFPendingTaskCount|any) => void): Request;
-      deprecateActivityType(params: SWFDeprecateActivityTypeInput, callback?: (err: SWFUnknownResourceFault|SWFTypeDeprecatedFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      deprecateDomain(params: SWFDeprecateDomainInput, callback?: (err: SWFUnknownResourceFault|SWFDomainDeprecatedFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      deprecateWorkflowType(params: SWFDeprecateWorkflowTypeInput, callback?: (err: SWFUnknownResourceFault|SWFTypeDeprecatedFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      describeActivityType(params: SWFDescribeActivityTypeInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFActivityTypeDetail|any) => void): Request;
-      describeDomain(params: SWFDescribeDomainInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFDomainDetail|any) => void): Request;
-      describeWorkflowExecution(params: SWFDescribeWorkflowExecutionInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFWorkflowExecutionDetail|any) => void): Request;
-      describeWorkflowType(params: SWFDescribeWorkflowTypeInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFWorkflowTypeDetail|any) => void): Request;
-      getWorkflowExecutionHistory(params: SWFGetWorkflowExecutionHistoryInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFHistory|any) => void): Request;
-      listActivityTypes(params: SWFListActivityTypesInput, callback?: (err: SWFOperationNotPermittedFault|SWFUnknownResourceFault|any, data: SWFActivityTypeInfos|any) => void): Request;
-      listClosedWorkflowExecutions(params: SWFListClosedWorkflowExecutionsInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFWorkflowExecutionInfos|any) => void): Request;
-      listDomains(params: SWFListDomainsInput, callback?: (err: SWFOperationNotPermittedFault|any, data: SWFDomainInfos|any) => void): Request;
-      listOpenWorkflowExecutions(params: SWFListOpenWorkflowExecutionsInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFWorkflowExecutionInfos|any) => void): Request;
-      listWorkflowTypes(params: SWFListWorkflowTypesInput, callback?: (err: SWFOperationNotPermittedFault|SWFUnknownResourceFault|any, data: SWFWorkflowTypeInfos|any) => void): Request;
-      pollForActivityTask(params: SWFPollForActivityTaskInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|SWFLimitExceededFault|any, data: SWFActivityTask|any) => void): Request;
-      pollForDecisionTask(params: SWFPollForDecisionTaskInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|SWFLimitExceededFault|any, data: SWFDecisionTask|any) => void): Request;
-      recordActivityTaskHeartbeat(params: SWFRecordActivityTaskHeartbeatInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: SWFActivityTaskStatus|any) => void): Request;
-      registerActivityType(params: SWFRegisterActivityTypeInput, callback?: (err: SWFTypeAlreadyExistsFault|SWFLimitExceededFault|SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      registerDomain(params: SWFRegisterDomainInput, callback?: (err: SWFDomainAlreadyExistsFault|SWFLimitExceededFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      registerWorkflowType(params: SWFRegisterWorkflowTypeInput, callback?: (err: SWFTypeAlreadyExistsFault|SWFLimitExceededFault|SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      requestCancelWorkflowExecution(params: SWFRequestCancelWorkflowExecutionInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      respondActivityTaskCanceled(params: SWFRespondActivityTaskCanceledInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      respondActivityTaskCompleted(params: SWFRespondActivityTaskCompletedInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      respondActivityTaskFailed(params: SWFRespondActivityTaskFailedInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      respondDecisionTaskCompleted(params: SWFRespondDecisionTaskCompletedInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      signalWorkflowExecution(params: SWFSignalWorkflowExecutionInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-      startWorkflowExecution(params: SWFStartWorkflowExecutionInput, callback?: (err: SWFUnknownResourceFault|SWFTypeDeprecatedFault|SWFWorkflowExecutionAlreadyStartedFault|SWFLimitExceededFault|SWFOperationNotPermittedFault|SWFDefaultUndefinedFault|any, data: SWFRun|any) => void): Request;
-      terminateWorkflowExecution(params: SWFTerminateWorkflowExecutionInput, callback?: (err: SWFUnknownResourceFault|SWFOperationNotPermittedFault|any, data: any) => void): Request;
-    }
-
-    export type SWFActivityId = string;
-    export interface SWFActivityTask {
-        taskToken: SWFTaskToken;
-        activityId: SWFActivityId;
-        startedEventId: SWFEventId;
-        workflowExecution: SWFWorkflowExecution;
-        activityType: SWFActivityType;
-        input?: SWFData;
-    }
-
-    export interface SWFActivityTaskCancelRequestedEventAttributes {
-        decisionTaskCompletedEventId: SWFEventId;
-        activityId: SWFActivityId;
-    }
-
-    export interface SWFActivityTaskCanceledEventAttributes {
-        details?: SWFData;
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-        latestCancelRequestedEventId?: SWFEventId;
-    }
-
-    export interface SWFActivityTaskCompletedEventAttributes {
-        result?: SWFData;
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFActivityTaskFailedEventAttributes {
-        reason?: SWFFailureReason;
-        details?: SWFData;
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFActivityTaskScheduledEventAttributes {
-        activityType: SWFActivityType;
-        activityId: SWFActivityId;
-        input?: SWFData;
-        control?: SWFData;
-        scheduleToStartTimeout?: SWFDurationInSecondsOptional;
-        scheduleToCloseTimeout?: SWFDurationInSecondsOptional;
-        startToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskList: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        decisionTaskCompletedEventId: SWFEventId;
-        heartbeatTimeout?: SWFDurationInSecondsOptional;
-    }
-
-    export interface SWFActivityTaskStartedEventAttributes {
-        identity?: SWFIdentity;
-        scheduledEventId: SWFEventId;
-    }
-
-    export interface SWFActivityTaskStatus {
-        cancelRequested: SWFCanceled;
-    }
-
-    export interface SWFActivityTaskTimedOutEventAttributes {
-        timeoutType: SWFActivityTaskTimeoutType;
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-        details?: SWFLimitedData;
-    }
-
-    export type SWFActivityTaskTimeoutType = string;
-    export interface SWFActivityType {
-        name: SWFName;
-        version: SWFVersion;
-    }
-
-    export interface SWFActivityTypeConfiguration {
-        defaultTaskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskHeartbeatTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskList?: SWFTaskList;
-        defaultTaskPriority?: SWFTaskPriority;
-        defaultTaskScheduleToStartTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskScheduleToCloseTimeout?: SWFDurationInSecondsOptional;
-    }
-
-    export interface SWFActivityTypeDetail {
-        typeInfo: SWFActivityTypeInfo;
-        configuration: SWFActivityTypeConfiguration;
-    }
-
-    export interface SWFActivityTypeInfo {
-        activityType: SWFActivityType;
-        status: SWFRegistrationStatus;
-        description?: SWFDescription;
-        creationDate: SWFTimestamp;
-        deprecationDate?: SWFTimestamp;
-    }
-
-    export type SWFActivityTypeInfoList = Array<SWFActivityTypeInfo>;
-    export interface SWFActivityTypeInfos {
-        typeInfos: SWFActivityTypeInfoList;
-        nextPageToken?: SWFPageToken;
-    }
-
-    export type SWFArn = string;
-    export interface SWFCancelTimerDecisionAttributes {
-        timerId: SWFTimerId;
-    }
-
-    export type SWFCancelTimerFailedCause = string;
-    export interface SWFCancelTimerFailedEventAttributes {
-        timerId: SWFTimerId;
-        cause: SWFCancelTimerFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFCancelWorkflowExecutionDecisionAttributes {
-        details?: SWFData;
-    }
-
-    export type SWFCancelWorkflowExecutionFailedCause = string;
-    export interface SWFCancelWorkflowExecutionFailedEventAttributes {
-        cause: SWFCancelWorkflowExecutionFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export type SWFCanceled = boolean;
-    export type SWFCauseMessage = string;
-    export type SWFChildPolicy = string;
-    export interface SWFChildWorkflowExecutionCanceledEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        details?: SWFData;
-        initiatedEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFChildWorkflowExecutionCompletedEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        result?: SWFData;
-        initiatedEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFChildWorkflowExecutionFailedEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        reason?: SWFFailureReason;
-        details?: SWFData;
-        initiatedEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFChildWorkflowExecutionStartedEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        initiatedEventId: SWFEventId;
-    }
-
-    export interface SWFChildWorkflowExecutionTerminatedEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        initiatedEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFChildWorkflowExecutionTimedOutEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        timeoutType: SWFWorkflowExecutionTimeoutType;
-        initiatedEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export type SWFCloseStatus = string;
-    export interface SWFCloseStatusFilter {
-        status: SWFCloseStatus;
-    }
-
-    export interface SWFCompleteWorkflowExecutionDecisionAttributes {
-        result?: SWFData;
-    }
-
-    export type SWFCompleteWorkflowExecutionFailedCause = string;
-    export interface SWFCompleteWorkflowExecutionFailedEventAttributes {
-        cause: SWFCompleteWorkflowExecutionFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFContinueAsNewWorkflowExecutionDecisionAttributes {
-        input?: SWFData;
-        executionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskList?: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        taskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        childPolicy?: SWFChildPolicy;
-        tagList?: SWFTagList;
-        workflowTypeVersion?: SWFVersion;
-        lambdaRole?: SWFArn;
-    }
-
-    export type SWFContinueAsNewWorkflowExecutionFailedCause = string;
-    export interface SWFContinueAsNewWorkflowExecutionFailedEventAttributes {
-        cause: SWFContinueAsNewWorkflowExecutionFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export type SWFCount = number;
-    export interface SWFCountClosedWorkflowExecutionsInput {
-        domain: SWFDomainName;
-        startTimeFilter?: SWFExecutionTimeFilter;
-        closeTimeFilter?: SWFExecutionTimeFilter;
-        executionFilter?: SWFWorkflowExecutionFilter;
-        typeFilter?: SWFWorkflowTypeFilter;
-        tagFilter?: SWFTagFilter;
-        closeStatusFilter?: SWFCloseStatusFilter;
-    }
-
-    export interface SWFCountOpenWorkflowExecutionsInput {
-        domain: SWFDomainName;
-        startTimeFilter: SWFExecutionTimeFilter;
-        typeFilter?: SWFWorkflowTypeFilter;
-        tagFilter?: SWFTagFilter;
-        executionFilter?: SWFWorkflowExecutionFilter;
-    }
-
-    export interface SWFCountPendingActivityTasksInput {
-        domain: SWFDomainName;
-        taskList: SWFTaskList;
-    }
-
-    export interface SWFCountPendingDecisionTasksInput {
-        domain: SWFDomainName;
-        taskList: SWFTaskList;
-    }
-
-    export type SWFData = string;
-    export interface SWFDecision {
-        decisionType: SWFDecisionType;
-        scheduleActivityTaskDecisionAttributes?: SWFScheduleActivityTaskDecisionAttributes;
-        requestCancelActivityTaskDecisionAttributes?: SWFRequestCancelActivityTaskDecisionAttributes;
-        completeWorkflowExecutionDecisionAttributes?: SWFCompleteWorkflowExecutionDecisionAttributes;
-        failWorkflowExecutionDecisionAttributes?: SWFFailWorkflowExecutionDecisionAttributes;
-        cancelWorkflowExecutionDecisionAttributes?: SWFCancelWorkflowExecutionDecisionAttributes;
-        continueAsNewWorkflowExecutionDecisionAttributes?: SWFContinueAsNewWorkflowExecutionDecisionAttributes;
-        recordMarkerDecisionAttributes?: SWFRecordMarkerDecisionAttributes;
-        startTimerDecisionAttributes?: SWFStartTimerDecisionAttributes;
-        cancelTimerDecisionAttributes?: SWFCancelTimerDecisionAttributes;
-        signalExternalWorkflowExecutionDecisionAttributes?: SWFSignalExternalWorkflowExecutionDecisionAttributes;
-        requestCancelExternalWorkflowExecutionDecisionAttributes?: SWFRequestCancelExternalWorkflowExecutionDecisionAttributes;
-        startChildWorkflowExecutionDecisionAttributes?: SWFStartChildWorkflowExecutionDecisionAttributes;
-        scheduleLambdaFunctionDecisionAttributes?: SWFScheduleLambdaFunctionDecisionAttributes;
-    }
-
-    export type SWFDecisionList = Array<SWFDecision>;
-    export interface SWFDecisionTask {
-        taskToken: SWFTaskToken;
-        startedEventId: SWFEventId;
-        workflowExecution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        events: SWFHistoryEventList;
-        nextPageToken?: SWFPageToken;
-        previousStartedEventId?: SWFEventId;
-    }
-
-    export interface SWFDecisionTaskCompletedEventAttributes {
-        executionContext?: SWFData;
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export interface SWFDecisionTaskScheduledEventAttributes {
-        taskList: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        startToCloseTimeout?: SWFDurationInSecondsOptional;
-    }
-
-    export interface SWFDecisionTaskStartedEventAttributes {
-        identity?: SWFIdentity;
-        scheduledEventId: SWFEventId;
-    }
-
-    export interface SWFDecisionTaskTimedOutEventAttributes {
-        timeoutType: SWFDecisionTaskTimeoutType;
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-    }
-
-    export type SWFDecisionTaskTimeoutType = string;
-    export type SWFDecisionType = string;
-    export interface SWFDefaultUndefinedFault {
-        message?: SWFErrorMessage;
-    }
-
-    export interface SWFDeprecateActivityTypeInput {
-        domain: SWFDomainName;
-        activityType: SWFActivityType;
-    }
-
-    export interface SWFDeprecateDomainInput {
-        name: SWFDomainName;
-    }
-
-    export interface SWFDeprecateWorkflowTypeInput {
-        domain: SWFDomainName;
-        workflowType: SWFWorkflowType;
-    }
-
-    export interface SWFDescribeActivityTypeInput {
-        domain: SWFDomainName;
-        activityType: SWFActivityType;
-    }
-
-    export interface SWFDescribeDomainInput {
-        name: SWFDomainName;
-    }
-
-    export interface SWFDescribeWorkflowExecutionInput {
-        domain: SWFDomainName;
-        execution: SWFWorkflowExecution;
-    }
-
-    export interface SWFDescribeWorkflowTypeInput {
-        domain: SWFDomainName;
-        workflowType: SWFWorkflowType;
-    }
-
-    export type SWFDescription = string;
-    export interface SWFDomainAlreadyExistsFault {
-        message?: SWFErrorMessage;
-    }
-
-    export interface SWFDomainConfiguration {
-        workflowExecutionRetentionPeriodInDays: SWFDurationInDays;
-    }
-
-    export interface SWFDomainDeprecatedFault {
-        message?: SWFErrorMessage;
-    }
-
-    export interface SWFDomainDetail {
-        domainInfo: SWFDomainInfo;
-        configuration: SWFDomainConfiguration;
-    }
-
-    export interface SWFDomainInfo {
-        name: SWFDomainName;
-        status: SWFRegistrationStatus;
-        description?: SWFDescription;
-    }
-
-    export type SWFDomainInfoList = Array<SWFDomainInfo>;
-    export interface SWFDomainInfos {
-        domainInfos: SWFDomainInfoList;
-        nextPageToken?: SWFPageToken;
-    }
-
-    export type SWFDomainName = string;
-    export type SWFDurationInDays = string;
-    export type SWFDurationInSeconds = string;
-    export type SWFDurationInSecondsOptional = string;
-    export type SWFErrorMessage = string;
-    export type SWFEventId = number;
-    export type SWFEventType = string;
-    export type SWFExecutionStatus = string;
-    export interface SWFExecutionTimeFilter {
-        oldestDate: SWFTimestamp;
-        latestDate?: SWFTimestamp;
-    }
-
-    export interface SWFExternalWorkflowExecutionCancelRequestedEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        initiatedEventId: SWFEventId;
-    }
-
-    export interface SWFExternalWorkflowExecutionSignaledEventAttributes {
-        workflowExecution: SWFWorkflowExecution;
-        initiatedEventId: SWFEventId;
-    }
-
-    export interface SWFFailWorkflowExecutionDecisionAttributes {
-        reason?: SWFFailureReason;
-        details?: SWFData;
-    }
-
-    export type SWFFailWorkflowExecutionFailedCause = string;
-    export interface SWFFailWorkflowExecutionFailedEventAttributes {
-        cause: SWFFailWorkflowExecutionFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export type SWFFailureReason = string;
-    export type SWFFunctionId = string;
-    export type SWFFunctionInput = string;
-    export type SWFFunctionName = string;
-    export interface SWFGetWorkflowExecutionHistoryInput {
-        domain: SWFDomainName;
-        execution: SWFWorkflowExecution;
-        nextPageToken?: SWFPageToken;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-    }
-
-    export interface SWFHistory {
-        events: SWFHistoryEventList;
-        nextPageToken?: SWFPageToken;
-    }
-
-    export interface SWFHistoryEvent {
-        eventTimestamp: SWFTimestamp;
-        eventType: SWFEventType;
-        eventId: SWFEventId;
-        workflowExecutionStartedEventAttributes?: SWFWorkflowExecutionStartedEventAttributes;
-        workflowExecutionCompletedEventAttributes?: SWFWorkflowExecutionCompletedEventAttributes;
-        completeWorkflowExecutionFailedEventAttributes?: SWFCompleteWorkflowExecutionFailedEventAttributes;
-        workflowExecutionFailedEventAttributes?: SWFWorkflowExecutionFailedEventAttributes;
-        failWorkflowExecutionFailedEventAttributes?: SWFFailWorkflowExecutionFailedEventAttributes;
-        workflowExecutionTimedOutEventAttributes?: SWFWorkflowExecutionTimedOutEventAttributes;
-        workflowExecutionCanceledEventAttributes?: SWFWorkflowExecutionCanceledEventAttributes;
-        cancelWorkflowExecutionFailedEventAttributes?: SWFCancelWorkflowExecutionFailedEventAttributes;
-        workflowExecutionContinuedAsNewEventAttributes?: SWFWorkflowExecutionContinuedAsNewEventAttributes;
-        continueAsNewWorkflowExecutionFailedEventAttributes?: SWFContinueAsNewWorkflowExecutionFailedEventAttributes;
-        workflowExecutionTerminatedEventAttributes?: SWFWorkflowExecutionTerminatedEventAttributes;
-        workflowExecutionCancelRequestedEventAttributes?: SWFWorkflowExecutionCancelRequestedEventAttributes;
-        decisionTaskScheduledEventAttributes?: SWFDecisionTaskScheduledEventAttributes;
-        decisionTaskStartedEventAttributes?: SWFDecisionTaskStartedEventAttributes;
-        decisionTaskCompletedEventAttributes?: SWFDecisionTaskCompletedEventAttributes;
-        decisionTaskTimedOutEventAttributes?: SWFDecisionTaskTimedOutEventAttributes;
-        activityTaskScheduledEventAttributes?: SWFActivityTaskScheduledEventAttributes;
-        activityTaskStartedEventAttributes?: SWFActivityTaskStartedEventAttributes;
-        activityTaskCompletedEventAttributes?: SWFActivityTaskCompletedEventAttributes;
-        activityTaskFailedEventAttributes?: SWFActivityTaskFailedEventAttributes;
-        activityTaskTimedOutEventAttributes?: SWFActivityTaskTimedOutEventAttributes;
-        activityTaskCanceledEventAttributes?: SWFActivityTaskCanceledEventAttributes;
-        activityTaskCancelRequestedEventAttributes?: SWFActivityTaskCancelRequestedEventAttributes;
-        workflowExecutionSignaledEventAttributes?: SWFWorkflowExecutionSignaledEventAttributes;
-        markerRecordedEventAttributes?: SWFMarkerRecordedEventAttributes;
-        recordMarkerFailedEventAttributes?: SWFRecordMarkerFailedEventAttributes;
-        timerStartedEventAttributes?: SWFTimerStartedEventAttributes;
-        timerFiredEventAttributes?: SWFTimerFiredEventAttributes;
-        timerCanceledEventAttributes?: SWFTimerCanceledEventAttributes;
-        startChildWorkflowExecutionInitiatedEventAttributes?: SWFStartChildWorkflowExecutionInitiatedEventAttributes;
-        childWorkflowExecutionStartedEventAttributes?: SWFChildWorkflowExecutionStartedEventAttributes;
-        childWorkflowExecutionCompletedEventAttributes?: SWFChildWorkflowExecutionCompletedEventAttributes;
-        childWorkflowExecutionFailedEventAttributes?: SWFChildWorkflowExecutionFailedEventAttributes;
-        childWorkflowExecutionTimedOutEventAttributes?: SWFChildWorkflowExecutionTimedOutEventAttributes;
-        childWorkflowExecutionCanceledEventAttributes?: SWFChildWorkflowExecutionCanceledEventAttributes;
-        childWorkflowExecutionTerminatedEventAttributes?: SWFChildWorkflowExecutionTerminatedEventAttributes;
-        signalExternalWorkflowExecutionInitiatedEventAttributes?: SWFSignalExternalWorkflowExecutionInitiatedEventAttributes;
-        externalWorkflowExecutionSignaledEventAttributes?: SWFExternalWorkflowExecutionSignaledEventAttributes;
-        signalExternalWorkflowExecutionFailedEventAttributes?: SWFSignalExternalWorkflowExecutionFailedEventAttributes;
-        externalWorkflowExecutionCancelRequestedEventAttributes?: SWFExternalWorkflowExecutionCancelRequestedEventAttributes;
-        requestCancelExternalWorkflowExecutionInitiatedEventAttributes?: SWFRequestCancelExternalWorkflowExecutionInitiatedEventAttributes;
-        requestCancelExternalWorkflowExecutionFailedEventAttributes?: SWFRequestCancelExternalWorkflowExecutionFailedEventAttributes;
-        scheduleActivityTaskFailedEventAttributes?: SWFScheduleActivityTaskFailedEventAttributes;
-        requestCancelActivityTaskFailedEventAttributes?: SWFRequestCancelActivityTaskFailedEventAttributes;
-        startTimerFailedEventAttributes?: SWFStartTimerFailedEventAttributes;
-        cancelTimerFailedEventAttributes?: SWFCancelTimerFailedEventAttributes;
-        startChildWorkflowExecutionFailedEventAttributes?: SWFStartChildWorkflowExecutionFailedEventAttributes;
-        lambdaFunctionScheduledEventAttributes?: SWFLambdaFunctionScheduledEventAttributes;
-        lambdaFunctionStartedEventAttributes?: SWFLambdaFunctionStartedEventAttributes;
-        lambdaFunctionCompletedEventAttributes?: SWFLambdaFunctionCompletedEventAttributes;
-        lambdaFunctionFailedEventAttributes?: SWFLambdaFunctionFailedEventAttributes;
-        lambdaFunctionTimedOutEventAttributes?: SWFLambdaFunctionTimedOutEventAttributes;
-        scheduleLambdaFunctionFailedEventAttributes?: SWFScheduleLambdaFunctionFailedEventAttributes;
-        startLambdaFunctionFailedEventAttributes?: SWFStartLambdaFunctionFailedEventAttributes;
-    }
-
-    export type SWFHistoryEventList = Array<SWFHistoryEvent>;
-    export type SWFIdentity = string;
-    export interface SWFLambdaFunctionCompletedEventAttributes {
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-        result?: SWFData;
-    }
-
-    export interface SWFLambdaFunctionFailedEventAttributes {
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-        reason?: SWFFailureReason;
-        details?: SWFData;
-    }
-
-    export interface SWFLambdaFunctionScheduledEventAttributes {
-        id: SWFFunctionId;
-        name: SWFFunctionName;
-        input?: SWFFunctionInput;
-        startToCloseTimeout?: SWFDurationInSecondsOptional;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFLambdaFunctionStartedEventAttributes {
-        scheduledEventId: SWFEventId;
-    }
-
-    export interface SWFLambdaFunctionTimedOutEventAttributes {
-        scheduledEventId: SWFEventId;
-        startedEventId: SWFEventId;
-        timeoutType?: SWFLambdaFunctionTimeoutType;
-    }
-
-    export type SWFLambdaFunctionTimeoutType = string;
-    export interface SWFLimitExceededFault {
-        message?: SWFErrorMessage;
-    }
-
-    export type SWFLimitedData = string;
-    export interface SWFListActivityTypesInput {
-        domain: SWFDomainName;
-        name?: SWFName;
-        registrationStatus: SWFRegistrationStatus;
-        nextPageToken?: SWFPageToken;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-    }
-
-    export interface SWFListClosedWorkflowExecutionsInput {
-        domain: SWFDomainName;
-        startTimeFilter?: SWFExecutionTimeFilter;
-        closeTimeFilter?: SWFExecutionTimeFilter;
-        executionFilter?: SWFWorkflowExecutionFilter;
-        closeStatusFilter?: SWFCloseStatusFilter;
-        typeFilter?: SWFWorkflowTypeFilter;
-        tagFilter?: SWFTagFilter;
-        nextPageToken?: SWFPageToken;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-    }
-
-    export interface SWFListDomainsInput {
-        nextPageToken?: SWFPageToken;
-        registrationStatus: SWFRegistrationStatus;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-    }
-
-    export interface SWFListOpenWorkflowExecutionsInput {
-        domain: SWFDomainName;
-        startTimeFilter: SWFExecutionTimeFilter;
-        typeFilter?: SWFWorkflowTypeFilter;
-        tagFilter?: SWFTagFilter;
-        nextPageToken?: SWFPageToken;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-        executionFilter?: SWFWorkflowExecutionFilter;
-    }
-
-    export interface SWFListWorkflowTypesInput {
-        domain: SWFDomainName;
-        name?: SWFName;
-        registrationStatus: SWFRegistrationStatus;
-        nextPageToken?: SWFPageToken;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-    }
-
-    export type SWFMarkerName = string;
-    export interface SWFMarkerRecordedEventAttributes {
-        markerName: SWFMarkerName;
-        details?: SWFData;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export type SWFName = string;
-    export type SWFOpenDecisionTasksCount = number;
-    export interface SWFOperationNotPermittedFault {
-        message?: SWFErrorMessage;
-    }
-
-    export type SWFPageSize = number;
-    export type SWFPageToken = string;
-    export interface SWFPendingTaskCount {
-        count: SWFCount;
-        truncated?: SWFTruncated;
-    }
-
-    export interface SWFPollForActivityTaskInput {
-        domain: SWFDomainName;
-        taskList: SWFTaskList;
-        identity?: SWFIdentity;
-    }
-
-    export interface SWFPollForDecisionTaskInput {
-        domain: SWFDomainName;
-        taskList: SWFTaskList;
-        identity?: SWFIdentity;
-        nextPageToken?: SWFPageToken;
-        maximumPageSize?: SWFPageSize;
-        reverseOrder?: SWFReverseOrder;
-    }
-
-    export interface SWFRecordActivityTaskHeartbeatInput {
-        taskToken: SWFTaskToken;
-        details?: SWFLimitedData;
-    }
-
-    export interface SWFRecordMarkerDecisionAttributes {
-        markerName: SWFMarkerName;
-        details?: SWFData;
-    }
-
-    export type SWFRecordMarkerFailedCause = string;
-    export interface SWFRecordMarkerFailedEventAttributes {
-        markerName: SWFMarkerName;
-        cause: SWFRecordMarkerFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFRegisterActivityTypeInput {
-        domain: SWFDomainName;
-        name: SWFName;
-        version: SWFVersion;
-        description?: SWFDescription;
-        defaultTaskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskHeartbeatTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskList?: SWFTaskList;
-        defaultTaskPriority?: SWFTaskPriority;
-        defaultTaskScheduleToStartTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskScheduleToCloseTimeout?: SWFDurationInSecondsOptional;
-    }
-
-    export interface SWFRegisterDomainInput {
-        name: SWFDomainName;
-        description?: SWFDescription;
-        workflowExecutionRetentionPeriodInDays: SWFDurationInDays;
-    }
-
-    export interface SWFRegisterWorkflowTypeInput {
-        domain: SWFDomainName;
-        name: SWFName;
-        version: SWFVersion;
-        description?: SWFDescription;
-        defaultTaskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        defaultExecutionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskList?: SWFTaskList;
-        defaultTaskPriority?: SWFTaskPriority;
-        defaultChildPolicy?: SWFChildPolicy;
-        defaultLambdaRole?: SWFArn;
-    }
-
-    export type SWFRegistrationStatus = string;
-    export interface SWFRequestCancelActivityTaskDecisionAttributes {
-        activityId: SWFActivityId;
-    }
-
-    export type SWFRequestCancelActivityTaskFailedCause = string;
-    export interface SWFRequestCancelActivityTaskFailedEventAttributes {
-        activityId: SWFActivityId;
-        cause: SWFRequestCancelActivityTaskFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFRequestCancelExternalWorkflowExecutionDecisionAttributes {
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        control?: SWFData;
-    }
-
-    export type SWFRequestCancelExternalWorkflowExecutionFailedCause = string;
-    export interface SWFRequestCancelExternalWorkflowExecutionFailedEventAttributes {
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        cause: SWFRequestCancelExternalWorkflowExecutionFailedCause;
-        initiatedEventId: SWFEventId;
-        decisionTaskCompletedEventId: SWFEventId;
-        control?: SWFData;
-    }
-
-    export interface SWFRequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        decisionTaskCompletedEventId: SWFEventId;
-        control?: SWFData;
-    }
-
-    export interface SWFRequestCancelWorkflowExecutionInput {
-        domain: SWFDomainName;
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-    }
-
-    export interface SWFRespondActivityTaskCanceledInput {
-        taskToken: SWFTaskToken;
-        details?: SWFData;
-    }
-
-    export interface SWFRespondActivityTaskCompletedInput {
-        taskToken: SWFTaskToken;
-        result?: SWFData;
-    }
-
-    export interface SWFRespondActivityTaskFailedInput {
-        taskToken: SWFTaskToken;
-        reason?: SWFFailureReason;
-        details?: SWFData;
-    }
-
-    export interface SWFRespondDecisionTaskCompletedInput {
-        taskToken: SWFTaskToken;
-        decisions?: SWFDecisionList;
-        executionContext?: SWFData;
-    }
-
-    export type SWFReverseOrder = boolean;
-    export interface SWFRun {
-        runId?: SWFRunId;
-    }
-
-    export type SWFRunId = string;
-    export type SWFRunIdOptional = string;
-    export interface SWFScheduleActivityTaskDecisionAttributes {
-        activityType: SWFActivityType;
-        activityId: SWFActivityId;
-        control?: SWFData;
-        input?: SWFData;
-        scheduleToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskList?: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        scheduleToStartTimeout?: SWFDurationInSecondsOptional;
-        startToCloseTimeout?: SWFDurationInSecondsOptional;
-        heartbeatTimeout?: SWFDurationInSecondsOptional;
-    }
-
-    export type SWFScheduleActivityTaskFailedCause = string;
-    export interface SWFScheduleActivityTaskFailedEventAttributes {
-        activityType: SWFActivityType;
-        activityId: SWFActivityId;
-        cause: SWFScheduleActivityTaskFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFScheduleLambdaFunctionDecisionAttributes {
-        id: SWFFunctionId;
-        name: SWFFunctionName;
-        input?: SWFFunctionInput;
-        startToCloseTimeout?: SWFDurationInSecondsOptional;
-    }
-
-    export type SWFScheduleLambdaFunctionFailedCause = string;
-    export interface SWFScheduleLambdaFunctionFailedEventAttributes {
-        id: SWFFunctionId;
-        name: SWFFunctionName;
-        cause: SWFScheduleLambdaFunctionFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFSignalExternalWorkflowExecutionDecisionAttributes {
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        signalName: SWFSignalName;
-        input?: SWFData;
-        control?: SWFData;
-    }
-
-    export type SWFSignalExternalWorkflowExecutionFailedCause = string;
-    export interface SWFSignalExternalWorkflowExecutionFailedEventAttributes {
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        cause: SWFSignalExternalWorkflowExecutionFailedCause;
-        initiatedEventId: SWFEventId;
-        decisionTaskCompletedEventId: SWFEventId;
-        control?: SWFData;
-    }
-
-    export interface SWFSignalExternalWorkflowExecutionInitiatedEventAttributes {
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        signalName: SWFSignalName;
-        input?: SWFData;
-        decisionTaskCompletedEventId: SWFEventId;
-        control?: SWFData;
-    }
-
-    export type SWFSignalName = string;
-    export interface SWFSignalWorkflowExecutionInput {
-        domain: SWFDomainName;
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        signalName: SWFSignalName;
-        input?: SWFData;
-    }
-
-    export interface SWFStartChildWorkflowExecutionDecisionAttributes {
-        workflowType: SWFWorkflowType;
-        workflowId: SWFWorkflowId;
-        control?: SWFData;
-        input?: SWFData;
-        executionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskList?: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        taskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        childPolicy?: SWFChildPolicy;
-        tagList?: SWFTagList;
-        lambdaRole?: SWFArn;
-    }
-
-    export type SWFStartChildWorkflowExecutionFailedCause = string;
-    export interface SWFStartChildWorkflowExecutionFailedEventAttributes {
-        workflowType: SWFWorkflowType;
-        cause: SWFStartChildWorkflowExecutionFailedCause;
-        workflowId: SWFWorkflowId;
-        initiatedEventId: SWFEventId;
-        decisionTaskCompletedEventId: SWFEventId;
-        control?: SWFData;
-    }
-
-    export interface SWFStartChildWorkflowExecutionInitiatedEventAttributes {
-        workflowId: SWFWorkflowId;
-        workflowType: SWFWorkflowType;
-        control?: SWFData;
-        input?: SWFData;
-        executionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskList: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        decisionTaskCompletedEventId: SWFEventId;
-        childPolicy: SWFChildPolicy;
-        taskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        tagList?: SWFTagList;
-        lambdaRole?: SWFArn;
-    }
-
-    export type SWFStartLambdaFunctionFailedCause = string;
-    export interface SWFStartLambdaFunctionFailedEventAttributes {
-        scheduledEventId?: SWFEventId;
-        cause?: SWFStartLambdaFunctionFailedCause;
-        message?: SWFCauseMessage;
-    }
+      countClosedWorkflowExecutions(params: SWF.CountClosedWorkflowExecutionsInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.WorkflowExecutionCount|any) => void): Request;
+      countOpenWorkflowExecutions(params: SWF.CountOpenWorkflowExecutionsInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.WorkflowExecutionCount|any) => void): Request;
+      countPendingActivityTasks(params: SWF.CountPendingActivityTasksInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.PendingTaskCount|any) => void): Request;
+      countPendingDecisionTasks(params: SWF.CountPendingDecisionTasksInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.PendingTaskCount|any) => void): Request;
+      deprecateActivityType(params: SWF.DeprecateActivityTypeInput, callback?: (err: SWF.UnknownResourceFault|SWF.TypeDeprecatedFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      deprecateDomain(params: SWF.DeprecateDomainInput, callback?: (err: SWF.UnknownResourceFault|SWF.DomainDeprecatedFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      deprecateWorkflowType(params: SWF.DeprecateWorkflowTypeInput, callback?: (err: SWF.UnknownResourceFault|SWF.TypeDeprecatedFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      describeActivityType(params: SWF.DescribeActivityTypeInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.ActivityTypeDetail|any) => void): Request;
+      describeDomain(params: SWF.DescribeDomainInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.DomainDetail|any) => void): Request;
+      describeWorkflowExecution(params: SWF.DescribeWorkflowExecutionInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.WorkflowExecutionDetail|any) => void): Request;
+      describeWorkflowType(params: SWF.DescribeWorkflowTypeInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.WorkflowTypeDetail|any) => void): Request;
+      getWorkflowExecutionHistory(params: SWF.GetWorkflowExecutionHistoryInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.History|any) => void): Request;
+      listActivityTypes(params: SWF.ListActivityTypesInput, callback?: (err: SWF.OperationNotPermittedFault|SWF.UnknownResourceFault|any, data: SWF.ActivityTypeInfos|any) => void): Request;
+      listClosedWorkflowExecutions(params: SWF.ListClosedWorkflowExecutionsInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.WorkflowExecutionInfos|any) => void): Request;
+      listDomains(params: SWF.ListDomainsInput, callback?: (err: SWF.OperationNotPermittedFault|any, data: SWF.DomainInfos|any) => void): Request;
+      listOpenWorkflowExecutions(params: SWF.ListOpenWorkflowExecutionsInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.WorkflowExecutionInfos|any) => void): Request;
+      listWorkflowTypes(params: SWF.ListWorkflowTypesInput, callback?: (err: SWF.OperationNotPermittedFault|SWF.UnknownResourceFault|any, data: SWF.WorkflowTypeInfos|any) => void): Request;
+      pollForActivityTask(params: SWF.PollForActivityTaskInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|SWF.LimitExceededFault|any, data: SWF.ActivityTask|any) => void): Request;
+      pollForDecisionTask(params: SWF.PollForDecisionTaskInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|SWF.LimitExceededFault|any, data: SWF.DecisionTask|any) => void): Request;
+      recordActivityTaskHeartbeat(params: SWF.RecordActivityTaskHeartbeatInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: SWF.ActivityTaskStatus|any) => void): Request;
+      registerActivityType(params: SWF.RegisterActivityTypeInput, callback?: (err: SWF.TypeAlreadyExistsFault|SWF.LimitExceededFault|SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      registerDomain(params: SWF.RegisterDomainInput, callback?: (err: SWF.DomainAlreadyExistsFault|SWF.LimitExceededFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      registerWorkflowType(params: SWF.RegisterWorkflowTypeInput, callback?: (err: SWF.TypeAlreadyExistsFault|SWF.LimitExceededFault|SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      requestCancelWorkflowExecution(params: SWF.RequestCancelWorkflowExecutionInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      respondActivityTaskCanceled(params: SWF.RespondActivityTaskCanceledInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      respondActivityTaskCompleted(params: SWF.RespondActivityTaskCompletedInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      respondActivityTaskFailed(params: SWF.RespondActivityTaskFailedInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      respondDecisionTaskCompleted(params: SWF.RespondDecisionTaskCompletedInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      signalWorkflowExecution(params: SWF.SignalWorkflowExecutionInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+      startWorkflowExecution(params: SWF.StartWorkflowExecutionInput, callback?: (err: SWF.UnknownResourceFault|SWF.TypeDeprecatedFault|SWF.WorkflowExecutionAlreadyStartedFault|SWF.LimitExceededFault|SWF.OperationNotPermittedFault|SWF.DefaultUndefinedFault|any, data: SWF.Run|any) => void): Request;
+      terminateWorkflowExecution(params: SWF.TerminateWorkflowExecutionInput, callback?: (err: SWF.UnknownResourceFault|SWF.OperationNotPermittedFault|any, data: any) => void): Request;
+    }
+    
+    export module SWF {
+        export type ActivityId = string;    // max: 256, min: 1
+        export type ActivityTaskTimeoutType = string;
+        export type ActivityTypeInfoList = ActivityTypeInfo[];
+        export type Arn = string;    // max: 1224, min: 1
+        export type CancelTimerFailedCause = string;
+        export type CancelWorkflowExecutionFailedCause = string;
+        export type Canceled = boolean;
+        export type CauseMessage = string;    // max: 1728
+        export type ChildPolicy = string;
+        export type CloseStatus = string;
+        export type CompleteWorkflowExecutionFailedCause = string;
+        export type ContinueAsNewWorkflowExecutionFailedCause = string;
+        export type Count = number;
+        export type Data = string;    // max: 32768
+        export type DecisionList = Decision[];
+        export type DecisionTaskTimeoutType = string;
+        export type DecisionType = string;
+        export type Description = string;    // max: 1024
+        export type DomainInfoList = DomainInfo[];
+        export type DomainName = string;    // max: 256, min: 1
+        export type DurationInDays = string;    // max: 8, min: 1
+        export type DurationInSeconds = string;    // max: 8, min: 1
+        export type DurationInSecondsOptional = string;    // max: 8
+        export type ErrorMessage = string;
+        export type EventId = number;
+        export type EventType = string;
+        export type ExecutionStatus = string;
+        export type FailWorkflowExecutionFailedCause = string;
+        export type FailureReason = string;    // max: 256
+        export type FunctionId = string;    // max: 256, min: 1
+        export type FunctionInput = string;    // max: 32768, min: 1
+        export type FunctionName = string;    // max: 64, min: 1
+        export type HistoryEventList = HistoryEvent[];
+        export type Identity = string;    // max: 256
+        export type LambdaFunctionTimeoutType = string;
+        export type LimitedData = string;    // max: 2048
+        export type MarkerName = string;    // max: 256, min: 1
+        export type Name = string;    // max: 256, min: 1
+        export type OpenDecisionTasksCount = number;    // max: 1
+        export type PageSize = number;    // max: 1000
+        export type PageToken = string;    // max: 2048
+        export type RecordMarkerFailedCause = string;
+        export type RegistrationStatus = string;
+        export type RequestCancelActivityTaskFailedCause = string;
+        export type RequestCancelExternalWorkflowExecutionFailedCause = string;
+        export type ReverseOrder = boolean;
+        export type RunId = string;    // max: 64, min: 1
+        export type RunIdOptional = string;    // max: 64
+        export type ScheduleActivityTaskFailedCause = string;
+        export type ScheduleLambdaFunctionFailedCause = string;
+        export type SignalExternalWorkflowExecutionFailedCause = string;
+        export type SignalName = string;    // max: 256, min: 1
+        export type StartChildWorkflowExecutionFailedCause = string;
+        export type StartLambdaFunctionFailedCause = string;
+        export type StartTimerFailedCause = string;
+        export type Tag = string;    // max: 256, min: 1
+        export type TagList = Tag[];    // max: 5
+        export type TaskPriority = string;    // max: 11
+        export type TaskToken = string;    // max: 1024, min: 1
+        export type TerminateReason = string;    // max: 256
+        export type TimerId = string;    // max: 256, min: 1
+        export type Timestamp = number;
+        export type Truncated = boolean;
+        export type Version = string;    // max: 64, min: 1
+        export type VersionOptional = string;    // max: 64
+        export type WorkflowExecutionCancelRequestedCause = string;
+        export type WorkflowExecutionInfoList = WorkflowExecutionInfo[];
+        export type WorkflowExecutionTerminatedCause = string;
+        export type WorkflowExecutionTimeoutType = string;
+        export type WorkflowId = string;    // max: 256, min: 1
+        export type WorkflowTypeInfoList = WorkflowTypeInfo[];
+
+        export interface ActivityTask {
+            taskToken: TaskToken;            
+            activityId: ActivityId;            
+            startedEventId: EventId;            
+            workflowExecution: WorkflowExecution;            
+            activityType: ActivityType;            
+            input?: Data;            
+        }
+        export interface ActivityTaskCancelRequestedEventAttributes {
+            decisionTaskCompletedEventId: EventId;            
+            activityId: ActivityId;            
+        }
+        export interface ActivityTaskCanceledEventAttributes {
+            details?: Data;            
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+            latestCancelRequestedEventId?: EventId;            
+        }
+        export interface ActivityTaskCompletedEventAttributes {
+            result?: Data;            
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface ActivityTaskFailedEventAttributes {
+            reason?: FailureReason;            
+            details?: Data;            
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface ActivityTaskScheduledEventAttributes {
+            activityType: ActivityType;            
+            activityId: ActivityId;            
+            input?: Data;            
+            control?: Data;            
+            scheduleToStartTimeout?: DurationInSecondsOptional;            
+            scheduleToCloseTimeout?: DurationInSecondsOptional;            
+            startToCloseTimeout?: DurationInSecondsOptional;            
+            taskList: TaskList;            
+            taskPriority?: TaskPriority;            
+            decisionTaskCompletedEventId: EventId;            
+            heartbeatTimeout?: DurationInSecondsOptional;            
+        }
+        export interface ActivityTaskStartedEventAttributes {
+            identity?: Identity;            
+            scheduledEventId: EventId;            
+        }
+        export interface ActivityTaskStatus {
+            cancelRequested: Canceled;            
+        }
+        export interface ActivityTaskTimedOutEventAttributes {
+            timeoutType: ActivityTaskTimeoutType;            
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+            details?: LimitedData;            
+        }
+        export interface ActivityType {
+            name: Name;            
+            version: Version;            
+        }
+        export interface ActivityTypeConfiguration {
+            defaultTaskStartToCloseTimeout?: DurationInSecondsOptional;            
+            defaultTaskHeartbeatTimeout?: DurationInSecondsOptional;            
+            defaultTaskList?: TaskList;            
+            defaultTaskPriority?: TaskPriority;            
+            defaultTaskScheduleToStartTimeout?: DurationInSecondsOptional;            
+            defaultTaskScheduleToCloseTimeout?: DurationInSecondsOptional;            
+        }
+        export interface ActivityTypeDetail {
+            typeInfo: ActivityTypeInfo;            
+            configuration: ActivityTypeConfiguration;            
+        }
+        export interface ActivityTypeInfo {
+            activityType: ActivityType;            
+            status: RegistrationStatus;            
+            description?: Description;            
+            creationDate: Timestamp;            
+            deprecationDate?: Timestamp;            
+        }
+        export interface ActivityTypeInfos {
+            typeInfos: ActivityTypeInfoList;            
+            nextPageToken?: PageToken;            
+        }
+        export interface CancelTimerDecisionAttributes {
+            timerId: TimerId;            
+        }
+        export interface CancelTimerFailedEventAttributes {
+            timerId: TimerId;            
+            cause: CancelTimerFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface CancelWorkflowExecutionDecisionAttributes {
+            details?: Data;            
+        }
+        export interface CancelWorkflowExecutionFailedEventAttributes {
+            cause: CancelWorkflowExecutionFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface ChildWorkflowExecutionCanceledEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            details?: Data;            
+            initiatedEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface ChildWorkflowExecutionCompletedEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            result?: Data;            
+            initiatedEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface ChildWorkflowExecutionFailedEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            reason?: FailureReason;            
+            details?: Data;            
+            initiatedEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface ChildWorkflowExecutionStartedEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            initiatedEventId: EventId;            
+        }
+        export interface ChildWorkflowExecutionTerminatedEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            initiatedEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface ChildWorkflowExecutionTimedOutEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            timeoutType: WorkflowExecutionTimeoutType;            
+            initiatedEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface CloseStatusFilter {
+            status: CloseStatus;            
+        }
+        export interface CompleteWorkflowExecutionDecisionAttributes {
+            result?: Data;            
+        }
+        export interface CompleteWorkflowExecutionFailedEventAttributes {
+            cause: CompleteWorkflowExecutionFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface ContinueAsNewWorkflowExecutionDecisionAttributes {
+            input?: Data;            
+            executionStartToCloseTimeout?: DurationInSecondsOptional;            
+            taskList?: TaskList;            
+            taskPriority?: TaskPriority;            
+            taskStartToCloseTimeout?: DurationInSecondsOptional;            
+            childPolicy?: ChildPolicy;            
+            tagList?: TagList;            
+            workflowTypeVersion?: Version;            
+            lambdaRole?: Arn;            
+        }
+        export interface ContinueAsNewWorkflowExecutionFailedEventAttributes {
+            cause: ContinueAsNewWorkflowExecutionFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface CountClosedWorkflowExecutionsInput {
+            domain: DomainName;            
+            startTimeFilter?: ExecutionTimeFilter;            
+            closeTimeFilter?: ExecutionTimeFilter;            
+            executionFilter?: WorkflowExecutionFilter;            
+            typeFilter?: WorkflowTypeFilter;            
+            tagFilter?: TagFilter;            
+            closeStatusFilter?: CloseStatusFilter;            
+        }
+        export interface CountOpenWorkflowExecutionsInput {
+            domain: DomainName;            
+            startTimeFilter: ExecutionTimeFilter;            
+            typeFilter?: WorkflowTypeFilter;            
+            tagFilter?: TagFilter;            
+            executionFilter?: WorkflowExecutionFilter;            
+        }
+        export interface CountPendingActivityTasksInput {
+            domain: DomainName;            
+            taskList: TaskList;            
+        }
+        export interface CountPendingDecisionTasksInput {
+            domain: DomainName;            
+            taskList: TaskList;            
+        }
+        export interface Decision {
+            decisionType: DecisionType;            
+            scheduleActivityTaskDecisionAttributes?: ScheduleActivityTaskDecisionAttributes;            
+            requestCancelActivityTaskDecisionAttributes?: RequestCancelActivityTaskDecisionAttributes;            
+            completeWorkflowExecutionDecisionAttributes?: CompleteWorkflowExecutionDecisionAttributes;            
+            failWorkflowExecutionDecisionAttributes?: FailWorkflowExecutionDecisionAttributes;            
+            cancelWorkflowExecutionDecisionAttributes?: CancelWorkflowExecutionDecisionAttributes;            
+            continueAsNewWorkflowExecutionDecisionAttributes?: ContinueAsNewWorkflowExecutionDecisionAttributes;            
+            recordMarkerDecisionAttributes?: RecordMarkerDecisionAttributes;            
+            startTimerDecisionAttributes?: StartTimerDecisionAttributes;            
+            cancelTimerDecisionAttributes?: CancelTimerDecisionAttributes;            
+            signalExternalWorkflowExecutionDecisionAttributes?: SignalExternalWorkflowExecutionDecisionAttributes;            
+            requestCancelExternalWorkflowExecutionDecisionAttributes?: RequestCancelExternalWorkflowExecutionDecisionAttributes;            
+            startChildWorkflowExecutionDecisionAttributes?: StartChildWorkflowExecutionDecisionAttributes;            
+            scheduleLambdaFunctionDecisionAttributes?: ScheduleLambdaFunctionDecisionAttributes;            
+        }
+        export interface DecisionTask {
+            taskToken: TaskToken;            
+            startedEventId: EventId;            
+            workflowExecution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            events: HistoryEventList;            
+            nextPageToken?: PageToken;            
+            previousStartedEventId?: EventId;            
+        }
+        export interface DecisionTaskCompletedEventAttributes {
+            executionContext?: Data;            
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface DecisionTaskScheduledEventAttributes {
+            taskList: TaskList;            
+            taskPriority?: TaskPriority;            
+            startToCloseTimeout?: DurationInSecondsOptional;            
+        }
+        export interface DecisionTaskStartedEventAttributes {
+            identity?: Identity;            
+            scheduledEventId: EventId;            
+        }
+        export interface DecisionTaskTimedOutEventAttributes {
+            timeoutType: DecisionTaskTimeoutType;            
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+        }
+        export interface DefaultUndefinedFault {
+            message?: ErrorMessage;            
+        }
+        export interface DeprecateActivityTypeInput {
+            domain: DomainName;            
+            activityType: ActivityType;            
+        }
+        export interface DeprecateDomainInput {
+            name: DomainName;            
+        }
+        export interface DeprecateWorkflowTypeInput {
+            domain: DomainName;            
+            workflowType: WorkflowType;            
+        }
+        export interface DescribeActivityTypeInput {
+            domain: DomainName;            
+            activityType: ActivityType;            
+        }
+        export interface DescribeDomainInput {
+            name: DomainName;            
+        }
+        export interface DescribeWorkflowExecutionInput {
+            domain: DomainName;            
+            execution: WorkflowExecution;            
+        }
+        export interface DescribeWorkflowTypeInput {
+            domain: DomainName;            
+            workflowType: WorkflowType;            
+        }
+        export interface DomainAlreadyExistsFault {
+            message?: ErrorMessage;            
+        }
+        export interface DomainConfiguration {
+            workflowExecutionRetentionPeriodInDays: DurationInDays;            
+        }
+        export interface DomainDeprecatedFault {
+            message?: ErrorMessage;            
+        }
+        export interface DomainDetail {
+            domainInfo: DomainInfo;            
+            configuration: DomainConfiguration;            
+        }
+        export interface DomainInfo {
+            name: DomainName;            
+            status: RegistrationStatus;            
+            description?: Description;            
+        }
+        export interface DomainInfos {
+            domainInfos: DomainInfoList;            
+            nextPageToken?: PageToken;            
+        }
+        export interface ExecutionTimeFilter {
+            oldestDate: Timestamp;            
+            latestDate?: Timestamp;            
+        }
+        export interface ExternalWorkflowExecutionCancelRequestedEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            initiatedEventId: EventId;            
+        }
+        export interface ExternalWorkflowExecutionSignaledEventAttributes {
+            workflowExecution: WorkflowExecution;            
+            initiatedEventId: EventId;            
+        }
+        export interface FailWorkflowExecutionDecisionAttributes {
+            reason?: FailureReason;            
+            details?: Data;            
+        }
+        export interface FailWorkflowExecutionFailedEventAttributes {
+            cause: FailWorkflowExecutionFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface GetWorkflowExecutionHistoryInput {
+            domain: DomainName;            
+            execution: WorkflowExecution;            
+            nextPageToken?: PageToken;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+        }
+        export interface History {
+            events: HistoryEventList;            
+            nextPageToken?: PageToken;            
+        }
+        export interface HistoryEvent {
+            eventTimestamp: Timestamp;            
+            eventType: EventType;            
+            eventId: EventId;            
+            workflowExecutionStartedEventAttributes?: WorkflowExecutionStartedEventAttributes;            
+            workflowExecutionCompletedEventAttributes?: WorkflowExecutionCompletedEventAttributes;            
+            completeWorkflowExecutionFailedEventAttributes?: CompleteWorkflowExecutionFailedEventAttributes;            
+            workflowExecutionFailedEventAttributes?: WorkflowExecutionFailedEventAttributes;            
+            failWorkflowExecutionFailedEventAttributes?: FailWorkflowExecutionFailedEventAttributes;            
+            workflowExecutionTimedOutEventAttributes?: WorkflowExecutionTimedOutEventAttributes;            
+            workflowExecutionCanceledEventAttributes?: WorkflowExecutionCanceledEventAttributes;            
+            cancelWorkflowExecutionFailedEventAttributes?: CancelWorkflowExecutionFailedEventAttributes;            
+            workflowExecutionContinuedAsNewEventAttributes?: WorkflowExecutionContinuedAsNewEventAttributes;            
+            continueAsNewWorkflowExecutionFailedEventAttributes?: ContinueAsNewWorkflowExecutionFailedEventAttributes;            
+            workflowExecutionTerminatedEventAttributes?: WorkflowExecutionTerminatedEventAttributes;            
+            workflowExecutionCancelRequestedEventAttributes?: WorkflowExecutionCancelRequestedEventAttributes;            
+            decisionTaskScheduledEventAttributes?: DecisionTaskScheduledEventAttributes;            
+            decisionTaskStartedEventAttributes?: DecisionTaskStartedEventAttributes;            
+            decisionTaskCompletedEventAttributes?: DecisionTaskCompletedEventAttributes;            
+            decisionTaskTimedOutEventAttributes?: DecisionTaskTimedOutEventAttributes;            
+            activityTaskScheduledEventAttributes?: ActivityTaskScheduledEventAttributes;            
+            activityTaskStartedEventAttributes?: ActivityTaskStartedEventAttributes;            
+            activityTaskCompletedEventAttributes?: ActivityTaskCompletedEventAttributes;            
+            activityTaskFailedEventAttributes?: ActivityTaskFailedEventAttributes;            
+            activityTaskTimedOutEventAttributes?: ActivityTaskTimedOutEventAttributes;            
+            activityTaskCanceledEventAttributes?: ActivityTaskCanceledEventAttributes;            
+            activityTaskCancelRequestedEventAttributes?: ActivityTaskCancelRequestedEventAttributes;            
+            workflowExecutionSignaledEventAttributes?: WorkflowExecutionSignaledEventAttributes;            
+            markerRecordedEventAttributes?: MarkerRecordedEventAttributes;            
+            recordMarkerFailedEventAttributes?: RecordMarkerFailedEventAttributes;            
+            timerStartedEventAttributes?: TimerStartedEventAttributes;            
+            timerFiredEventAttributes?: TimerFiredEventAttributes;            
+            timerCanceledEventAttributes?: TimerCanceledEventAttributes;            
+            startChildWorkflowExecutionInitiatedEventAttributes?: StartChildWorkflowExecutionInitiatedEventAttributes;            
+            childWorkflowExecutionStartedEventAttributes?: ChildWorkflowExecutionStartedEventAttributes;            
+            childWorkflowExecutionCompletedEventAttributes?: ChildWorkflowExecutionCompletedEventAttributes;            
+            childWorkflowExecutionFailedEventAttributes?: ChildWorkflowExecutionFailedEventAttributes;            
+            childWorkflowExecutionTimedOutEventAttributes?: ChildWorkflowExecutionTimedOutEventAttributes;            
+            childWorkflowExecutionCanceledEventAttributes?: ChildWorkflowExecutionCanceledEventAttributes;            
+            childWorkflowExecutionTerminatedEventAttributes?: ChildWorkflowExecutionTerminatedEventAttributes;            
+            signalExternalWorkflowExecutionInitiatedEventAttributes?: SignalExternalWorkflowExecutionInitiatedEventAttributes;            
+            externalWorkflowExecutionSignaledEventAttributes?: ExternalWorkflowExecutionSignaledEventAttributes;            
+            signalExternalWorkflowExecutionFailedEventAttributes?: SignalExternalWorkflowExecutionFailedEventAttributes;            
+            externalWorkflowExecutionCancelRequestedEventAttributes?: ExternalWorkflowExecutionCancelRequestedEventAttributes;            
+            requestCancelExternalWorkflowExecutionInitiatedEventAttributes?: RequestCancelExternalWorkflowExecutionInitiatedEventAttributes;            
+            requestCancelExternalWorkflowExecutionFailedEventAttributes?: RequestCancelExternalWorkflowExecutionFailedEventAttributes;            
+            scheduleActivityTaskFailedEventAttributes?: ScheduleActivityTaskFailedEventAttributes;            
+            requestCancelActivityTaskFailedEventAttributes?: RequestCancelActivityTaskFailedEventAttributes;            
+            startTimerFailedEventAttributes?: StartTimerFailedEventAttributes;            
+            cancelTimerFailedEventAttributes?: CancelTimerFailedEventAttributes;            
+            startChildWorkflowExecutionFailedEventAttributes?: StartChildWorkflowExecutionFailedEventAttributes;            
+            lambdaFunctionScheduledEventAttributes?: LambdaFunctionScheduledEventAttributes;            
+            lambdaFunctionStartedEventAttributes?: LambdaFunctionStartedEventAttributes;            
+            lambdaFunctionCompletedEventAttributes?: LambdaFunctionCompletedEventAttributes;            
+            lambdaFunctionFailedEventAttributes?: LambdaFunctionFailedEventAttributes;            
+            lambdaFunctionTimedOutEventAttributes?: LambdaFunctionTimedOutEventAttributes;            
+            scheduleLambdaFunctionFailedEventAttributes?: ScheduleLambdaFunctionFailedEventAttributes;            
+            startLambdaFunctionFailedEventAttributes?: StartLambdaFunctionFailedEventAttributes;            
+        }
+        export interface LambdaFunctionCompletedEventAttributes {
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+            result?: Data;            
+        }
+        export interface LambdaFunctionFailedEventAttributes {
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+            reason?: FailureReason;            
+            details?: Data;            
+        }
+        export interface LambdaFunctionScheduledEventAttributes {
+            id: FunctionId;            
+            name: FunctionName;            
+            input?: FunctionInput;            
+            startToCloseTimeout?: DurationInSecondsOptional;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface LambdaFunctionStartedEventAttributes {
+            scheduledEventId: EventId;            
+        }
+        export interface LambdaFunctionTimedOutEventAttributes {
+            scheduledEventId: EventId;            
+            startedEventId: EventId;            
+            timeoutType?: LambdaFunctionTimeoutType;            
+        }
+        export interface LimitExceededFault {
+            message?: ErrorMessage;            
+        }
+        export interface ListActivityTypesInput {
+            domain: DomainName;            
+            name?: Name;            
+            registrationStatus: RegistrationStatus;            
+            nextPageToken?: PageToken;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+        }
+        export interface ListClosedWorkflowExecutionsInput {
+            domain: DomainName;            
+            startTimeFilter?: ExecutionTimeFilter;            
+            closeTimeFilter?: ExecutionTimeFilter;            
+            executionFilter?: WorkflowExecutionFilter;            
+            closeStatusFilter?: CloseStatusFilter;            
+            typeFilter?: WorkflowTypeFilter;            
+            tagFilter?: TagFilter;            
+            nextPageToken?: PageToken;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+        }
+        export interface ListDomainsInput {
+            nextPageToken?: PageToken;            
+            registrationStatus: RegistrationStatus;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+        }
+        export interface ListOpenWorkflowExecutionsInput {
+            domain: DomainName;            
+            startTimeFilter: ExecutionTimeFilter;            
+            typeFilter?: WorkflowTypeFilter;            
+            tagFilter?: TagFilter;            
+            nextPageToken?: PageToken;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+            executionFilter?: WorkflowExecutionFilter;            
+        }
+        export interface ListWorkflowTypesInput {
+            domain: DomainName;            
+            name?: Name;            
+            registrationStatus: RegistrationStatus;            
+            nextPageToken?: PageToken;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+        }
+        export interface MarkerRecordedEventAttributes {
+            markerName: MarkerName;            
+            details?: Data;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface OperationNotPermittedFault {
+            message?: ErrorMessage;            
+        }
+        export interface PendingTaskCount {
+            count: Count;            
+            truncated?: Truncated;            
+        }
+        export interface PollForActivityTaskInput {
+            domain: DomainName;            
+            taskList: TaskList;            
+            identity?: Identity;            
+        }
+        export interface PollForDecisionTaskInput {
+            domain: DomainName;            
+            taskList: TaskList;            
+            identity?: Identity;            
+            nextPageToken?: PageToken;            
+            maximumPageSize?: PageSize;            
+            reverseOrder?: ReverseOrder;            
+        }
+        export interface RecordActivityTaskHeartbeatInput {
+            taskToken: TaskToken;            
+            details?: LimitedData;            
+        }
+        export interface RecordMarkerDecisionAttributes {
+            markerName: MarkerName;            
+            details?: Data;            
+        }
+        export interface RecordMarkerFailedEventAttributes {
+            markerName: MarkerName;            
+            cause: RecordMarkerFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface RegisterActivityTypeInput {
+            domain: DomainName;            
+            name: Name;            
+            version: Version;            
+            description?: Description;            
+            defaultTaskStartToCloseTimeout?: DurationInSecondsOptional;            
+            defaultTaskHeartbeatTimeout?: DurationInSecondsOptional;            
+            defaultTaskList?: TaskList;            
+            defaultTaskPriority?: TaskPriority;            
+            defaultTaskScheduleToStartTimeout?: DurationInSecondsOptional;            
+            defaultTaskScheduleToCloseTimeout?: DurationInSecondsOptional;            
+        }
+        export interface RegisterDomainInput {
+            name: DomainName;            
+            description?: Description;            
+            workflowExecutionRetentionPeriodInDays: DurationInDays;            
+        }
+        export interface RegisterWorkflowTypeInput {
+            domain: DomainName;            
+            name: Name;            
+            version: Version;            
+            description?: Description;            
+            defaultTaskStartToCloseTimeout?: DurationInSecondsOptional;            
+            defaultExecutionStartToCloseTimeout?: DurationInSecondsOptional;            
+            defaultTaskList?: TaskList;            
+            defaultTaskPriority?: TaskPriority;            
+            defaultChildPolicy?: ChildPolicy;            
+            defaultLambdaRole?: Arn;            
+        }
+        export interface RequestCancelActivityTaskDecisionAttributes {
+            activityId: ActivityId;            
+        }
+        export interface RequestCancelActivityTaskFailedEventAttributes {
+            activityId: ActivityId;            
+            cause: RequestCancelActivityTaskFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface RequestCancelExternalWorkflowExecutionDecisionAttributes {
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            control?: Data;            
+        }
+        export interface RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            cause: RequestCancelExternalWorkflowExecutionFailedCause;            
+            initiatedEventId: EventId;            
+            decisionTaskCompletedEventId: EventId;            
+            control?: Data;            
+        }
+        export interface RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            decisionTaskCompletedEventId: EventId;            
+            control?: Data;            
+        }
+        export interface RequestCancelWorkflowExecutionInput {
+            domain: DomainName;            
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+        }
+        export interface RespondActivityTaskCanceledInput {
+            taskToken: TaskToken;            
+            details?: Data;            
+        }
+        export interface RespondActivityTaskCompletedInput {
+            taskToken: TaskToken;            
+            result?: Data;            
+        }
+        export interface RespondActivityTaskFailedInput {
+            taskToken: TaskToken;            
+            reason?: FailureReason;            
+            details?: Data;            
+        }
+        export interface RespondDecisionTaskCompletedInput {
+            taskToken: TaskToken;            
+            decisions?: DecisionList;            
+            executionContext?: Data;            
+        }
+        export interface Run {
+            runId?: RunId;            
+        }
+        export interface ScheduleActivityTaskDecisionAttributes {
+            activityType: ActivityType;            
+            activityId: ActivityId;            
+            control?: Data;            
+            input?: Data;            
+            scheduleToCloseTimeout?: DurationInSecondsOptional;            
+            taskList?: TaskList;            
+            taskPriority?: TaskPriority;            
+            scheduleToStartTimeout?: DurationInSecondsOptional;            
+            startToCloseTimeout?: DurationInSecondsOptional;            
+            heartbeatTimeout?: DurationInSecondsOptional;            
+        }
+        export interface ScheduleActivityTaskFailedEventAttributes {
+            activityType: ActivityType;            
+            activityId: ActivityId;            
+            cause: ScheduleActivityTaskFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface ScheduleLambdaFunctionDecisionAttributes {
+            id: FunctionId;            
+            name: FunctionName;            
+            input?: FunctionInput;            
+            startToCloseTimeout?: DurationInSecondsOptional;            
+        }
+        export interface ScheduleLambdaFunctionFailedEventAttributes {
+            id: FunctionId;            
+            name: FunctionName;            
+            cause: ScheduleLambdaFunctionFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface SignalExternalWorkflowExecutionDecisionAttributes {
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            signalName: SignalName;            
+            input?: Data;            
+            control?: Data;            
+        }
+        export interface SignalExternalWorkflowExecutionFailedEventAttributes {
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            cause: SignalExternalWorkflowExecutionFailedCause;            
+            initiatedEventId: EventId;            
+            decisionTaskCompletedEventId: EventId;            
+            control?: Data;            
+        }
+        export interface SignalExternalWorkflowExecutionInitiatedEventAttributes {
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            signalName: SignalName;            
+            input?: Data;            
+            decisionTaskCompletedEventId: EventId;            
+            control?: Data;            
+        }
+        export interface SignalWorkflowExecutionInput {
+            domain: DomainName;            
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            signalName: SignalName;            
+            input?: Data;            
+        }
+        export interface StartChildWorkflowExecutionDecisionAttributes {
+            workflowType: WorkflowType;            
+            workflowId: WorkflowId;            
+            control?: Data;            
+            input?: Data;            
+            executionStartToCloseTimeout?: DurationInSecondsOptional;            
+            taskList?: TaskList;            
+            taskPriority?: TaskPriority;            
+            taskStartToCloseTimeout?: DurationInSecondsOptional;            
+            childPolicy?: ChildPolicy;            
+            tagList?: TagList;            
+            lambdaRole?: Arn;            
+        }
+        export interface StartChildWorkflowExecutionFailedEventAttributes {
+            workflowType: WorkflowType;            
+            cause: StartChildWorkflowExecutionFailedCause;            
+            workflowId: WorkflowId;            
+            initiatedEventId: EventId;            
+            decisionTaskCompletedEventId: EventId;            
+            control?: Data;            
+        }
+        export interface StartChildWorkflowExecutionInitiatedEventAttributes {
+            workflowId: WorkflowId;            
+            workflowType: WorkflowType;            
+            control?: Data;            
+            input?: Data;            
+            executionStartToCloseTimeout?: DurationInSecondsOptional;            
+            taskList: TaskList;            
+            taskPriority?: TaskPriority;            
+            decisionTaskCompletedEventId: EventId;            
+            childPolicy: ChildPolicy;            
+            taskStartToCloseTimeout?: DurationInSecondsOptional;            
+            tagList?: TagList;            
+            lambdaRole?: Arn;            
+        }
+        export interface StartLambdaFunctionFailedEventAttributes {
+            scheduledEventId?: EventId;            
+            cause?: StartLambdaFunctionFailedCause;            
+            message?: CauseMessage;            
+        }
+        export interface StartTimerDecisionAttributes {
+            timerId: TimerId;            
+            control?: Data;            
+            startToFireTimeout: DurationInSeconds;            
+        }
+        export interface StartTimerFailedEventAttributes {
+            timerId: TimerId;            
+            cause: StartTimerFailedCause;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface StartWorkflowExecutionInput {
+            domain: DomainName;            
+            workflowId: WorkflowId;            
+            workflowType: WorkflowType;            
+            taskList?: TaskList;            
+            taskPriority?: TaskPriority;            
+            input?: Data;            
+            executionStartToCloseTimeout?: DurationInSecondsOptional;            
+            tagList?: TagList;            
+            taskStartToCloseTimeout?: DurationInSecondsOptional;            
+            childPolicy?: ChildPolicy;            
+            lambdaRole?: Arn;            
+        }
+        export interface TagFilter {
+            tag: Tag;            
+        }
+        export interface TaskList {
+            name: Name;            
+        }
+        export interface TerminateWorkflowExecutionInput {
+            domain: DomainName;            
+            workflowId: WorkflowId;            
+            runId?: RunIdOptional;            
+            reason?: TerminateReason;            
+            details?: Data;            
+            childPolicy?: ChildPolicy;            
+        }
+        export interface TimerCanceledEventAttributes {
+            timerId: TimerId;            
+            startedEventId: EventId;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface TimerFiredEventAttributes {
+            timerId: TimerId;            
+            startedEventId: EventId;            
+        }
+        export interface TimerStartedEventAttributes {
+            timerId: TimerId;            
+            control?: Data;            
+            startToFireTimeout: DurationInSeconds;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface TypeAlreadyExistsFault {
+            message?: ErrorMessage;            
+        }
+        export interface TypeDeprecatedFault {
+            message?: ErrorMessage;            
+        }
+        export interface UnknownResourceFault {
+            message?: ErrorMessage;            
+        }
+        export interface WorkflowExecution {
+            workflowId: WorkflowId;            
+            runId: RunId;            
+        }
+        export interface WorkflowExecutionAlreadyStartedFault {
+            message?: ErrorMessage;            
+        }
+        export interface WorkflowExecutionCancelRequestedEventAttributes {
+            externalWorkflowExecution?: WorkflowExecution;            
+            externalInitiatedEventId?: EventId;            
+            cause?: WorkflowExecutionCancelRequestedCause;            
+        }
+        export interface WorkflowExecutionCanceledEventAttributes {
+            details?: Data;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface WorkflowExecutionCompletedEventAttributes {
+            result?: Data;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface WorkflowExecutionConfiguration {
+            taskStartToCloseTimeout: DurationInSeconds;            
+            executionStartToCloseTimeout: DurationInSeconds;            
+            taskList: TaskList;            
+            taskPriority?: TaskPriority;            
+            childPolicy: ChildPolicy;            
+            lambdaRole?: Arn;            
+        }
+        export interface WorkflowExecutionContinuedAsNewEventAttributes {
+            input?: Data;            
+            decisionTaskCompletedEventId: EventId;            
+            newExecutionRunId: RunId;            
+            executionStartToCloseTimeout?: DurationInSecondsOptional;            
+            taskList: TaskList;            
+            taskPriority?: TaskPriority;            
+            taskStartToCloseTimeout?: DurationInSecondsOptional;            
+            childPolicy: ChildPolicy;            
+            tagList?: TagList;            
+            workflowType: WorkflowType;            
+            lambdaRole?: Arn;            
+        }
+        export interface WorkflowExecutionCount {
+            count: Count;            
+            truncated?: Truncated;            
+        }
+        export interface WorkflowExecutionDetail {
+            executionInfo: WorkflowExecutionInfo;            
+            executionConfiguration: WorkflowExecutionConfiguration;            
+            openCounts: WorkflowExecutionOpenCounts;            
+            latestActivityTaskTimestamp?: Timestamp;            
+            latestExecutionContext?: Data;            
+        }
+        export interface WorkflowExecutionFailedEventAttributes {
+            reason?: FailureReason;            
+            details?: Data;            
+            decisionTaskCompletedEventId: EventId;            
+        }
+        export interface WorkflowExecutionFilter {
+            workflowId: WorkflowId;            
+        }
+        export interface WorkflowExecutionInfo {
+            execution: WorkflowExecution;            
+            workflowType: WorkflowType;            
+            startTimestamp: Timestamp;            
+            closeTimestamp?: Timestamp;            
+            executionStatus: ExecutionStatus;            
+            closeStatus?: CloseStatus;            
+            parent?: WorkflowExecution;            
+            tagList?: TagList;            
+            cancelRequested?: Canceled;            
+        }
+        export interface WorkflowExecutionInfos {
+            executionInfos: WorkflowExecutionInfoList;            
+            nextPageToken?: PageToken;            
+        }
+        export interface WorkflowExecutionOpenCounts {
+            openActivityTasks: Count;            
+            openDecisionTasks: OpenDecisionTasksCount;            
+            openTimers: Count;            
+            openChildWorkflowExecutions: Count;            
+            openLambdaFunctions?: Count;            
+        }
+        export interface WorkflowExecutionSignaledEventAttributes {
+            signalName: SignalName;            
+            input?: Data;            
+            externalWorkflowExecution?: WorkflowExecution;            
+            externalInitiatedEventId?: EventId;            
+        }
+        export interface WorkflowExecutionStartedEventAttributes {
+            input?: Data;            
+            executionStartToCloseTimeout?: DurationInSecondsOptional;            
+            taskStartToCloseTimeout?: DurationInSecondsOptional;            
+            childPolicy: ChildPolicy;            
+            taskList: TaskList;            
+            workflowType: WorkflowType;            
+            tagList?: TagList;            
+            taskPriority?: TaskPriority;            
+            continuedExecutionRunId?: RunIdOptional;            
+            parentWorkflowExecution?: WorkflowExecution;            
+            parentInitiatedEventId?: EventId;            
+            lambdaRole?: Arn;            
+        }
+        export interface WorkflowExecutionTerminatedEventAttributes {
+            reason?: TerminateReason;            
+            details?: Data;            
+            childPolicy: ChildPolicy;            
+            cause?: WorkflowExecutionTerminatedCause;            
+        }
+        export interface WorkflowExecutionTimedOutEventAttributes {
+            timeoutType: WorkflowExecutionTimeoutType;            
+            childPolicy: ChildPolicy;            
+        }
+        export interface WorkflowType {
+            name: Name;            
+            version: Version;            
+        }
+        export interface WorkflowTypeConfiguration {
+            defaultTaskStartToCloseTimeout?: DurationInSecondsOptional;            
+            defaultExecutionStartToCloseTimeout?: DurationInSecondsOptional;            
+            defaultTaskList?: TaskList;            
+            defaultTaskPriority?: TaskPriority;            
+            defaultChildPolicy?: ChildPolicy;            
+            defaultLambdaRole?: Arn;            
+        }
+        export interface WorkflowTypeDetail {
+            typeInfo: WorkflowTypeInfo;            
+            configuration: WorkflowTypeConfiguration;            
+        }
+        export interface WorkflowTypeFilter {
+            name: Name;            
+            version?: VersionOptional;            
+        }
+        export interface WorkflowTypeInfo {
+            workflowType: WorkflowType;            
+            status: RegistrationStatus;            
+            description?: Description;            
+            creationDate: Timestamp;            
+            deprecationDate?: Timestamp;            
+        }
+        export interface WorkflowTypeInfos {
+            typeInfos: WorkflowTypeInfoList;            
+            nextPageToken?: PageToken;            
+        }
 
-    export interface SWFStartTimerDecisionAttributes {
-        timerId: SWFTimerId;
-        control?: SWFData;
-        startToFireTimeout: SWFDurationInSeconds;
     }
-
-    export type SWFStartTimerFailedCause = string;
-    export interface SWFStartTimerFailedEventAttributes {
-        timerId: SWFTimerId;
-        cause: SWFStartTimerFailedCause;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFStartWorkflowExecutionInput {
-        domain: SWFDomainName;
-        workflowId: SWFWorkflowId;
-        workflowType: SWFWorkflowType;
-        taskList?: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        input?: SWFData;
-        executionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        tagList?: SWFTagList;
-        taskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        childPolicy?: SWFChildPolicy;
-        lambdaRole?: SWFArn;
-    }
-
-    export type SWFTag = string;
-    export interface SWFTagFilter {
-        tag: SWFTag;
-    }
-
-    export type SWFTagList = Array<SWFTag>; // max: 5
-    export interface SWFTaskList {
-        name: SWFName;
-    }
-
-    export type SWFTaskPriority = string;
-    export type SWFTaskToken = string;
-    export type SWFTerminateReason = string;
-    export interface SWFTerminateWorkflowExecutionInput {
-        domain: SWFDomainName;
-        workflowId: SWFWorkflowId;
-        runId?: SWFRunIdOptional;
-        reason?: SWFTerminateReason;
-        details?: SWFData;
-        childPolicy?: SWFChildPolicy;
-    }
-
-    export interface SWFTimerCanceledEventAttributes {
-        timerId: SWFTimerId;
-        startedEventId: SWFEventId;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFTimerFiredEventAttributes {
-        timerId: SWFTimerId;
-        startedEventId: SWFEventId;
-    }
-
-    export type SWFTimerId = string;
-    export interface SWFTimerStartedEventAttributes {
-        timerId: SWFTimerId;
-        control?: SWFData;
-        startToFireTimeout: SWFDurationInSeconds;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export type SWFTimestamp = number;
-    export type SWFTruncated = boolean;
-    export interface SWFTypeAlreadyExistsFault {
-        message?: SWFErrorMessage;
-    }
-
-    export interface SWFTypeDeprecatedFault {
-        message?: SWFErrorMessage;
-    }
-
-    export interface SWFUnknownResourceFault {
-        message?: SWFErrorMessage;
-    }
-
-    export type SWFVersion = string;
-    export type SWFVersionOptional = string;
-    export interface SWFWorkflowExecution {
-        workflowId: SWFWorkflowId;
-        runId: SWFRunId;
-    }
-
-    export interface SWFWorkflowExecutionAlreadyStartedFault {
-        message?: SWFErrorMessage;
-    }
-
-    export type SWFWorkflowExecutionCancelRequestedCause = string;
-    export interface SWFWorkflowExecutionCancelRequestedEventAttributes {
-        externalWorkflowExecution?: SWFWorkflowExecution;
-        externalInitiatedEventId?: SWFEventId;
-        cause?: SWFWorkflowExecutionCancelRequestedCause;
-    }
-
-    export interface SWFWorkflowExecutionCanceledEventAttributes {
-        details?: SWFData;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFWorkflowExecutionCompletedEventAttributes {
-        result?: SWFData;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFWorkflowExecutionConfiguration {
-        taskStartToCloseTimeout: SWFDurationInSeconds;
-        executionStartToCloseTimeout: SWFDurationInSeconds;
-        taskList: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        childPolicy: SWFChildPolicy;
-        lambdaRole?: SWFArn;
-    }
-
-    export interface SWFWorkflowExecutionContinuedAsNewEventAttributes {
-        input?: SWFData;
-        decisionTaskCompletedEventId: SWFEventId;
-        newExecutionRunId: SWFRunId;
-        executionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskList: SWFTaskList;
-        taskPriority?: SWFTaskPriority;
-        taskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        childPolicy: SWFChildPolicy;
-        tagList?: SWFTagList;
-        workflowType: SWFWorkflowType;
-        lambdaRole?: SWFArn;
-    }
-
-    export interface SWFWorkflowExecutionCount {
-        count: SWFCount;
-        truncated?: SWFTruncated;
-    }
-
-    export interface SWFWorkflowExecutionDetail {
-        executionInfo: SWFWorkflowExecutionInfo;
-        executionConfiguration: SWFWorkflowExecutionConfiguration;
-        openCounts: SWFWorkflowExecutionOpenCounts;
-        latestActivityTaskTimestamp?: SWFTimestamp;
-        latestExecutionContext?: SWFData;
-    }
-
-    export interface SWFWorkflowExecutionFailedEventAttributes {
-        reason?: SWFFailureReason;
-        details?: SWFData;
-        decisionTaskCompletedEventId: SWFEventId;
-    }
-
-    export interface SWFWorkflowExecutionFilter {
-        workflowId: SWFWorkflowId;
-    }
-
-    export interface SWFWorkflowExecutionInfo {
-        execution: SWFWorkflowExecution;
-        workflowType: SWFWorkflowType;
-        startTimestamp: SWFTimestamp;
-        closeTimestamp?: SWFTimestamp;
-        executionStatus: SWFExecutionStatus;
-        closeStatus?: SWFCloseStatus;
-        parent?: SWFWorkflowExecution;
-        tagList?: SWFTagList;
-        cancelRequested?: SWFCanceled;
-    }
-
-    export type SWFWorkflowExecutionInfoList = Array<SWFWorkflowExecutionInfo>;
-    export interface SWFWorkflowExecutionInfos {
-        executionInfos: SWFWorkflowExecutionInfoList;
-        nextPageToken?: SWFPageToken;
-    }
-
-    export interface SWFWorkflowExecutionOpenCounts {
-        openActivityTasks: SWFCount;
-        openDecisionTasks: SWFOpenDecisionTasksCount;
-        openTimers: SWFCount;
-        openChildWorkflowExecutions: SWFCount;
-        openLambdaFunctions?: SWFCount;
-    }
-
-    export interface SWFWorkflowExecutionSignaledEventAttributes {
-        signalName: SWFSignalName;
-        input?: SWFData;
-        externalWorkflowExecution?: SWFWorkflowExecution;
-        externalInitiatedEventId?: SWFEventId;
-    }
-
-    export interface SWFWorkflowExecutionStartedEventAttributes {
-        input?: SWFData;
-        executionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        taskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        childPolicy: SWFChildPolicy;
-        taskList: SWFTaskList;
-        workflowType: SWFWorkflowType;
-        tagList?: SWFTagList;
-        taskPriority?: SWFTaskPriority;
-        continuedExecutionRunId?: SWFRunIdOptional;
-        parentWorkflowExecution?: SWFWorkflowExecution;
-        parentInitiatedEventId?: SWFEventId;
-        lambdaRole?: SWFArn;
-    }
-
-    export type SWFWorkflowExecutionTerminatedCause = string;
-    export interface SWFWorkflowExecutionTerminatedEventAttributes {
-        reason?: SWFTerminateReason;
-        details?: SWFData;
-        childPolicy: SWFChildPolicy;
-        cause?: SWFWorkflowExecutionTerminatedCause;
-    }
-
-    export interface SWFWorkflowExecutionTimedOutEventAttributes {
-        timeoutType: SWFWorkflowExecutionTimeoutType;
-        childPolicy: SWFChildPolicy;
-    }
-
-    export type SWFWorkflowExecutionTimeoutType = string;
-    export type SWFWorkflowId = string;
-    export interface SWFWorkflowType {
-        name: SWFName;
-        version: SWFVersion;
-    }
-
-    export interface SWFWorkflowTypeConfiguration {
-        defaultTaskStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        defaultExecutionStartToCloseTimeout?: SWFDurationInSecondsOptional;
-        defaultTaskList?: SWFTaskList;
-        defaultTaskPriority?: SWFTaskPriority;
-        defaultChildPolicy?: SWFChildPolicy;
-        defaultLambdaRole?: SWFArn;
-    }
-
-    export interface SWFWorkflowTypeDetail {
-        typeInfo: SWFWorkflowTypeInfo;
-        configuration: SWFWorkflowTypeConfiguration;
-    }
-
-    export interface SWFWorkflowTypeFilter {
-        name: SWFName;
-        version?: SWFVersionOptional;
-    }
-
-    export interface SWFWorkflowTypeInfo {
-        workflowType: SWFWorkflowType;
-        status: SWFRegistrationStatus;
-        description?: SWFDescription;
-        creationDate: SWFTimestamp;
-        deprecationDate?: SWFTimestamp;
-    }
-
-    export type SWFWorkflowTypeInfoList = Array<SWFWorkflowTypeInfo>;
-    export interface SWFWorkflowTypeInfos {
-        typeInfos: SWFWorkflowTypeInfoList;
-        nextPageToken?: SWFPageToken;
-    }
-
 }

--- a/output/aws-waf.d.ts
+++ b/output/aws-waf.d.ts
@@ -6,544 +6,455 @@ declare module "aws-sdk" {
 
     export class WAF extends Service {
       constructor(options?: any);
-      createByteMatchSet(params: WAFCreateByteMatchSetRequest, callback?: (err: WAFWAFDisallowedNameException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidParameterException|WAFWAFStaleDataException|WAFWAFLimitsExceededException|any, data: WAFCreateByteMatchSetResponse|any) => void): Request;
-      createIPSet(params: WAFCreateIPSetRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFDisallowedNameException|WAFWAFInvalidParameterException|WAFWAFLimitsExceededException|any, data: WAFCreateIPSetResponse|any) => void): Request;
-      createRule(params: WAFCreateRuleRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFDisallowedNameException|WAFWAFInvalidParameterException|WAFWAFLimitsExceededException|any, data: WAFCreateRuleResponse|any) => void): Request;
-      createSqlInjectionMatchSet(params: WAFCreateSqlInjectionMatchSetRequest, callback?: (err: WAFWAFDisallowedNameException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidParameterException|WAFWAFStaleDataException|WAFWAFLimitsExceededException|any, data: WAFCreateSqlInjectionMatchSetResponse|any) => void): Request;
-      createWebACL(params: WAFCreateWebACLRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFDisallowedNameException|WAFWAFInvalidParameterException|WAFWAFLimitsExceededException|any, data: WAFCreateWebACLResponse|any) => void): Request;
-      deleteByteMatchSet(params: WAFDeleteByteMatchSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFStaleDataException|WAFWAFNonEmptyEntityException|any, data: WAFDeleteByteMatchSetResponse|any) => void): Request;
-      deleteIPSet(params: WAFDeleteIPSetRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFNonEmptyEntityException|any, data: WAFDeleteIPSetResponse|any) => void): Request;
-      deleteRule(params: WAFDeleteRuleRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFNonEmptyEntityException|any, data: WAFDeleteRuleResponse|any) => void): Request;
-      deleteSqlInjectionMatchSet(params: WAFDeleteSqlInjectionMatchSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFStaleDataException|WAFWAFNonEmptyEntityException|any, data: WAFDeleteSqlInjectionMatchSetResponse|any) => void): Request;
-      deleteWebACL(params: WAFDeleteWebACLRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFNonEmptyEntityException|any, data: WAFDeleteWebACLResponse|any) => void): Request;
-      getByteMatchSet(params: WAFGetByteMatchSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|any, data: WAFGetByteMatchSetResponse|any) => void): Request;
-      getChangeToken(params: WAFGetChangeTokenRequest, callback?: (err: WAFWAFInternalErrorException|any, data: WAFGetChangeTokenResponse|any) => void): Request;
-      getChangeTokenStatus(params: WAFGetChangeTokenStatusRequest, callback?: (err: WAFWAFNonexistentItemException|WAFWAFInternalErrorException|any, data: WAFGetChangeTokenStatusResponse|any) => void): Request;
-      getIPSet(params: WAFGetIPSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|any, data: WAFGetIPSetResponse|any) => void): Request;
-      getRule(params: WAFGetRuleRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|any, data: WAFGetRuleResponse|any) => void): Request;
-      getSampledRequests(params: WAFGetSampledRequestsRequest, callback?: (err: WAFWAFNonexistentItemException|any, data: WAFGetSampledRequestsResponse|any) => void): Request;
-      getSqlInjectionMatchSet(params: WAFGetSqlInjectionMatchSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|any, data: WAFGetSqlInjectionMatchSetResponse|any) => void): Request;
-      getWebACL(params: WAFGetWebACLRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFNonexistentItemException|any, data: WAFGetWebACLResponse|any) => void): Request;
-      listByteMatchSets(params: WAFListByteMatchSetsRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|any, data: WAFListByteMatchSetsResponse|any) => void): Request;
-      listIPSets(params: WAFListIPSetsRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|any, data: WAFListIPSetsResponse|any) => void): Request;
-      listRules(params: WAFListRulesRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|any, data: WAFListRulesResponse|any) => void): Request;
-      listSqlInjectionMatchSets(params: WAFListSqlInjectionMatchSetsRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|any, data: WAFListSqlInjectionMatchSetsResponse|any) => void): Request;
-      listWebACLs(params: WAFListWebACLsRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|any, data: WAFListWebACLsResponse|any) => void): Request;
-      updateByteMatchSet(params: WAFUpdateByteMatchSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidOperationException|WAFWAFInvalidParameterException|WAFWAFNonexistentContainerException|WAFWAFNonexistentItemException|WAFWAFStaleDataException|WAFWAFLimitsExceededException|any, data: WAFUpdateByteMatchSetResponse|any) => void): Request;
-      updateIPSet(params: WAFUpdateIPSetRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidOperationException|WAFWAFInvalidParameterException|WAFWAFNonexistentContainerException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFLimitsExceededException|any, data: WAFUpdateIPSetResponse|any) => void): Request;
-      updateRule(params: WAFUpdateRuleRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidOperationException|WAFWAFInvalidParameterException|WAFWAFNonexistentContainerException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFLimitsExceededException|any, data: WAFUpdateRuleResponse|any) => void): Request;
-      updateSqlInjectionMatchSet(params: WAFUpdateSqlInjectionMatchSetRequest, callback?: (err: WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidOperationException|WAFWAFInvalidParameterException|WAFWAFNonexistentContainerException|WAFWAFNonexistentItemException|WAFWAFStaleDataException|WAFWAFLimitsExceededException|any, data: WAFUpdateSqlInjectionMatchSetResponse|any) => void): Request;
-      updateWebACL(params: WAFUpdateWebACLRequest, callback?: (err: WAFWAFStaleDataException|WAFWAFInternalErrorException|WAFWAFInvalidAccountException|WAFWAFInvalidOperationException|WAFWAFInvalidParameterException|WAFWAFNonexistentContainerException|WAFWAFNonexistentItemException|WAFWAFReferencedItemException|WAFWAFLimitsExceededException|any, data: WAFUpdateWebACLResponse|any) => void): Request;
-    }
-
-    export type WAFAction = string;
-    export interface WAFActivatedRule {
-        Priority: WAFRulePriority;
-        RuleId: WAFResourceId;
-        Action: WAFWafAction;
-    }
-
-    export type WAFActivatedRules = Array<WAFActivatedRule>;
-    export interface WAFByteMatchSet {
-        ByteMatchSetId: WAFResourceId;
-        Name?: WAFResourceName;
-        ByteMatchTuples: WAFByteMatchTuples;
-    }
-
-    export type WAFByteMatchSetSummaries = Array<WAFByteMatchSetSummary>;
-    export interface WAFByteMatchSetSummary {
-        ByteMatchSetId: WAFResourceId;
-        Name: WAFResourceName;
-    }
-
-    export interface WAFByteMatchSetUpdate {
-        Action: WAFChangeAction;
-        ByteMatchTuple: WAFByteMatchTuple;
-    }
-
-    export type WAFByteMatchSetUpdates = Array<WAFByteMatchSetUpdate>;
-    export type WAFByteMatchTargetString = any; // not really - it was 'blob' instead - must fix this one
-    export interface WAFByteMatchTuple {
-        FieldToMatch: WAFFieldToMatch;
-        TargetString: WAFByteMatchTargetString;
-        TextTransformation: WAFTextTransformation;
-        PositionalConstraint: WAFPositionalConstraint;
-    }
-
-    export type WAFByteMatchTuples = Array<WAFByteMatchTuple>;
-    export type WAFChangeAction = string;
-    export type WAFChangeToken = string;
-    export type WAFChangeTokenStatus = string;
-    export type WAFCountry = string;
-    export interface WAFCreateByteMatchSetRequest {
-        Name: WAFResourceName;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFCreateByteMatchSetResponse {
-        ByteMatchSet?: WAFByteMatchSet;
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFCreateIPSetRequest {
-        Name: WAFResourceName;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFCreateIPSetResponse {
-        IPSet?: WAFIPSet;
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFCreateRuleRequest {
-        Name: WAFResourceName;
-        MetricName: WAFMetricName;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFCreateRuleResponse {
-        Rule?: WAFRule;
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFCreateSqlInjectionMatchSetRequest {
-        Name: WAFResourceName;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFCreateSqlInjectionMatchSetResponse {
-        SqlInjectionMatchSet?: WAFSqlInjectionMatchSet;
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFCreateWebACLRequest {
-        Name: WAFResourceName;
-        MetricName: WAFMetricName;
-        DefaultAction: WAFWafAction;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFCreateWebACLResponse {
-        WebACL?: WAFWebACL;
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFDeleteByteMatchSetRequest {
-        ByteMatchSetId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFDeleteByteMatchSetResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFDeleteIPSetRequest {
-        IPSetId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFDeleteIPSetResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFDeleteRuleRequest {
-        RuleId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFDeleteRuleResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFDeleteSqlInjectionMatchSetRequest {
-        SqlInjectionMatchSetId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFDeleteSqlInjectionMatchSetResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFDeleteWebACLRequest {
-        WebACLId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFDeleteWebACLResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFFieldToMatch {
-        Type: WAFMatchFieldType;
-        Data?: WAFMatchFieldData;
-    }
-
-    export interface WAFGetByteMatchSetRequest {
-        ByteMatchSetId: WAFResourceId;
-    }
-
-    export interface WAFGetByteMatchSetResponse {
-        ByteMatchSet?: WAFByteMatchSet;
-    }
-
-    export interface WAFGetChangeTokenRequest {
-    }
-
-    export interface WAFGetChangeTokenResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFGetChangeTokenStatusRequest {
-        ChangeToken: WAFChangeToken;
-    }
-
-    export interface WAFGetChangeTokenStatusResponse {
-        ChangeTokenStatus?: WAFChangeTokenStatus;
-    }
-
-    export interface WAFGetIPSetRequest {
-        IPSetId: WAFResourceId;
-    }
-
-    export interface WAFGetIPSetResponse {
-        IPSet?: WAFIPSet;
-    }
-
-    export interface WAFGetRuleRequest {
-        RuleId: WAFResourceId;
-    }
-
-    export interface WAFGetRuleResponse {
-        Rule?: WAFRule;
-    }
-
-    export interface WAFGetSampledRequestsRequest {
-        WebAclId: WAFResourceId;
-        RuleId: WAFResourceId;
-        TimeWindow: WAFTimeWindow;
-        MaxItems: WAFListMaxItems;
-    }
-
-    export interface WAFGetSampledRequestsResponse {
-        SampledRequests?: WAFSampledHTTPRequests;
-        PopulationSize?: WAFPopulationSize;
-        TimeWindow?: WAFTimeWindow;
-    }
-
-    export interface WAFGetSqlInjectionMatchSetRequest {
-        SqlInjectionMatchSetId: WAFResourceId;
-    }
-
-    export interface WAFGetSqlInjectionMatchSetResponse {
-        SqlInjectionMatchSet?: WAFSqlInjectionMatchSet;
-    }
-
-    export interface WAFGetWebACLRequest {
-        WebACLId: WAFResourceId;
-    }
-
-    export interface WAFGetWebACLResponse {
-        WebACL?: WAFWebACL;
-    }
-
-    export interface WAFHTTPHeader {
-        Name?: WAFHeaderName;
-        Value?: WAFHeaderValue;
-    }
-
-    export type WAFHTTPHeaders = Array<WAFHTTPHeader>;
-    export type WAFHTTPMethod = string;
-    export interface WAFHTTPRequest {
-        ClientIP?: WAFIPString;
-        Country?: WAFCountry;
-        URI?: WAFURIString;
-        Method?: WAFHTTPMethod;
-        HTTPVersion?: WAFHTTPVersion;
-        Headers?: WAFHTTPHeaders;
-    }
-
-    export type WAFHTTPVersion = string;
-    export type WAFHeaderName = string;
-    export type WAFHeaderValue = string;
-    export interface WAFIPSet {
-        IPSetId: WAFResourceId;
-        Name?: WAFResourceName;
-        IPSetDescriptors: WAFIPSetDescriptors;
-    }
-
-    export interface WAFIPSetDescriptor {
-        Type: WAFIPSetDescriptorType;
-        Value: WAFIPSetDescriptorValue;
-    }
+      createByteMatchSet(params: WAF.CreateByteMatchSetRequest, callback?: (err: WAF.WAFDisallowedNameException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidParameterException|WAF.WAFStaleDataException|WAF.WAFLimitsExceededException|any, data: WAF.CreateByteMatchSetResponse|any) => void): Request;
+      createIPSet(params: WAF.CreateIPSetRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFDisallowedNameException|WAF.WAFInvalidParameterException|WAF.WAFLimitsExceededException|any, data: WAF.CreateIPSetResponse|any) => void): Request;
+      createRule(params: WAF.CreateRuleRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFDisallowedNameException|WAF.WAFInvalidParameterException|WAF.WAFLimitsExceededException|any, data: WAF.CreateRuleResponse|any) => void): Request;
+      createSqlInjectionMatchSet(params: WAF.CreateSqlInjectionMatchSetRequest, callback?: (err: WAF.WAFDisallowedNameException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidParameterException|WAF.WAFStaleDataException|WAF.WAFLimitsExceededException|any, data: WAF.CreateSqlInjectionMatchSetResponse|any) => void): Request;
+      createWebACL(params: WAF.CreateWebACLRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFDisallowedNameException|WAF.WAFInvalidParameterException|WAF.WAFLimitsExceededException|any, data: WAF.CreateWebACLResponse|any) => void): Request;
+      deleteByteMatchSet(params: WAF.DeleteByteMatchSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFStaleDataException|WAF.WAFNonEmptyEntityException|any, data: WAF.DeleteByteMatchSetResponse|any) => void): Request;
+      deleteIPSet(params: WAF.DeleteIPSetRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFNonEmptyEntityException|any, data: WAF.DeleteIPSetResponse|any) => void): Request;
+      deleteRule(params: WAF.DeleteRuleRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFNonEmptyEntityException|any, data: WAF.DeleteRuleResponse|any) => void): Request;
+      deleteSqlInjectionMatchSet(params: WAF.DeleteSqlInjectionMatchSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFStaleDataException|WAF.WAFNonEmptyEntityException|any, data: WAF.DeleteSqlInjectionMatchSetResponse|any) => void): Request;
+      deleteWebACL(params: WAF.DeleteWebACLRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFNonEmptyEntityException|any, data: WAF.DeleteWebACLResponse|any) => void): Request;
+      getByteMatchSet(params: WAF.GetByteMatchSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|any, data: WAF.GetByteMatchSetResponse|any) => void): Request;
+      getChangeToken(params: WAF.GetChangeTokenRequest, callback?: (err: WAF.WAFInternalErrorException|any, data: WAF.GetChangeTokenResponse|any) => void): Request;
+      getChangeTokenStatus(params: WAF.GetChangeTokenStatusRequest, callback?: (err: WAF.WAFNonexistentItemException|WAF.WAFInternalErrorException|any, data: WAF.GetChangeTokenStatusResponse|any) => void): Request;
+      getIPSet(params: WAF.GetIPSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|any, data: WAF.GetIPSetResponse|any) => void): Request;
+      getRule(params: WAF.GetRuleRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|any, data: WAF.GetRuleResponse|any) => void): Request;
+      getSampledRequests(params: WAF.GetSampledRequestsRequest, callback?: (err: WAF.WAFNonexistentItemException|any, data: WAF.GetSampledRequestsResponse|any) => void): Request;
+      getSqlInjectionMatchSet(params: WAF.GetSqlInjectionMatchSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|any, data: WAF.GetSqlInjectionMatchSetResponse|any) => void): Request;
+      getWebACL(params: WAF.GetWebACLRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFNonexistentItemException|any, data: WAF.GetWebACLResponse|any) => void): Request;
+      listByteMatchSets(params: WAF.ListByteMatchSetsRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|any, data: WAF.ListByteMatchSetsResponse|any) => void): Request;
+      listIPSets(params: WAF.ListIPSetsRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|any, data: WAF.ListIPSetsResponse|any) => void): Request;
+      listRules(params: WAF.ListRulesRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|any, data: WAF.ListRulesResponse|any) => void): Request;
+      listSqlInjectionMatchSets(params: WAF.ListSqlInjectionMatchSetsRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|any, data: WAF.ListSqlInjectionMatchSetsResponse|any) => void): Request;
+      listWebACLs(params: WAF.ListWebACLsRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|any, data: WAF.ListWebACLsResponse|any) => void): Request;
+      updateByteMatchSet(params: WAF.UpdateByteMatchSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidOperationException|WAF.WAFInvalidParameterException|WAF.WAFNonexistentContainerException|WAF.WAFNonexistentItemException|WAF.WAFStaleDataException|WAF.WAFLimitsExceededException|any, data: WAF.UpdateByteMatchSetResponse|any) => void): Request;
+      updateIPSet(params: WAF.UpdateIPSetRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidOperationException|WAF.WAFInvalidParameterException|WAF.WAFNonexistentContainerException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFLimitsExceededException|any, data: WAF.UpdateIPSetResponse|any) => void): Request;
+      updateRule(params: WAF.UpdateRuleRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidOperationException|WAF.WAFInvalidParameterException|WAF.WAFNonexistentContainerException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFLimitsExceededException|any, data: WAF.UpdateRuleResponse|any) => void): Request;
+      updateSqlInjectionMatchSet(params: WAF.UpdateSqlInjectionMatchSetRequest, callback?: (err: WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidOperationException|WAF.WAFInvalidParameterException|WAF.WAFNonexistentContainerException|WAF.WAFNonexistentItemException|WAF.WAFStaleDataException|WAF.WAFLimitsExceededException|any, data: WAF.UpdateSqlInjectionMatchSetResponse|any) => void): Request;
+      updateWebACL(params: WAF.UpdateWebACLRequest, callback?: (err: WAF.WAFStaleDataException|WAF.WAFInternalErrorException|WAF.WAFInvalidAccountException|WAF.WAFInvalidOperationException|WAF.WAFInvalidParameterException|WAF.WAFNonexistentContainerException|WAF.WAFNonexistentItemException|WAF.WAFReferencedItemException|WAF.WAFLimitsExceededException|any, data: WAF.UpdateWebACLResponse|any) => void): Request;
+    }
+    
+    export module WAF {
+        export type Action = string;
+        export type ActivatedRules = ActivatedRule[];
+        export type ByteMatchSetSummaries = ByteMatchSetSummary[];
+        export type ByteMatchSetUpdates = ByteMatchSetUpdate[];
+        export type ByteMatchTargetString = any;    // type: blob
+        export type ByteMatchTuples = ByteMatchTuple[];
+        export type ChangeAction = string;
+        export type ChangeToken = string;
+        export type ChangeTokenStatus = string;
+        export type Country = string;
+        export type HTTPHeaders = HTTPHeader[];
+        export type HTTPMethod = string;
+        export type HTTPVersion = string;
+        export type HeaderName = string;
+        export type HeaderValue = string;
+        export type IPSetDescriptorType = string;
+        export type IPSetDescriptorValue = string;
+        export type IPSetDescriptors = IPSetDescriptor[];
+        export type IPSetSummaries = IPSetSummary[];
+        export type IPSetUpdates = IPSetUpdate[];
+        export type IPString = string;
+        export type ListMaxItems = number;    // max: 100, min: 1
+        export type MatchFieldData = string;
+        export type MatchFieldType = string;
+        export type MetricName = string;
+        export type Negated = boolean;
+        export type NextMarker = string;    // min: 1
+        export type PaginationLimit = number;    // max: 100, min: 1
+        export type ParameterExceptionField = string;
+        export type ParameterExceptionParameter = string;    // min: 1
+        export type PopulationSize = number;
+        export type PositionalConstraint = string;
+        export type PredicateDataId = string;
+        export type PredicateType = string;
+        export type Predicates = Predicate[];
+        export type ResourceId = string;    // max: 128, min: 1
+        export type ResourceName = string;    // max: 128, min: 1
+        export type RulePriority = number;
+        export type RuleSummaries = RuleSummary[];
+        export type RuleUpdates = RuleUpdate[];
+        export type SampleWeight = number;
+        export type SampledHTTPRequests = SampledHTTPRequest[];
+        export type SqlInjectionMatchSetSummaries = SqlInjectionMatchSetSummary[];
+        export type SqlInjectionMatchSetUpdates = SqlInjectionMatchSetUpdate[];
+        export type SqlInjectionMatchTuples = SqlInjectionMatchTuple[];
+        export type TextTransformation = string;
+        export type Timestamp = number;
+        export type URIString = string;
+        export type WafActionType = string;
+        export type WebACLSummaries = WebACLSummary[];
+        export type WebACLUpdates = WebACLUpdate[];
+        export type errorMessage = string;
+
+        export interface ActivatedRule {
+            Priority: RulePriority;            
+            RuleId: ResourceId;            
+            Action: WafAction;            
+        }
+        export interface ByteMatchSet {
+            ByteMatchSetId: ResourceId;            
+            Name?: ResourceName;            
+            ByteMatchTuples: ByteMatchTuples;            
+        }
+        export interface ByteMatchSetSummary {
+            ByteMatchSetId: ResourceId;            
+            Name: ResourceName;            
+        }
+        export interface ByteMatchSetUpdate {
+            Action: ChangeAction;            
+            ByteMatchTuple: ByteMatchTuple;            
+        }
+        export interface ByteMatchTuple {
+            FieldToMatch: FieldToMatch;            
+            TargetString: ByteMatchTargetString;            
+            TextTransformation: TextTransformation;            
+            PositionalConstraint: PositionalConstraint;            
+        }
+        export interface CreateByteMatchSetRequest {
+            Name: ResourceName;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface CreateByteMatchSetResponse {
+            ByteMatchSet?: ByteMatchSet;            
+            ChangeToken?: ChangeToken;            
+        }
+        export interface CreateIPSetRequest {
+            Name: ResourceName;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface CreateIPSetResponse {
+            IPSet?: IPSet;            
+            ChangeToken?: ChangeToken;            
+        }
+        export interface CreateRuleRequest {
+            Name: ResourceName;            
+            MetricName: MetricName;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface CreateRuleResponse {
+            Rule?: Rule;            
+            ChangeToken?: ChangeToken;            
+        }
+        export interface CreateSqlInjectionMatchSetRequest {
+            Name: ResourceName;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface CreateSqlInjectionMatchSetResponse {
+            SqlInjectionMatchSet?: SqlInjectionMatchSet;            
+            ChangeToken?: ChangeToken;            
+        }
+        export interface CreateWebACLRequest {
+            Name: ResourceName;            
+            MetricName: MetricName;            
+            DefaultAction: WafAction;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface CreateWebACLResponse {
+            WebACL?: WebACL;            
+            ChangeToken?: ChangeToken;            
+        }
+        export interface DeleteByteMatchSetRequest {
+            ByteMatchSetId: ResourceId;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface DeleteByteMatchSetResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface DeleteIPSetRequest {
+            IPSetId: ResourceId;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface DeleteIPSetResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface DeleteRuleRequest {
+            RuleId: ResourceId;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface DeleteRuleResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface DeleteSqlInjectionMatchSetRequest {
+            SqlInjectionMatchSetId: ResourceId;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface DeleteSqlInjectionMatchSetResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface DeleteWebACLRequest {
+            WebACLId: ResourceId;            
+            ChangeToken: ChangeToken;            
+        }
+        export interface DeleteWebACLResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface FieldToMatch {
+            Type: MatchFieldType;            
+            Data?: MatchFieldData;            
+        }
+        export interface GetByteMatchSetRequest {
+            ByteMatchSetId: ResourceId;            
+        }
+        export interface GetByteMatchSetResponse {
+            ByteMatchSet?: ByteMatchSet;            
+        }
+        export interface GetChangeTokenRequest {
+        }
+        export interface GetChangeTokenResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface GetChangeTokenStatusRequest {
+            ChangeToken: ChangeToken;            
+        }
+        export interface GetChangeTokenStatusResponse {
+            ChangeTokenStatus?: ChangeTokenStatus;            
+        }
+        export interface GetIPSetRequest {
+            IPSetId: ResourceId;            
+        }
+        export interface GetIPSetResponse {
+            IPSet?: IPSet;            
+        }
+        export interface GetRuleRequest {
+            RuleId: ResourceId;            
+        }
+        export interface GetRuleResponse {
+            Rule?: Rule;            
+        }
+        export interface GetSampledRequestsRequest {
+            WebAclId: ResourceId;            
+            RuleId: ResourceId;            
+            TimeWindow: TimeWindow;            
+            MaxItems: ListMaxItems;            
+        }
+        export interface GetSampledRequestsResponse {
+            SampledRequests?: SampledHTTPRequests;            
+            PopulationSize?: PopulationSize;            
+            TimeWindow?: TimeWindow;            
+        }
+        export interface GetSqlInjectionMatchSetRequest {
+            SqlInjectionMatchSetId: ResourceId;            
+        }
+        export interface GetSqlInjectionMatchSetResponse {
+            SqlInjectionMatchSet?: SqlInjectionMatchSet;            
+        }
+        export interface GetWebACLRequest {
+            WebACLId: ResourceId;            
+        }
+        export interface GetWebACLResponse {
+            WebACL?: WebACL;            
+        }
+        export interface HTTPHeader {
+            Name?: HeaderName;            
+            Value?: HeaderValue;            
+        }
+        export interface HTTPRequest {
+            ClientIP?: IPString;            
+            Country?: Country;            
+            URI?: URIString;            
+            Method?: HTTPMethod;            
+            HTTPVersion?: HTTPVersion;            
+            Headers?: HTTPHeaders;            
+        }
+        export interface IPSet {
+            IPSetId: ResourceId;            
+            Name?: ResourceName;            
+            IPSetDescriptors: IPSetDescriptors;            
+        }
+        export interface IPSetDescriptor {
+            Type: IPSetDescriptorType;            
+            Value: IPSetDescriptorValue;            
+        }
+        export interface IPSetSummary {
+            IPSetId: ResourceId;            
+            Name: ResourceName;            
+        }
+        export interface IPSetUpdate {
+            Action: ChangeAction;            
+            IPSetDescriptor: IPSetDescriptor;            
+        }
+        export interface ListByteMatchSetsRequest {
+            NextMarker?: NextMarker;            
+            Limit: PaginationLimit;            
+        }
+        export interface ListByteMatchSetsResponse {
+            NextMarker?: NextMarker;            
+            ByteMatchSets?: ByteMatchSetSummaries;            
+        }
+        export interface ListIPSetsRequest {
+            NextMarker?: NextMarker;            
+            Limit: PaginationLimit;            
+        }
+        export interface ListIPSetsResponse {
+            NextMarker?: NextMarker;            
+            IPSets?: IPSetSummaries;            
+        }
+        export interface ListRulesRequest {
+            NextMarker?: NextMarker;            
+            Limit: PaginationLimit;            
+        }
+        export interface ListRulesResponse {
+            NextMarker?: NextMarker;            
+            Rules?: RuleSummaries;            
+        }
+        export interface ListSqlInjectionMatchSetsRequest {
+            NextMarker?: NextMarker;            
+            Limit: PaginationLimit;            
+        }
+        export interface ListSqlInjectionMatchSetsResponse {
+            NextMarker?: NextMarker;            
+            SqlInjectionMatchSets?: SqlInjectionMatchSetSummaries;            
+        }
+        export interface ListWebACLsRequest {
+            NextMarker?: NextMarker;            
+            Limit: PaginationLimit;            
+        }
+        export interface ListWebACLsResponse {
+            NextMarker?: NextMarker;            
+            WebACLs?: WebACLSummaries;            
+        }
+        export interface Predicate {
+            Negated: Negated;            
+            Type: PredicateType;            
+            DataId: PredicateDataId;            
+        }
+        export interface Rule {
+            RuleId: ResourceId;            
+            Name?: ResourceName;            
+            MetricName?: MetricName;            
+            Predicates: Predicates;            
+        }
+        export interface RuleSummary {
+            RuleId: ResourceId;            
+            Name: ResourceName;            
+        }
+        export interface RuleUpdate {
+            Action: ChangeAction;            
+            Predicate: Predicate;            
+        }
+        export interface SampledHTTPRequest {
+            Request: HTTPRequest;            
+            Weight: SampleWeight;            
+            Timestamp?: Timestamp;            
+            Action?: Action;            
+        }
+        export interface SqlInjectionMatchSet {
+            SqlInjectionMatchSetId: ResourceId;            
+            Name?: ResourceName;            
+            SqlInjectionMatchTuples: SqlInjectionMatchTuples;            
+        }
+        export interface SqlInjectionMatchSetSummary {
+            SqlInjectionMatchSetId: ResourceId;            
+            Name: ResourceName;            
+        }
+        export interface SqlInjectionMatchSetUpdate {
+            Action: ChangeAction;            
+            SqlInjectionMatchTuple: SqlInjectionMatchTuple;            
+        }
+        export interface SqlInjectionMatchTuple {
+            FieldToMatch: FieldToMatch;            
+            TextTransformation: TextTransformation;            
+        }
+        export interface TimeWindow {
+            StartTime: Timestamp;            
+            EndTime: Timestamp;            
+        }
+        export interface UpdateByteMatchSetRequest {
+            ByteMatchSetId: ResourceId;            
+            ChangeToken: ChangeToken;            
+            Updates: ByteMatchSetUpdates;            
+        }
+        export interface UpdateByteMatchSetResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface UpdateIPSetRequest {
+            IPSetId: ResourceId;            
+            ChangeToken: ChangeToken;            
+            Updates: IPSetUpdates;            
+        }
+        export interface UpdateIPSetResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface UpdateRuleRequest {
+            RuleId: ResourceId;            
+            ChangeToken: ChangeToken;            
+            Updates: RuleUpdates;            
+        }
+        export interface UpdateRuleResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface UpdateSqlInjectionMatchSetRequest {
+            SqlInjectionMatchSetId: ResourceId;            
+            ChangeToken: ChangeToken;            
+            Updates: SqlInjectionMatchSetUpdates;            
+        }
+        export interface UpdateSqlInjectionMatchSetResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface UpdateWebACLRequest {
+            WebACLId: ResourceId;            
+            ChangeToken: ChangeToken;            
+            Updates?: WebACLUpdates;            
+            DefaultAction?: WafAction;            
+        }
+        export interface UpdateWebACLResponse {
+            ChangeToken?: ChangeToken;            
+        }
+        export interface WAFDisallowedNameException {
+            message?: errorMessage;            
+        }
+        export interface WAFInternalErrorException {
+            message?: errorMessage;            
+        }
+        export interface WAFInvalidAccountException {
+        }
+        export interface WAFInvalidOperationException {
+            message?: errorMessage;            
+        }
+        export interface WAFInvalidParameterException {
+            field?: ParameterExceptionField;            
+            parameter?: ParameterExceptionParameter;            
+        }
+        export interface WAFLimitsExceededException {
+            message?: errorMessage;            
+        }
+        export interface WAFNonEmptyEntityException {
+            message?: errorMessage;            
+        }
+        export interface WAFNonexistentContainerException {
+            message?: errorMessage;            
+        }
+        export interface WAFNonexistentItemException {
+            message?: errorMessage;            
+        }
+        export interface WAFReferencedItemException {
+            message?: errorMessage;            
+        }
+        export interface WAFStaleDataException {
+            message?: errorMessage;            
+        }
+        export interface WafAction {
+            Type: WafActionType;            
+        }
+        export interface WebACL {
+            WebACLId: ResourceId;            
+            Name?: ResourceName;            
+            MetricName?: MetricName;            
+            DefaultAction: WafAction;            
+            Rules: ActivatedRules;            
+        }
+        export interface WebACLSummary {
+            WebACLId: ResourceId;            
+            Name: ResourceName;            
+        }
+        export interface WebACLUpdate {
+            Action: ChangeAction;            
+            ActivatedRule: ActivatedRule;            
+        }
 
-    export type WAFIPSetDescriptorType = string;
-    export type WAFIPSetDescriptorValue = string;
-    export type WAFIPSetDescriptors = Array<WAFIPSetDescriptor>;
-    export type WAFIPSetSummaries = Array<WAFIPSetSummary>;
-    export interface WAFIPSetSummary {
-        IPSetId: WAFResourceId;
-        Name: WAFResourceName;
     }
-
-    export interface WAFIPSetUpdate {
-        Action: WAFChangeAction;
-        IPSetDescriptor: WAFIPSetDescriptor;
-    }
-
-    export type WAFIPSetUpdates = Array<WAFIPSetUpdate>;
-    export type WAFIPString = string;
-    export interface WAFListByteMatchSetsRequest {
-        NextMarker?: WAFNextMarker;
-        Limit: WAFPaginationLimit;
-    }
-
-    export interface WAFListByteMatchSetsResponse {
-        NextMarker?: WAFNextMarker;
-        ByteMatchSets?: WAFByteMatchSetSummaries;
-    }
-
-    export interface WAFListIPSetsRequest {
-        NextMarker?: WAFNextMarker;
-        Limit: WAFPaginationLimit;
-    }
-
-    export interface WAFListIPSetsResponse {
-        NextMarker?: WAFNextMarker;
-        IPSets?: WAFIPSetSummaries;
-    }
-
-    export type WAFListMaxItems = number;
-    export interface WAFListRulesRequest {
-        NextMarker?: WAFNextMarker;
-        Limit: WAFPaginationLimit;
-    }
-
-    export interface WAFListRulesResponse {
-        NextMarker?: WAFNextMarker;
-        Rules?: WAFRuleSummaries;
-    }
-
-    export interface WAFListSqlInjectionMatchSetsRequest {
-        NextMarker?: WAFNextMarker;
-        Limit: WAFPaginationLimit;
-    }
-
-    export interface WAFListSqlInjectionMatchSetsResponse {
-        NextMarker?: WAFNextMarker;
-        SqlInjectionMatchSets?: WAFSqlInjectionMatchSetSummaries;
-    }
-
-    export interface WAFListWebACLsRequest {
-        NextMarker?: WAFNextMarker;
-        Limit: WAFPaginationLimit;
-    }
-
-    export interface WAFListWebACLsResponse {
-        NextMarker?: WAFNextMarker;
-        WebACLs?: WAFWebACLSummaries;
-    }
-
-    export type WAFMatchFieldData = string;
-    export type WAFMatchFieldType = string;
-    export type WAFMetricName = string;
-    export type WAFNegated = boolean;
-    export type WAFNextMarker = string;
-    export type WAFPaginationLimit = number;
-    export type WAFParameterExceptionField = string;
-    export type WAFParameterExceptionParameter = string;
-    export type WAFPopulationSize = number;
-    export type WAFPositionalConstraint = string;
-    export interface WAFPredicate {
-        Negated: WAFNegated;
-        Type: WAFPredicateType;
-        DataId: WAFPredicateDataId;
-    }
-
-    export type WAFPredicateDataId = string;
-    export type WAFPredicateType = string;
-    export type WAFPredicates = Array<WAFPredicate>;
-    export type WAFResourceId = string;
-    export type WAFResourceName = string;
-    export interface WAFRule {
-        RuleId: WAFResourceId;
-        Name?: WAFResourceName;
-        MetricName?: WAFMetricName;
-        Predicates: WAFPredicates;
-    }
-
-    export type WAFRulePriority = number;
-    export type WAFRuleSummaries = Array<WAFRuleSummary>;
-    export interface WAFRuleSummary {
-        RuleId: WAFResourceId;
-        Name: WAFResourceName;
-    }
-
-    export interface WAFRuleUpdate {
-        Action: WAFChangeAction;
-        Predicate: WAFPredicate;
-    }
-
-    export type WAFRuleUpdates = Array<WAFRuleUpdate>;
-    export type WAFSampleWeight = number;
-    export interface WAFSampledHTTPRequest {
-        Request: WAFHTTPRequest;
-        Weight: WAFSampleWeight;
-        Timestamp?: WAFTimestamp;
-        Action?: WAFAction;
-    }
-
-    export type WAFSampledHTTPRequests = Array<WAFSampledHTTPRequest>;
-    export interface WAFSqlInjectionMatchSet {
-        SqlInjectionMatchSetId: WAFResourceId;
-        Name?: WAFResourceName;
-        SqlInjectionMatchTuples: WAFSqlInjectionMatchTuples;
-    }
-
-    export type WAFSqlInjectionMatchSetSummaries = Array<WAFSqlInjectionMatchSetSummary>;
-    export interface WAFSqlInjectionMatchSetSummary {
-        SqlInjectionMatchSetId: WAFResourceId;
-        Name: WAFResourceName;
-    }
-
-    export interface WAFSqlInjectionMatchSetUpdate {
-        Action: WAFChangeAction;
-        SqlInjectionMatchTuple: WAFSqlInjectionMatchTuple;
-    }
-
-    export type WAFSqlInjectionMatchSetUpdates = Array<WAFSqlInjectionMatchSetUpdate>;
-    export interface WAFSqlInjectionMatchTuple {
-        FieldToMatch: WAFFieldToMatch;
-        TextTransformation: WAFTextTransformation;
-    }
-
-    export type WAFSqlInjectionMatchTuples = Array<WAFSqlInjectionMatchTuple>;
-    export type WAFTextTransformation = string;
-    export interface WAFTimeWindow {
-        StartTime: WAFTimestamp;
-        EndTime: WAFTimestamp;
-    }
-
-    export type WAFTimestamp = number;
-    export type WAFURIString = string;
-    export interface WAFUpdateByteMatchSetRequest {
-        ByteMatchSetId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-        Updates: WAFByteMatchSetUpdates;
-    }
-
-    export interface WAFUpdateByteMatchSetResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFUpdateIPSetRequest {
-        IPSetId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-        Updates: WAFIPSetUpdates;
-    }
-
-    export interface WAFUpdateIPSetResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFUpdateRuleRequest {
-        RuleId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-        Updates: WAFRuleUpdates;
-    }
-
-    export interface WAFUpdateRuleResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFUpdateSqlInjectionMatchSetRequest {
-        SqlInjectionMatchSetId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-        Updates: WAFSqlInjectionMatchSetUpdates;
-    }
-
-    export interface WAFUpdateSqlInjectionMatchSetResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFUpdateWebACLRequest {
-        WebACLId: WAFResourceId;
-        ChangeToken: WAFChangeToken;
-        Updates?: WAFWebACLUpdates;
-        DefaultAction?: WAFWafAction;
-    }
-
-    export interface WAFUpdateWebACLResponse {
-        ChangeToken?: WAFChangeToken;
-    }
-
-    export interface WAFWAFDisallowedNameException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFInternalErrorException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFInvalidAccountException {
-    }
-
-    export interface WAFWAFInvalidOperationException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFInvalidParameterException {
-        field?: WAFParameterExceptionField;
-        parameter?: WAFParameterExceptionParameter;
-    }
-
-    export interface WAFWAFLimitsExceededException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFNonEmptyEntityException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFNonexistentContainerException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFNonexistentItemException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFReferencedItemException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWAFStaleDataException {
-        message?: WAFerrorMessage;
-    }
-
-    export interface WAFWafAction {
-        Type: WAFWafActionType;
-    }
-
-    export type WAFWafActionType = string;
-    export interface WAFWebACL {
-        WebACLId: WAFResourceId;
-        Name?: WAFResourceName;
-        MetricName?: WAFMetricName;
-        DefaultAction: WAFWafAction;
-        Rules: WAFActivatedRules;
-    }
-
-    export type WAFWebACLSummaries = Array<WAFWebACLSummary>;
-    export interface WAFWebACLSummary {
-        WebACLId: WAFResourceId;
-        Name: WAFResourceName;
-    }
-
-    export interface WAFWebACLUpdate {
-        Action: WAFChangeAction;
-        ActivatedRule: WAFActivatedRule;
-    }
-
-    export type WAFWebACLUpdates = Array<WAFWebACLUpdate>;
-    export type WAFerrorMessage = string;
 }

--- a/output/aws-workspaces.d.ts
+++ b/output/aws-workspaces.d.ts
@@ -6,226 +6,201 @@ declare module "aws-sdk" {
 
     export class WorkSpaces extends Service {
       constructor(options?: any);
-      createWorkspaces(params: WorkSpacesCreateWorkspacesRequest, callback?: (err: WorkSpacesResourceLimitExceededException|any, data: WorkSpacesCreateWorkspacesResult|any) => void): Request;
-      describeWorkspaceBundles(params: WorkSpacesDescribeWorkspaceBundlesRequest, callback?: (err: WorkSpacesInvalidParameterValuesException|any, data: WorkSpacesDescribeWorkspaceBundlesResult|any) => void): Request;
-      describeWorkspaceDirectories(params: WorkSpacesDescribeWorkspaceDirectoriesRequest, callback?: (err: WorkSpacesInvalidParameterValuesException|any, data: WorkSpacesDescribeWorkspaceDirectoriesResult|any) => void): Request;
-      describeWorkspaces(params: WorkSpacesDescribeWorkspacesRequest, callback?: (err: WorkSpacesInvalidParameterValuesException|WorkSpacesResourceUnavailableException|any, data: WorkSpacesDescribeWorkspacesResult|any) => void): Request;
-      rebootWorkspaces(params: WorkSpacesRebootWorkspacesRequest, callback?: (err: any, data: WorkSpacesRebootWorkspacesResult|any) => void): Request;
-      rebuildWorkspaces(params: WorkSpacesRebuildWorkspacesRequest, callback?: (err: any, data: WorkSpacesRebuildWorkspacesResult|any) => void): Request;
-      terminateWorkspaces(params: WorkSpacesTerminateWorkspacesRequest, callback?: (err: any, data: WorkSpacesTerminateWorkspacesResult|any) => void): Request;
+      createWorkspaces(params: WorkSpaces.CreateWorkspacesRequest, callback?: (err: WorkSpaces.ResourceLimitExceededException|any, data: WorkSpaces.CreateWorkspacesResult|any) => void): Request;
+      describeWorkspaceBundles(params: WorkSpaces.DescribeWorkspaceBundlesRequest, callback?: (err: WorkSpaces.InvalidParameterValuesException|any, data: WorkSpaces.DescribeWorkspaceBundlesResult|any) => void): Request;
+      describeWorkspaceDirectories(params: WorkSpaces.DescribeWorkspaceDirectoriesRequest, callback?: (err: WorkSpaces.InvalidParameterValuesException|any, data: WorkSpaces.DescribeWorkspaceDirectoriesResult|any) => void): Request;
+      describeWorkspaces(params: WorkSpaces.DescribeWorkspacesRequest, callback?: (err: WorkSpaces.InvalidParameterValuesException|WorkSpaces.ResourceUnavailableException|any, data: WorkSpaces.DescribeWorkspacesResult|any) => void): Request;
+      rebootWorkspaces(params: WorkSpaces.RebootWorkspacesRequest, callback?: (err: any, data: WorkSpaces.RebootWorkspacesResult|any) => void): Request;
+      rebuildWorkspaces(params: WorkSpaces.RebuildWorkspacesRequest, callback?: (err: any, data: WorkSpaces.RebuildWorkspacesResult|any) => void): Request;
+      terminateWorkspaces(params: WorkSpaces.TerminateWorkspacesRequest, callback?: (err: any, data: WorkSpaces.TerminateWorkspacesResult|any) => void): Request;
     }
+    
+    export module WorkSpaces {
+        export type ARN = string;    // pattern: &quot;^arn:aws:[A-Za-z0-9][A-za-z0-9_/.-]{0,62}:[A-za-z0-9_/.-]{0,63}:[A-za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-za-z0-9_/.-]{0,127}$&quot;
+        export type Alias = string;
+        export type BooleanObject = boolean;
+        export type BundleId = string;    // pattern: &quot;^wsb-[0-9a-z]{8,63}$&quot;
+        export type BundleIdList = BundleId[];    // max: 25, min: 1
+        export type BundleList = WorkspaceBundle[];
+        export type BundleOwner = string;
+        export type Compute = string;
+        export type ComputerName = string;
+        export type DefaultOu = string;
+        export type Description = string;
+        export type DirectoryId = string;    // pattern: &quot;^d-[0-9a-f]{8,63}$&quot;
+        export type DirectoryIdList = DirectoryId[];    // max: 25, min: 1
+        export type DirectoryList = WorkspaceDirectory[];
+        export type DirectoryName = string;
+        export type DnsIpAddresses = IpAddress[];
+        export type ErrorType = string;
+        export type ExceptionMessage = string;
+        export type FailedCreateWorkspaceRequests = FailedCreateWorkspaceRequest[];
+        export type FailedRebootWorkspaceRequests = FailedWorkspaceChangeRequest[];
+        export type FailedRebuildWorkspaceRequests = FailedWorkspaceChangeRequest[];
+        export type FailedTerminateWorkspaceRequests = FailedWorkspaceChangeRequest[];
+        export type IpAddress = string;
+        export type Limit = number;    // max: 25, min: 1
+        export type NonEmptyString = string;    // min: 1
+        export type PaginationToken = string;    // max: 63, min: 1
+        export type RebootWorkspaceRequests = RebootRequest[];    // max: 25, min: 1
+        export type RebuildWorkspaceRequests = RebuildRequest[];    // max: 1, min: 1
+        export type RegistrationCode = string;    // max: 20, min: 1
+        export type SecurityGroupId = string;    // pattern: &quot;^(sg-[0-9a-f]{8})$&quot;
+        export type SubnetId = string;    // pattern: &quot;^(subnet-[0-9a-f]{8})$&quot;
+        export type SubnetIds = SubnetId[];
+        export type TerminateWorkspaceRequests = TerminateRequest[];    // max: 25, min: 1
+        export type UserName = string;    // max: 63, min: 1
+        export type VolumeEncryptionKey = string;
+        export type WorkspaceDirectoryState = string;
+        export type WorkspaceDirectoryType = string;
+        export type WorkspaceErrorCode = string;
+        export type WorkspaceId = string;    // pattern: &quot;^ws-[0-9a-z]{8,63}$&quot;
+        export type WorkspaceIdList = WorkspaceId[];    // max: 25, min: 1
+        export type WorkspaceList = Workspace[];
+        export type WorkspaceRequestList = WorkspaceRequest[];    // max: 25, min: 1
+        export type WorkspaceState = string;
 
-    export type WorkSpacesARN = string; // pattern: "^arn:aws:[A-Za-z0-9][A-za-z0-9_/.-]{0,62}:[A-za-z0-9_/.-]{0,63}:[A-za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-za-z0-9_/.-]{0,127}$"
-    export type WorkSpacesAlias = string;
-    export type WorkSpacesBooleanObject = boolean;
-    export type WorkSpacesBundleId = string; // pattern: "^wsb-[0-9a-z]{8,63}$"
-    export type WorkSpacesBundleIdList = Array<WorkSpacesBundleId>; // max: 25
-    export type WorkSpacesBundleList = Array<WorkSpacesWorkspaceBundle>;
-    export type WorkSpacesBundleOwner = string;
-    export type WorkSpacesCompute = string;
-    export interface WorkSpacesComputeType {
-        Name?: WorkSpacesCompute;
+        export interface ComputeType {
+            Name?: Compute;            
+        }
+        export interface CreateWorkspacesRequest {
+            Workspaces: WorkspaceRequestList;            
+        }
+        export interface CreateWorkspacesResult {
+            FailedRequests?: FailedCreateWorkspaceRequests;            
+            PendingRequests?: WorkspaceList;            
+        }
+        export interface DefaultWorkspaceCreationProperties {
+            EnableWorkDocs?: BooleanObject;            
+            EnableInternetAccess?: BooleanObject;            
+            DefaultOu?: DefaultOu;            
+            CustomSecurityGroupId?: SecurityGroupId;            
+            UserEnabledAsLocalAdministrator?: BooleanObject;            
+        }
+        export interface DescribeWorkspaceBundlesRequest {
+            BundleIds?: BundleIdList;            
+            Owner?: BundleOwner;            
+            NextToken?: PaginationToken;            
+        }
+        export interface DescribeWorkspaceBundlesResult {
+            Bundles?: BundleList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface DescribeWorkspaceDirectoriesRequest {
+            DirectoryIds?: DirectoryIdList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface DescribeWorkspaceDirectoriesResult {
+            Directories?: DirectoryList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface DescribeWorkspacesRequest {
+            WorkspaceIds?: WorkspaceIdList;            
+            DirectoryId?: DirectoryId;            
+            UserName?: UserName;            
+            BundleId?: BundleId;            
+            Limit?: Limit;            
+            NextToken?: PaginationToken;            
+        }
+        export interface DescribeWorkspacesResult {
+            Workspaces?: WorkspaceList;            
+            NextToken?: PaginationToken;            
+        }
+        export interface FailedCreateWorkspaceRequest {
+            WorkspaceRequest?: WorkspaceRequest;            
+            ErrorCode?: ErrorType;            
+            ErrorMessage?: Description;            
+        }
+        export interface FailedWorkspaceChangeRequest {
+            WorkspaceId?: WorkspaceId;            
+            ErrorCode?: ErrorType;            
+            ErrorMessage?: Description;            
+        }
+        export interface InvalidParameterValuesException {
+            message?: ExceptionMessage;            
+        }
+        export interface RebootRequest {
+            WorkspaceId: WorkspaceId;            
+        }
+        export interface RebootWorkspacesRequest {
+            RebootWorkspaceRequests: RebootWorkspaceRequests;            
+        }
+        export interface RebootWorkspacesResult {
+            FailedRequests?: FailedRebootWorkspaceRequests;            
+        }
+        export interface RebuildRequest {
+            WorkspaceId: WorkspaceId;            
+        }
+        export interface RebuildWorkspacesRequest {
+            RebuildWorkspaceRequests: RebuildWorkspaceRequests;            
+        }
+        export interface RebuildWorkspacesResult {
+            FailedRequests?: FailedRebuildWorkspaceRequests;            
+        }
+        export interface ResourceLimitExceededException {
+            message?: ExceptionMessage;            
+        }
+        export interface ResourceUnavailableException {
+            message?: ExceptionMessage;            
+            ResourceId?: NonEmptyString;            
+        }
+        export interface TerminateRequest {
+            WorkspaceId: WorkspaceId;            
+        }
+        export interface TerminateWorkspacesRequest {
+            TerminateWorkspaceRequests: TerminateWorkspaceRequests;            
+        }
+        export interface TerminateWorkspacesResult {
+            FailedRequests?: FailedTerminateWorkspaceRequests;            
+        }
+        export interface UserStorage {
+            Capacity?: NonEmptyString;            
+        }
+        export interface Workspace {
+            WorkspaceId?: WorkspaceId;            
+            DirectoryId?: DirectoryId;            
+            UserName?: UserName;            
+            IpAddress?: IpAddress;            
+            State?: WorkspaceState;            
+            BundleId?: BundleId;            
+            SubnetId?: SubnetId;            
+            ErrorMessage?: Description;            
+            ErrorCode?: WorkspaceErrorCode;            
+            ComputerName?: ComputerName;            
+            VolumeEncryptionKey?: VolumeEncryptionKey;            
+            UserVolumeEncryptionEnabled?: BooleanObject;            
+            RootVolumeEncryptionEnabled?: BooleanObject;            
+        }
+        export interface WorkspaceBundle {
+            BundleId?: BundleId;            
+            Name?: NonEmptyString;            
+            Owner?: BundleOwner;            
+            Description?: Description;            
+            UserStorage?: UserStorage;            
+            ComputeType?: ComputeType;            
+        }
+        export interface WorkspaceDirectory {
+            DirectoryId?: DirectoryId;            
+            Alias?: Alias;            
+            DirectoryName?: DirectoryName;            
+            RegistrationCode?: RegistrationCode;            
+            SubnetIds?: SubnetIds;            
+            DnsIpAddresses?: DnsIpAddresses;            
+            CustomerUserName?: UserName;            
+            IamRoleId?: ARN;            
+            DirectoryType?: WorkspaceDirectoryType;            
+            WorkspaceSecurityGroupId?: SecurityGroupId;            
+            State?: WorkspaceDirectoryState;            
+            WorkspaceCreationProperties?: DefaultWorkspaceCreationProperties;            
+        }
+        export interface WorkspaceRequest {
+            DirectoryId: DirectoryId;            
+            UserName: UserName;            
+            BundleId: BundleId;            
+            VolumeEncryptionKey?: VolumeEncryptionKey;            
+            UserVolumeEncryptionEnabled?: BooleanObject;            
+            RootVolumeEncryptionEnabled?: BooleanObject;            
+        }
+
     }
-
-    export type WorkSpacesComputerName = string;
-    export interface WorkSpacesCreateWorkspacesRequest {
-        Workspaces: WorkSpacesWorkspaceRequestList;
-    }
-
-    export interface WorkSpacesCreateWorkspacesResult {
-        FailedRequests?: WorkSpacesFailedCreateWorkspaceRequests;
-        PendingRequests?: WorkSpacesWorkspaceList;
-    }
-
-    export type WorkSpacesDefaultOu = string;
-    export interface WorkSpacesDefaultWorkspaceCreationProperties {
-        EnableWorkDocs?: WorkSpacesBooleanObject;
-        EnableInternetAccess?: WorkSpacesBooleanObject;
-        DefaultOu?: WorkSpacesDefaultOu;
-        CustomSecurityGroupId?: WorkSpacesSecurityGroupId;
-        UserEnabledAsLocalAdministrator?: WorkSpacesBooleanObject;
-    }
-
-    export interface WorkSpacesDescribeWorkspaceBundlesRequest {
-        BundleIds?: WorkSpacesBundleIdList;
-        Owner?: WorkSpacesBundleOwner;
-        NextToken?: WorkSpacesPaginationToken;
-    }
-
-    export interface WorkSpacesDescribeWorkspaceBundlesResult {
-        Bundles?: WorkSpacesBundleList;
-        NextToken?: WorkSpacesPaginationToken;
-    }
-
-    export interface WorkSpacesDescribeWorkspaceDirectoriesRequest {
-        DirectoryIds?: WorkSpacesDirectoryIdList;
-        NextToken?: WorkSpacesPaginationToken;
-    }
-
-    export interface WorkSpacesDescribeWorkspaceDirectoriesResult {
-        Directories?: WorkSpacesDirectoryList;
-        NextToken?: WorkSpacesPaginationToken;
-    }
-
-    export interface WorkSpacesDescribeWorkspacesRequest {
-        WorkspaceIds?: WorkSpacesWorkspaceIdList;
-        DirectoryId?: WorkSpacesDirectoryId;
-        UserName?: WorkSpacesUserName;
-        BundleId?: WorkSpacesBundleId;
-        Limit?: WorkSpacesLimit;
-        NextToken?: WorkSpacesPaginationToken;
-    }
-
-    export interface WorkSpacesDescribeWorkspacesResult {
-        Workspaces?: WorkSpacesWorkspaceList;
-        NextToken?: WorkSpacesPaginationToken;
-    }
-
-    export type WorkSpacesDescription = string;
-    export type WorkSpacesDirectoryId = string; // pattern: "^d-[0-9a-f]{8,63}$"
-    export type WorkSpacesDirectoryIdList = Array<WorkSpacesDirectoryId>; // max: 25
-    export type WorkSpacesDirectoryList = Array<WorkSpacesWorkspaceDirectory>;
-    export type WorkSpacesDirectoryName = string;
-    export type WorkSpacesDnsIpAddresses = Array<WorkSpacesIpAddress>;
-    export type WorkSpacesErrorType = string;
-    export type WorkSpacesExceptionMessage = string;
-    export interface WorkSpacesFailedCreateWorkspaceRequest {
-        WorkspaceRequest?: WorkSpacesWorkspaceRequest;
-        ErrorCode?: WorkSpacesErrorType;
-        ErrorMessage?: WorkSpacesDescription;
-    }
-
-    export type WorkSpacesFailedCreateWorkspaceRequests = Array<WorkSpacesFailedCreateWorkspaceRequest>;
-    export type WorkSpacesFailedRebootWorkspaceRequests = Array<WorkSpacesFailedWorkspaceChangeRequest>;
-    export type WorkSpacesFailedRebuildWorkspaceRequests = Array<WorkSpacesFailedWorkspaceChangeRequest>;
-    export type WorkSpacesFailedTerminateWorkspaceRequests = Array<WorkSpacesFailedWorkspaceChangeRequest>;
-    export interface WorkSpacesFailedWorkspaceChangeRequest {
-        WorkspaceId?: WorkSpacesWorkspaceId;
-        ErrorCode?: WorkSpacesErrorType;
-        ErrorMessage?: WorkSpacesDescription;
-    }
-
-    export interface WorkSpacesInvalidParameterValuesException {
-        message?: WorkSpacesExceptionMessage;
-    }
-
-    export type WorkSpacesIpAddress = string;
-    export type WorkSpacesLimit = number;
-    export type WorkSpacesNonEmptyString = string;
-    export type WorkSpacesPaginationToken = string;
-    export interface WorkSpacesRebootRequest {
-        WorkspaceId: WorkSpacesWorkspaceId;
-    }
-
-    export type WorkSpacesRebootWorkspaceRequests = Array<WorkSpacesRebootRequest>; // max: 25
-    export interface WorkSpacesRebootWorkspacesRequest {
-        RebootWorkspaceRequests: WorkSpacesRebootWorkspaceRequests;
-    }
-
-    export interface WorkSpacesRebootWorkspacesResult {
-        FailedRequests?: WorkSpacesFailedRebootWorkspaceRequests;
-    }
-
-    export interface WorkSpacesRebuildRequest {
-        WorkspaceId: WorkSpacesWorkspaceId;
-    }
-
-    export type WorkSpacesRebuildWorkspaceRequests = Array<WorkSpacesRebuildRequest>; // max: 1
-    export interface WorkSpacesRebuildWorkspacesRequest {
-        RebuildWorkspaceRequests: WorkSpacesRebuildWorkspaceRequests;
-    }
-
-    export interface WorkSpacesRebuildWorkspacesResult {
-        FailedRequests?: WorkSpacesFailedRebuildWorkspaceRequests;
-    }
-
-    export type WorkSpacesRegistrationCode = string;
-    export interface WorkSpacesResourceLimitExceededException {
-        message?: WorkSpacesExceptionMessage;
-    }
-
-    export interface WorkSpacesResourceUnavailableException {
-        message?: WorkSpacesExceptionMessage;
-        ResourceId?: WorkSpacesNonEmptyString;
-    }
-
-    export type WorkSpacesSecurityGroupId = string; // pattern: "^(sg-[0-9a-f]{8})$"
-    export type WorkSpacesSubnetId = string; // pattern: "^(subnet-[0-9a-f]{8})$"
-    export type WorkSpacesSubnetIds = Array<WorkSpacesSubnetId>;
-    export interface WorkSpacesTerminateRequest {
-        WorkspaceId: WorkSpacesWorkspaceId;
-    }
-
-    export type WorkSpacesTerminateWorkspaceRequests = Array<WorkSpacesTerminateRequest>; // max: 25
-    export interface WorkSpacesTerminateWorkspacesRequest {
-        TerminateWorkspaceRequests: WorkSpacesTerminateWorkspaceRequests;
-    }
-
-    export interface WorkSpacesTerminateWorkspacesResult {
-        FailedRequests?: WorkSpacesFailedTerminateWorkspaceRequests;
-    }
-
-    export type WorkSpacesUserName = string;
-    export interface WorkSpacesUserStorage {
-        Capacity?: WorkSpacesNonEmptyString;
-    }
-
-    export type WorkSpacesVolumeEncryptionKey = string;
-    export interface WorkSpacesWorkspace {
-        WorkspaceId?: WorkSpacesWorkspaceId;
-        DirectoryId?: WorkSpacesDirectoryId;
-        UserName?: WorkSpacesUserName;
-        IpAddress?: WorkSpacesIpAddress;
-        State?: WorkSpacesWorkspaceState;
-        BundleId?: WorkSpacesBundleId;
-        SubnetId?: WorkSpacesSubnetId;
-        ErrorMessage?: WorkSpacesDescription;
-        ErrorCode?: WorkSpacesWorkspaceErrorCode;
-        ComputerName?: WorkSpacesComputerName;
-        VolumeEncryptionKey?: WorkSpacesVolumeEncryptionKey;
-        UserVolumeEncryptionEnabled?: WorkSpacesBooleanObject;
-        RootVolumeEncryptionEnabled?: WorkSpacesBooleanObject;
-    }
-
-    export interface WorkSpacesWorkspaceBundle {
-        BundleId?: WorkSpacesBundleId;
-        Name?: WorkSpacesNonEmptyString;
-        Owner?: WorkSpacesBundleOwner;
-        Description?: WorkSpacesDescription;
-        UserStorage?: WorkSpacesUserStorage;
-        ComputeType?: WorkSpacesComputeType;
-    }
-
-    export interface WorkSpacesWorkspaceDirectory {
-        DirectoryId?: WorkSpacesDirectoryId;
-        Alias?: WorkSpacesAlias;
-        DirectoryName?: WorkSpacesDirectoryName;
-        RegistrationCode?: WorkSpacesRegistrationCode;
-        SubnetIds?: WorkSpacesSubnetIds;
-        DnsIpAddresses?: WorkSpacesDnsIpAddresses;
-        CustomerUserName?: WorkSpacesUserName;
-        IamRoleId?: WorkSpacesARN;
-        DirectoryType?: WorkSpacesWorkspaceDirectoryType;
-        WorkspaceSecurityGroupId?: WorkSpacesSecurityGroupId;
-        State?: WorkSpacesWorkspaceDirectoryState;
-        WorkspaceCreationProperties?: WorkSpacesDefaultWorkspaceCreationProperties;
-    }
-
-    export type WorkSpacesWorkspaceDirectoryState = string;
-    export type WorkSpacesWorkspaceDirectoryType = string;
-    export type WorkSpacesWorkspaceErrorCode = string;
-    export type WorkSpacesWorkspaceId = string; // pattern: "^ws-[0-9a-z]{8,63}$"
-    export type WorkSpacesWorkspaceIdList = Array<WorkSpacesWorkspaceId>; // max: 25
-    export type WorkSpacesWorkspaceList = Array<WorkSpacesWorkspace>;
-    export interface WorkSpacesWorkspaceRequest {
-        DirectoryId: WorkSpacesDirectoryId;
-        UserName: WorkSpacesUserName;
-        BundleId: WorkSpacesBundleId;
-        VolumeEncryptionKey?: WorkSpacesVolumeEncryptionKey;
-        UserVolumeEncryptionEnabled?: WorkSpacesBooleanObject;
-        RootVolumeEncryptionEnabled?: WorkSpacesBooleanObject;
-    }
-
-    export type WorkSpacesWorkspaceRequestList = Array<WorkSpacesWorkspaceRequest>; // max: 25
-    export type WorkSpacesWorkspaceState = string;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "aws-sdk": "^2.1.31",
     "glob": "^5.0.10",
-    "handlebars": "^3.0.3"
+    "handlebars": "^3.0.3",
+    "source-map-support": "^0.4.0"
   },
   "devDependencies": {
     "del": "^2.1.0",


### PR DESCRIPTION
Moved all of the types associated with a service into a submodule with the service name (e.g. `SQS.Message`) & added support for `map` types.
